### PR TITLE
fix(tmux): keep panes open after agent exit

### DIFF
--- a/bin/tt
+++ b/bin/tt
@@ -52,9 +52,9 @@ shell_quote() {
 }
 
 default_login_shell() {
-  local shell_path=""
+  local shell_path="${TT_LOGIN_SHELL:-}"
 
-  if command -v dscl >/dev/null 2>&1 && [[ -n "${USER:-}" ]]; then
+  if [[ -z "$shell_path" ]] && command -v dscl >/dev/null 2>&1 && [[ -n "${USER:-}" ]]; then
     shell_path="$(dscl . -read "/Users/$USER" UserShell 2>/dev/null | awk '{print $2; exit}')"
   fi
 
@@ -86,6 +86,22 @@ ensure_tmux_default_shell() {
 
 agent_color_prefix() {
   printf 'env -u NO_COLOR -u TERMINFO CLICOLOR=1 CLICOLOR_FORCE=1 FORCE_COLOR=3 COLORTERM=truecolor TERMINFO_DIRS=$HOME/.terminfo:/usr/share/terminfo'
+}
+
+agent_shell_fallback_suffix() {
+  printf '; exec %s' "$(default_login_shell_command)"
+}
+
+command_with_shell_fallback() {
+  local command="$1"
+
+  printf '%s%s\n' "$command" "$(agent_shell_fallback_suffix)"
+}
+
+agent_pane_command() {
+  local command="$1"
+
+  command_with_shell_fallback "$(agent_color_prefix) $command"
 }
 
 agent_kind_for_command() {
@@ -153,10 +169,14 @@ set_pane_git_label() {
 
 clean_agent_command() {
   local command="$1"
-  local prefix
+  local prefix suffix
 
   command="${command#\"}"
   command="${command%\"}"
+  suffix="$(agent_shell_fallback_suffix)"
+  if [[ "$command" == *"$suffix" ]]; then
+    command="${command%"$suffix"}"
+  fi
   prefix="$(agent_color_prefix) "
   if [[ "$command" == "$prefix"* ]]; then
     command="${command#"$prefix"}"
@@ -1964,7 +1984,7 @@ codex_restore_execute() {
     matched=$((matched + 1))
     printf '%s\t%s\t%s\t%s\n' "$target" "$kind" "$status" "$restore"
     if "$TMUX_BIN" list-panes -a -F '#{session_name}:#{window_index}.#{pane_index}' 2>/dev/null | grep -Fxq "$target"; then
-      "$TMUX_BIN" respawn-pane -k -t "$target" "$restore"
+      "$TMUX_BIN" respawn-pane -k -t "$target" "$(command_with_shell_fallback "$restore")"
       restored=$((restored + 1))
     else
       printf 'missing pane: %s\n' "$target" >&2
@@ -2496,7 +2516,7 @@ launch_agent_cockpit_panes() {
     "$TMUX_BIN" select-pane -t "$target" -T "$title" 2>/dev/null || true
 
     if [[ -n "${command:-}" ]]; then
-      "$TMUX_BIN" respawn-pane -k -t "$target" -c "$dir" "$(agent_color_prefix) $command"
+      "$TMUX_BIN" respawn-pane -k -t "$target" -c "$dir" "$(agent_pane_command "$command")"
     else
       "$TMUX_BIN" respawn-pane -k -t "$target" -c "$dir" "$(default_login_shell_command)"
     fi
@@ -2532,7 +2552,7 @@ refresh_agent_pane_colors() {
     fi
     set_pane_git_label "$pane" "$dir"
 
-    "$TMUX_BIN" respawn-pane -k -t "$pane" -c "$dir" "$(agent_color_prefix) $command"
+    "$TMUX_BIN" respawn-pane -k -t "$pane" -c "$dir" "$(agent_pane_command "$command")"
     count=$((count + 1))
   done < <("$TMUX_BIN" list-panes -a -F '#{session_name}	#{pane_id}	#{pane_current_path}	#{pane_start_command}	#{@tt_base_title}	#{@tt_agent_command}' 2>/dev/null || true)
 
@@ -2655,7 +2675,7 @@ restore_cockpit_snapshot() {
       echo "tt: missing recovery pane $target" >&2
       continue
     fi
-    "$TMUX_BIN" respawn-pane -k -t "$restore_target" -c "$cwd" "$(agent_color_prefix) codex resume --no-alt-screen $session_id" 2>/dev/null || true
+    "$TMUX_BIN" respawn-pane -k -t "$restore_target" -c "$cwd" "$(agent_pane_command "codex resume --no-alt-screen $session_id")" 2>/dev/null || true
     restored=$((restored + 1))
   done < "$snapshot"
 

--- a/tests/tt-lifecycle-test.sh
+++ b/tests/tt-lifecycle-test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tt="$repo/bin/tt"
+temporary="$(mktemp -d)"
+trap 'rm -rf "$temporary"' EXIT
+
+fake_tmux="$temporary/tmux"
+tmux_log="$temporary/tmux.log"
+
+cat >"$fake_tmux" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${TT_TEST_TMUX_LOG:-}" ]]; then
+  for arg in "$@"; do
+    printf '[%s]' "$arg" >>"$TT_TEST_TMUX_LOG"
+  done
+  printf '\n' >>"$TT_TEST_TMUX_LOG"
+fi
+
+if [[ "$*" == *"list-panes -a -F"* && "$*" == *"@tt_profile"* ]]; then
+  printf 'factory2\tstudio\t1\t1\t6\t/tmp/work\t"%s codex --no-alt-screen; exec /bin/sh -il"\tcodex\ttest\ttest\n' "${TT_TEST_AGENT_PREFIX:?}"
+elif [[ "$*" == *"list-panes -a -F"* && "$*" == *"session_name}:#{window_index}.#{pane_index}"* ]]; then
+  printf 'cockpit:1.1\n'
+fi
+SH
+chmod +x "$fake_tmux"
+
+session_id="11111111-1111-1111-1111-111111111111"
+snapshot="$temporary/codex.tsv"
+printf '# target\tkind\tcwd\ttitle\tcurrent_command\tsession_id\tstatus\trestore\n' >"$snapshot"
+printf 'cockpit:1.1\tcodex\t/tmp/work\ttest\tcodex\t%s\texact\tcd /tmp/work && codex resume --no-alt-screen %s\n' \
+  "$session_id" "$session_id" >>"$snapshot"
+
+HOME="$temporary/home" \
+  TT_LOGIN_SHELL=/bin/sh \
+  TT_TMUX_BIN="$fake_tmux" \
+  TT_TEST_TMUX_LOG="$tmux_log" \
+  "$tt" codex-restore pane cockpit:1.1 "$snapshot" --execute >/dev/null
+
+grep -Fq "[respawn-pane][-k][-t][cockpit:1.1][cd /tmp/work && codex resume --no-alt-screen $session_id; exec /bin/sh -il]" "$tmux_log"
+
+agent_state="$temporary/agent-state.tsv"
+# shellcheck disable=SC2016
+agent_prefix='env -u NO_COLOR -u TERMINFO CLICOLOR=1 CLICOLOR_FORCE=1 FORCE_COLOR=3 COLORTERM=truecolor TERMINFO_DIRS=$HOME/.terminfo:/usr/share/terminfo'
+HOME="$temporary/home" \
+  XDG_CONFIG_HOME="$temporary/config" \
+  TT_LOGIN_SHELL=/bin/sh \
+  TT_TMUX_BIN="$fake_tmux" \
+  TT_TEST_AGENT_PREFIX="$agent_prefix" \
+  "$tt" snapshot "$agent_state" --quiet
+
+grep -Fq $'\tcodex --no-alt-screen' "$agent_state"
+if grep -Fq '; exec /bin/sh -il' "$agent_state"; then
+  printf 'agent snapshot retained the shell fallback suffix\n' >&2
+  exit 1
+fi
+
+printf 'tt_lifecycle_test=passed\n'

--- a/tests/tt-recovery-test.sh
+++ b/tests/tt-recovery-test.sh
@@ -87,6 +87,7 @@ env -u TMUX \
   HOME="$temporary/home" \
   XDG_CONFIG_HOME="$temporary/config" \
   TT_TMUX_BIN="$fake_tmux" \
+  TT_LOGIN_SHELL=/bin/sh \
   TT_TEST_TMUX_LOG="$tmux_log" \
   TT_TEST_TMUX_SERVER_RUNNING=1 \
   "$tt" recover cockpit "$snapshot"
@@ -99,7 +100,7 @@ grep -Eq '^new-session .* -s cockpit ' "$tmux_log"
 grep -Eq '^set-option -t cockpit base-index 1$' "$tmux_log"
 grep -Eq '^set-option -t cockpit pane-base-index 1$' "$tmux_log"
 grep -Eq '^move-window -s @1 -t cockpit:1$' "$tmux_log"
-grep -Eq '^respawn-pane -k -t %1 -c .*codex resume --no-alt-screen fake-session$' "$tmux_log"
+grep -Eq '^respawn-pane -k -t %1 -c .*codex resume --no-alt-screen fake-session; exec /bin/sh -il$' "$tmux_log"
 if grep -Eq '^(set|set-option|set-hook) -g' "$tmux_log"; then
   printf 'recovery rewrote global server configuration\n' >&2
   exit 1
@@ -110,6 +111,7 @@ env -u TMUX \
   HOME="$temporary/home" \
   XDG_CONFIG_HOME="$temporary/config" \
   TT_TMUX_BIN="$fake_tmux" \
+  TT_LOGIN_SHELL=/bin/sh \
   TT_TEST_TMUX_LOG="$tmux_log" \
   "$tt" recover cockpit "$snapshot"
 
@@ -120,7 +122,7 @@ fi
 grep -Eq '^set-option -t cockpit base-index 1$' "$tmux_log"
 grep -Eq '^set-option -t cockpit pane-base-index 1$' "$tmux_log"
 grep -Eq '^move-window -s @1 -t cockpit:1$' "$tmux_log"
-grep -Eq '^respawn-pane -k -t %1 -c .*codex resume --no-alt-screen fake-session$' "$tmux_log"
+grep -Eq '^respawn-pane -k -t %1 -c .*codex resume --no-alt-screen fake-session; exec /bin/sh -il$' "$tmux_log"
 
 : >"$tmux_log"
 agent_manifest="$temporary/agents.tsv"
@@ -129,6 +131,7 @@ env -u TMUX \
   HOME="$temporary/home" \
   XDG_CONFIG_HOME="$temporary/config" \
   TT_TMUX_BIN="$fake_tmux" \
+  TT_LOGIN_SHELL=/bin/sh \
   TT_TEST_TMUX_LOG="$tmux_log" \
   TT_TEST_TMUX_SERVER_RUNNING=1 \
   "$tt" recover agents "$agent_manifest" factory2
@@ -140,7 +143,7 @@ fi
 grep -Eq '^set-option -t factory2 base-index 1$' "$tmux_log"
 grep -Eq '^set-option -t factory2 pane-base-index 1$' "$tmux_log"
 grep -Eq '^move-window -s @1 -t factory2:1$' "$tmux_log"
-grep -Eq '^respawn-pane -k -t %1 -c .*printf ready$' "$tmux_log"
+grep -Eq '^respawn-pane -k -t %1 -c .*printf ready; exec /bin/sh -il$' "$tmux_log"
 if grep -Eq '^(set|set-option|set-hook) -g' "$tmux_log"; then
   printf 'agent recovery rewrote global server configuration\n' >&2
   exit 1
@@ -151,6 +154,7 @@ env -u TMUX \
   HOME="$temporary/home" \
   XDG_CONFIG_HOME="$temporary/config" \
   TT_TMUX_BIN="$fake_tmux" \
+  TT_LOGIN_SHELL=/bin/sh \
   TT_TEST_TMUX_LOG="$tmux_log" \
   "$tt" recover agents "$agent_manifest" factory2
 
@@ -161,7 +165,7 @@ fi
 grep -Eq '^set-option -t factory2 base-index 1$' "$tmux_log"
 grep -Eq '^set-option -t factory2 pane-base-index 1$' "$tmux_log"
 grep -Eq '^move-window -s @1 -t factory2:1$' "$tmux_log"
-grep -Eq '^respawn-pane -k -t %1 -c .*printf ready$' "$tmux_log"
+grep -Eq '^respawn-pane -k -t %1 -c .*printf ready; exec /bin/sh -il$' "$tmux_log"
 
 : >"$tmux_log"
 if env -u TMUX \


### PR DESCRIPTION
## Summary

- keep tmux panes alive by returning to the login shell after Codex or Claude exits
- apply the fallback to targeted restores, cockpit recovery, and agent refresh/recovery
- strip the fallback from saved manifests so repeated restores do not accumulate shell commands

## Verification

- `tests/tt-recovery-test.sh`
- `tests/tt-lifecycle-test.sh`
- isolated tmux smoke: exited command leaves `dead=0 command=zsh`
