### PR TITLE
fix(ghx): preserve stdin-backed payloads

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -115,7 +115,8 @@
 - Do prerequisite lookup or discovery before dependent actions.
 - Before finalizing, quickly verify correctness, coverage, formatting, and obvious side effects.
 - Before contributing, read `CONTRIBUTING.md` and relevant issue/PR templates. Match repo style. If an issue is linked, use closing refs like `Fixes #123`.
-- Use `ghx` for GitHub work; it is a drop-in replacement for `gh`. Prefer draft PRs first.
+- Use `ghx` for GitHub work. Prefer draft PRs first.
+- Never send a GitHub payload through `ghx` stdin (`--body-file -`, `-F -`, `--input -`, `--with-token`, or `/dev/stdin`). The proxy daemon does not forward stdin. Write the payload to a real temporary file and pass its path; after PR/issue body changes, read the live field back with `ghx --no-cache` and fail if it is empty or mismatched.
 - Prefer worktrees and spawning subagents.
 - Create new worktrees with `gwt new <branch> [start-point]` or the repo-native wrapper.
 - Start in a branch/worktree early so commits can be made incrementally.

--- a/bin/ghx
+++ b/bin/ghx
@@ -16,6 +16,28 @@ done
 ghx_bin="$(PATH="$lookup_path" command -v ghx || true)"
 gh_bin="$(PATH="$lookup_path" command -v gh || true)"
 
+uses_stdin_payload() {
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      - | -F- | /dev/stdin | /dev/fd/0 | --body-file=- | --body-file=/dev/stdin | --body-file=/dev/fd/0 | --input=- | --input=/dev/stdin | --input=/dev/fd/0 | --with-token)
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
+# ghx's daemon protocol forwards argv, cwd, and output, but not stdin. Sending
+# stdin-backed mutations through it can turn a valid payload into an empty one.
+if uses_stdin_payload "$@"; then
+  if [[ -z "$gh_bin" || ! -x "$gh_bin" ]]; then
+    printf 'ghx: stdin-backed commands require the real GitHub CLI\n' >&2
+    exit 127
+  fi
+  exec env NO_COLOR=1 CLICOLOR=0 CLICOLOR_FORCE=0 GH_FORCE_TTY=0 "$gh_bin" "$@"
+fi
+
 if [[ -n "$ghx_bin" && -x "$ghx_bin" ]]; then
   # Avoid resolving this gh wrapper when ghx needs the real GitHub CLI.
   if [[ -n "$gh_bin" && -x "$gh_bin" ]]; then

--- a/tests/ghx-test.sh
+++ b/tests/ghx-test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+temporary="$(mktemp -d)"
+trap 'rm -rf "$temporary"' EXIT
+
+wrapper_dir="$temporary/wrapper"
+backend_dir="$temporary/backend"
+mkdir -p "$wrapper_dir" "$backend_dir"
+cp "$repo_root/bin/ghx" "$wrapper_dir/ghx"
+
+cat >"$backend_dir/ghx" <<'EOF'
+#!/usr/bin/env bash
+printf 'ghx:%s\n' "$*"
+printf 'backend:%s\n' "${GHX_GH_PATH:-}"
+EOF
+
+cat >"$backend_dir/gh" <<'EOF'
+#!/usr/bin/env bash
+printf 'gh:%s\n' "$*"
+cat
+EOF
+
+chmod +x "$wrapper_dir/ghx" "$backend_dir/ghx" "$backend_dir/gh"
+
+normal_output="$(PATH="$wrapper_dir:$backend_dir:/usr/bin:/bin" "$wrapper_dir/ghx" pr view 123)"
+grep -Fq 'ghx:pr view 123' <<<"$normal_output"
+grep -Fq "backend:$backend_dir/gh" <<<"$normal_output"
+
+stdin_output="$(printf 'preserved body' | PATH="$wrapper_dir:$backend_dir:/usr/bin:/bin" "$wrapper_dir/ghx" pr edit 123 --body-file -)"
+grep -Fq 'gh:pr edit 123 --body-file -' <<<"$stdin_output"
+grep -Fq 'preserved body' <<<"$stdin_output"
+if grep -Fq 'ghx:' <<<"$stdin_output"; then
+  printf 'stdin-backed command unexpectedly used ghx\n' >&2
+  exit 1
+fi
+
+token_output="$(printf 'token-value' | PATH="$wrapper_dir:$backend_dir:/usr/bin:/bin" "$wrapper_dir/ghx" auth login --with-token)"
+grep -Fq 'gh:auth login --with-token' <<<"$token_output"
+grep -Fq 'token-value' <<<"$token_output"
+
+printf 'ghx wrapper tests passed\n'


### PR DESCRIPTION
## Summary
- bypass the ghx daemon for commands that consume stdin-backed payloads
- teach fleet Codex agents to use file-backed GitHub bodies and verify live content
- add a regression test proving PR body and auth-token stdin reach the real GitHub CLI

## Root Cause
`ghx` v1.5.2 serializes command arguments and working-directory context to `ghxd`, but the daemon protocol does not carry stdin. Commands such as `gh pr edit --body-file -` therefore receive EOF and can silently replace a valid body with an empty string.

## Verification
- `bash -n bin/ghx tests/ghx-test.sh`
- `tests/ghx-test.sh`
- `shellcheck bin/ghx tests/ghx-test.sh`
- `git diff --check`
