### PR TITLE
fix(wsl): preserve Windows interop across tmux

### DIFF
--- a/bin/powershell.exe
+++ b/bin/powershell.exe
@@ -11,7 +11,7 @@ valid_c_mount() {
   record="$(findmnt -rn -M /mnt/c -o SOURCE,FSTYPE,OPTIONS 2>/dev/null || true)"
   [[ -n "$record" && "$record" != *$'\n'* ]] || return 1
   read -r source fstype options extra <<<"$record"
-  [[ -z "${extra:-}" && "$source" == C:* ]] || return 1
+  [[ -z "${extra:-}" && "$source" == "C:" ]] || return 1
   case "$fstype" in
     drvfs)
       ;;
@@ -22,7 +22,7 @@ valid_c_mount() {
       return 1
       ;;
   esac
-  [[ ",$options," == *,ro,* ]]
+  [[ ",$options," == *,ro,* && ",$options," != *,rw,* ]]
 }
 
 socket="${WSL_INTEROP:-}"

--- a/bin/powershell.exe
+++ b/bin/powershell.exe
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+valid_socket() {
+  [[ "$1" =~ ^/run/WSL/[0-9]+_interop$ ]] && [[ -S "$1" ]]
+}
+
+valid_c_mount() {
+  local record source fstype options extra
+
+  record="$(findmnt -rn -M /mnt/c -o SOURCE,FSTYPE,OPTIONS 2>/dev/null || true)"
+  [[ -n "$record" && "$record" != *$'\n'* ]] || return 1
+  read -r source fstype options extra <<<"$record"
+  [[ -z "${extra:-}" && "$source" == C:* ]] || return 1
+  case "$fstype" in
+    drvfs)
+      ;;
+    9p)
+      [[ ",$options," == *",aname=drvfs"* ]] || return 1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  [[ ",$options," == *,ro,* ]]
+}
+
+socket="${WSL_INTEROP:-}"
+if ! valid_socket "$socket"; then
+  socket="$(tmux show-option -gqv @tt_wsl_interop 2>/dev/null || true)"
+fi
+valid_socket "$socket" || {
+  echo "powershell.exe: no live validated WSL interop socket" >&2
+  exit 126
+}
+valid_c_mount || {
+  echo "powershell.exe: /mnt/c must be a read-only C: drvfs mount" >&2
+  exit 126
+}
+
+target="/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+[[ -x "$target" ]] || {
+  echo "powershell.exe: fixed Windows PowerShell path is unavailable" >&2
+  exit 127
+}
+
+export WSL_INTEROP="$socket"
+exec "$target" "$@"

--- a/bin/pwsh.exe
+++ b/bin/pwsh.exe
@@ -11,7 +11,7 @@ valid_c_mount() {
   record="$(findmnt -rn -M /mnt/c -o SOURCE,FSTYPE,OPTIONS 2>/dev/null || true)"
   [[ -n "$record" && "$record" != *$'\n'* ]] || return 1
   read -r source fstype options extra <<<"$record"
-  [[ -z "${extra:-}" && "$source" == C:* ]] || return 1
+  [[ -z "${extra:-}" && "$source" == "C:" ]] || return 1
   case "$fstype" in
     drvfs)
       ;;
@@ -22,7 +22,7 @@ valid_c_mount() {
       return 1
       ;;
   esac
-  [[ ",$options," == *,ro,* ]]
+  [[ ",$options," == *,ro,* && ",$options," != *,rw,* ]]
 }
 
 socket="${WSL_INTEROP:-}"

--- a/bin/pwsh.exe
+++ b/bin/pwsh.exe
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+valid_socket() {
+  [[ "$1" =~ ^/run/WSL/[0-9]+_interop$ ]] && [[ -S "$1" ]]
+}
+
+valid_c_mount() {
+  local record source fstype options extra
+
+  record="$(findmnt -rn -M /mnt/c -o SOURCE,FSTYPE,OPTIONS 2>/dev/null || true)"
+  [[ -n "$record" && "$record" != *$'\n'* ]] || return 1
+  read -r source fstype options extra <<<"$record"
+  [[ -z "${extra:-}" && "$source" == C:* ]] || return 1
+  case "$fstype" in
+    drvfs)
+      ;;
+    9p)
+      [[ ",$options," == *",aname=drvfs"* ]] || return 1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  [[ ",$options," == *,ro,* ]]
+}
+
+socket="${WSL_INTEROP:-}"
+if ! valid_socket "$socket"; then
+  socket="$(tmux show-option -gqv @tt_wsl_interop 2>/dev/null || true)"
+fi
+valid_socket "$socket" || {
+  echo "pwsh.exe: no live validated WSL interop socket" >&2
+  exit 126
+}
+valid_c_mount || {
+  echo "pwsh.exe: /mnt/c must be a read-only C: drvfs mount" >&2
+  exit 126
+}
+
+target="/mnt/c/Program Files/PowerShell/7/pwsh.exe"
+if [[ ! -x "$target" ]]; then
+  shopt -s nullglob
+  matches=(/mnt/c/Program\ Files/WindowsApps/Microsoft.PowerShell_*_arm64__8wekyb3d8bbwe/pwsh.exe)
+  shopt -u nullglob
+  executable_matches=()
+  for candidate in "${matches[@]}"; do
+    [[ -x "$candidate" ]] && executable_matches+=("$candidate")
+  done
+  if [[ "${#executable_matches[@]}" -ne 1 ]]; then
+    echo "pwsh.exe: expected exactly one executable ARM64 WindowsApps PowerShell package, found ${#executable_matches[@]}" >&2
+    exit 127
+  fi
+  target="${executable_matches[0]}"
+fi
+
+export WSL_INTEROP="$socket"
+exec "$target" "$@"

--- a/bin/pwsh.exe
+++ b/bin/pwsh.exe
@@ -39,20 +39,35 @@ valid_c_mount || {
 }
 
 target="/mnt/c/Program Files/PowerShell/7/pwsh.exe"
-if [[ ! -x "$target" ]]; then
+if [[ -x "$target" ]]; then
+  export WSL_INTEROP="$socket"
+  exec "$target" "$@"
+fi
+
+if [[ -e "$target" ]]; then
+  echo "pwsh.exe: fixed PowerShell path exists but is not executable" >&2
+  exit 126
+fi
+
+[[ -x /init && ! -L /init && "$(stat -c %u /init)" == "0" ]] || {
+  echo "pwsh.exe: trusted WSL PE interpreter is unavailable" >&2
+  exit 126
+}
+
+{
   shopt -s nullglob
   matches=(/mnt/c/Program\ Files/WindowsApps/Microsoft.PowerShell_*_arm64__8wekyb3d8bbwe/pwsh.exe)
   shopt -u nullglob
-  executable_matches=()
+  appx_matches=()
   for candidate in "${matches[@]}"; do
-    [[ -x "$candidate" ]] && executable_matches+=("$candidate")
+    [[ -f "$candidate" && ! -L "$candidate" ]] && appx_matches+=("$candidate")
   done
-  if [[ "${#executable_matches[@]}" -ne 1 ]]; then
-    echo "pwsh.exe: expected exactly one executable ARM64 WindowsApps PowerShell package, found ${#executable_matches[@]}" >&2
+  if [[ "${#appx_matches[@]}" -ne 1 ]]; then
+    echo "pwsh.exe: expected exactly one canonical ARM64 WindowsApps PowerShell package, found ${#appx_matches[@]}" >&2
     exit 127
   fi
-  target="${executable_matches[0]}"
-fi
+  target="${appx_matches[0]}"
+}
 
 export WSL_INTEROP="$socket"
-exec "$target" "$@"
+exec /init "$target" "$@"

--- a/bin/tt
+++ b/bin/tt
@@ -16,6 +16,11 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 DOTFILES_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
 TT_WSL_BRIDGE_READY=0
+TT_WSL_BRIDGE_PENDING=0
+TT_WSL_BRIDGE_PENDING_PID=""
+TT_WSL_BRIDGE_PENDING_STARTTIME=""
+TT_WSL_BRIDGE_PENDING_NS=""
+TT_WSL_BRIDGE_PENDING_EXE=""
 
 wsl_bridge_is_wsl() {
   [[ -n "${WSL_DISTRO_NAME:-}" ]] &&
@@ -28,37 +33,301 @@ wsl_bridge_valid_socket() {
   [[ "$socket" =~ ^/run/WSL/[0-9]+_interop$ ]] && [[ -S "$socket" ]]
 }
 
-wsl_bridge_mount_record() {
-  local record
+wsl_bridge_proc_starttime() {
+  local pid="$1"
+  local stat_line stat_fields
+  local -a fields
 
-  record="$(findmnt -rn -M /mnt/c -o SOURCE,FSTYPE,OPTIONS 2>/dev/null || true)"
-  [[ -n "$record" ]] || return 1
-  [[ "$record" != *$'\n'* ]] || return 1
-  printf '%s\n' "$record"
+  stat_line="$(<"/proc/$pid/stat")" || return 1
+  stat_fields="${stat_line#*) }"
+  read -r -a fields <<<"$stat_fields"
+  [[ "${#fields[@]}" -ge 20 ]] || return 1
+  printf '%s\n' "${fields[19]}"
 }
 
-wsl_bridge_mount_valid() {
-  local record source fstype options extra
+wsl_bridge_current_identity() {
+  local pid="$$"
+  local starttime namespace exe
 
-  record="$(wsl_bridge_mount_record)" || return 1
-  read -r source fstype options extra <<<"$record"
-  [[ -z "${extra:-}" ]] || return 1
-  [[ "$source" == C:* ]] || return 1
-  case "$fstype" in
-    drvfs)
-      ;;
-    9p)
-      [[ ",$options," == *",aname=drvfs"* ]] || return 1
-      ;;
-    *)
-      return 1
-      ;;
-  esac
-  [[ ",$options," == *,ro,* ]]
+  starttime="$(wsl_bridge_proc_starttime "$pid")" || return 1
+  namespace="$(readlink "/proc/$pid/ns/mnt")" || return 1
+  exe="$(readlink "/proc/$pid/exe")" || return 1
+  [[ "$namespace" =~ ^mnt:\[[0-9]+\]$ ]] || return 1
+  printf '%s|%s|%s|%s\n' "$pid" "$starttime" "$namespace" "$exe"
+}
+
+wsl_bridge_server_snapshot() {
+  local pid starttime namespace exe expected_exe owner pane pane_namespace panes
+  local -a pane_ids
+
+  pid="$("$TMUX_BIN" display-message -p '#{pid}' 2>/dev/null || true)"
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  [[ "$(<"/proc/$pid/comm")" == "tmux: server" ]] || return 1
+  owner="$(stat -c %u "/proc/$pid")" || return 1
+  [[ "$owner" == "$(id -u)" ]] || return 1
+  starttime="$(wsl_bridge_proc_starttime "$pid")" || return 1
+  namespace="$(readlink "/proc/$pid/ns/mnt")" || return 1
+  [[ "$namespace" =~ ^mnt:\[[0-9]+\]$ ]] || return 1
+  exe="$(readlink "/proc/$pid/exe")" || return 1
+  expected_exe="$(readlink -f "$TMUX_BIN")" || return 1
+  [[ "$exe" == "$expected_exe" ]] || return 1
+
+  panes="$("$TMUX_BIN" list-panes -a -F '#{pane_pid}' 2>/dev/null | sort -nu | paste -sd, -)"
+  [[ -n "$panes" ]] || return 1
+  IFS=',' read -r -a pane_ids <<<"$panes"
+  for pane in "${pane_ids[@]}"; do
+    [[ "$pane" =~ ^[0-9]+$ ]] || return 1
+    [[ "$(stat -c %u "/proc/$pane")" == "$owner" ]] || return 1
+    pane_namespace="$(readlink "/proc/$pane/ns/mnt")" || return 1
+    [[ "$pane_namespace" == "$namespace" ]] || return 1
+  done
+
+  printf '%s|%s|%s|%s|%s\n' "$pid" "$starttime" "$namespace" "$exe" "$panes"
+}
+
+wsl_bridge_root_action() {
+  local action="$1"
+  local target_kind="$2"
+  local target_pid="$3"
+  local target_starttime="$4"
+  local target_namespace="$5"
+  local target_exe="$6"
+  local pane_pids="$7"
+  local current_pid="$8"
+  local current_starttime="$9"
+  local current_namespace="${10}"
+  local current_exe="${11}"
+  local uid gid
+
+  uid="$(id -u)"
+  gid="$(id -g)"
+  [[ "$uid" =~ ^[0-9]+$ && "$gid" =~ ^[0-9]+$ ]] || {
+    echo "tt: could not determine numeric uid/gid for drvfs mount" >&2
+    return 2
+  }
+
+  sudo -n /usr/bin/flock -x /run/lock/tt-wsl-bridge.lock /usr/bin/bash -c '
+    set -euo pipefail
+    action="$1"
+    target_kind="$2"
+    target_pid="$3"
+    target_starttime="$4"
+    target_namespace="$5"
+    target_exe="$6"
+    pane_pids="$7"
+    current_pid="$8"
+    current_starttime="$9"
+    current_namespace="${10}"
+    current_exe="${11}"
+    uid="${12}"
+    gid="${13}"
+    marker_dir=/run/tt-wsl-bridge
+    marker="$marker_dir/mount-$uid"
+    pending="$marker_dir/pending-$uid"
+
+    proc_starttime() {
+      local pid="$1"
+      local stat_line stat_fields
+      local -a fields
+      stat_line="$(<"/proc/$pid/stat")" || return 1
+      stat_fields="${stat_line#*) }"
+      read -r -a fields <<<"$stat_fields"
+      [[ "${#fields[@]}" -ge 20 ]] || return 1
+      printf "%s\n" "${fields[19]}"
+    }
+
+    validate_process() {
+      local pid="$1"
+      local expected_starttime="$2"
+      local expected_namespace="$3"
+      local expected_exe="$4"
+      local expected_comm="${5:-}"
+      [[ "$pid" =~ ^[0-9]+$ && -d "/proc/$pid" ]] || return 1
+      [[ "$(/usr/bin/stat -c %u "/proc/$pid")" == "$uid" ]] || return 1
+      [[ "$(proc_starttime "$pid")" == "$expected_starttime" ]] || return 1
+      [[ "$(/usr/bin/readlink "/proc/$pid/ns/mnt")" == "$expected_namespace" ]] || return 1
+      [[ "$(/usr/bin/readlink "/proc/$pid/exe")" == "$expected_exe" ]] || return 1
+      if [[ -n "$expected_comm" ]]; then
+        [[ "$(<"/proc/$pid/comm")" == "$expected_comm" ]] || return 1
+      fi
+    }
+
+    validate_process "$current_pid" "$current_starttime" "$current_namespace" "$current_exe"
+    if [[ "$target_kind" == "server" ]]; then
+      validate_process "$target_pid" "$target_starttime" "$target_namespace" "$target_exe" "tmux: server"
+      [[ -n "$pane_pids" ]] || {
+        echo "tt: tmux server has no validated panes" >&2
+        exit 2
+      }
+      IFS=, read -r -a panes <<<"$pane_pids"
+      for pane in "${panes[@]}"; do
+        [[ "$pane" =~ ^[0-9]+$ && -d "/proc/$pane" ]] || {
+          echo "tt: tmux pane PID changed during bridge setup" >&2
+          exit 2
+        }
+        [[ "$(/usr/bin/stat -c %u "/proc/$pane")" == "$uid" ]] || {
+          echo "tt: tmux pane ownership mismatch" >&2
+          exit 2
+        }
+        [[ "$(/usr/bin/readlink "/proc/$pane/ns/mnt")" == "$target_namespace" ]] || {
+          echo "tt: tmux pane mount namespace mismatch" >&2
+          exit 2
+        }
+      done
+    else
+      [[ "$target_kind" == "current" ]] || exit 2
+      target_pid="$current_pid"
+      target_starttime="$current_starttime"
+      target_namespace="$current_namespace"
+      target_exe="$current_exe"
+    fi
+
+    nsrun() {
+      /usr/bin/nsenter -t "$target_pid" -m -- "$@"
+    }
+
+    mount_record() {
+      local record
+      record="$(nsrun /usr/bin/findmnt -rn -M /mnt/c -o SOURCE,FSTYPE,OPTIONS 2>/dev/null || true)"
+      [[ -n "$record" ]] || return 1
+      [[ "$record" != *$'\''\n'\''* ]] || return 1
+      printf "%s\n" "$record"
+    }
+
+    mount_valid() {
+      local record source fstype options extra
+      record="$(mount_record)" || return 1
+      read -r source fstype options extra <<<"$record"
+      [[ -z "${extra:-}" && "$source" == "C:" ]] || return 1
+      case "$fstype" in
+        drvfs)
+          ;;
+        9p)
+          [[ ",$options," == *",aname=drvfs"* ]] || return 1
+          ;;
+        *)
+          return 1
+          ;;
+      esac
+      [[ ",$options," == *,ro,* && ",$options," != *,rw,* ]]
+    }
+
+    propagation="$(nsrun /usr/bin/findmnt -rn -M / -o PROPAGATION)"
+    [[ "$propagation" != shared* ]] || {
+      echo "tt: refusing bridge in a shared root mount namespace" >&2
+      exit 2
+    }
+
+    marker_value="$target_pid|$target_starttime|$target_namespace"
+    current_value="$current_pid|$current_starttime|$current_namespace"
+    /usr/bin/mkdir -p "$marker_dir"
+
+    case "$action" in
+      ensure)
+        if nsrun /usr/bin/findmnt -rn -M /mnt/c >/dev/null 2>&1; then
+          mount_valid || {
+            echo "tt: refusing unexpected /mnt/c mount; expected read-only C: drvfs" >&2
+            exit 2
+          }
+          if [[ -f "$marker" && "$(<"$marker")" != "$marker_value" ]]; then
+            echo "tt: refusing stale WSL bridge mount marker" >&2
+            exit 2
+          fi
+          if [[ "$target_kind" == "server" && -f "$pending" ]]; then
+            [[ "$(<"$pending")" == "$current_value" && "$current_namespace" == "$target_namespace" ]] || {
+              echo "tt: refusing stale WSL bridge pending marker" >&2
+              exit 2
+            }
+            printf "%s\n" "$marker_value" >"$marker"
+            /usr/bin/rm "$pending"
+            printf "promoted\n"
+          else
+            printf "existing\n"
+          fi
+          exit 0
+        fi
+
+        [[ ! -e "$marker" && ! -e "$pending" ]] || {
+          echo "tt: refusing bridge mount with stale marker state" >&2
+          exit 2
+        }
+        if [[ -L /mnt/c || ( -e /mnt/c && ! -d /mnt/c ) ]]; then
+          echo "tt: refusing non-directory /mnt/c mountpoint" >&2
+          exit 2
+        fi
+        if [[ -d /mnt/c ]] && [[ -n "$(nsrun /usr/bin/find /mnt/c -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+          echo "tt: refusing nonempty unmounted /mnt/c" >&2
+          exit 2
+        fi
+
+        nsrun /usr/bin/mkdir -p /mnt/c
+        nsrun /usr/bin/mount -t drvfs -o "ro,uid=$uid,gid=$gid,umask=022,fmask=011" C: /mnt/c
+        mount_valid || {
+          nsrun /usr/bin/umount /mnt/c 2>/dev/null || true
+          echo "tt: /mnt/c failed post-mount validation" >&2
+          exit 2
+        }
+        if [[ "$target_kind" == "server" ]]; then
+          printf "%s\n" "$marker_value" >"$marker"
+          printf "created\n"
+        else
+          printf "%s\n" "$current_value" >"$pending"
+          printf "prepared\n"
+        fi
+        ;;
+      rollback-server)
+        [[ "$target_kind" == "server" && -f "$marker" && "$(<"$marker")" == "$marker_value" ]] || {
+          echo "tt: refusing rollback without exact server mount marker" >&2
+          exit 2
+        }
+        mount_valid || {
+          echo "tt: refusing rollback of an unvalidated mount" >&2
+          exit 2
+        }
+        nsrun /usr/bin/umount /mnt/c
+        nsrun /usr/bin/findmnt -rn -M /mnt/c >/dev/null 2>&1 && exit 2
+        /usr/bin/rm "$marker"
+        printf "rolled-back\n"
+        ;;
+      rollback-current)
+        [[ "$target_kind" == "current" && -f "$pending" && "$(<"$pending")" == "$current_value" ]] || {
+          echo "tt: refusing rollback without exact pending mount marker" >&2
+          exit 2
+        }
+        mount_valid || {
+          echo "tt: refusing rollback of an unvalidated pending mount" >&2
+          exit 2
+        }
+        nsrun /usr/bin/umount /mnt/c
+        nsrun /usr/bin/findmnt -rn -M /mnt/c >/dev/null 2>&1 && exit 2
+        /usr/bin/rm "$pending"
+        printf "rolled-back\n"
+        ;;
+      *)
+        exit 2
+        ;;
+    esac
+  ' tt-wsl-bridge "$action" "$target_kind" "$target_pid" "$target_starttime" \
+    "$target_namespace" "$target_exe" "$pane_pids" "$current_pid" \
+    "$current_starttime" "$current_namespace" "$current_exe" "$uid" "$gid"
+}
+
+wsl_bridge_cleanup_pending() {
+  [[ "$TT_WSL_BRIDGE_PENDING" == "1" ]] || return 0
+  wsl_bridge_root_action rollback-current current \
+    "$TT_WSL_BRIDGE_PENDING_PID" "$TT_WSL_BRIDGE_PENDING_STARTTIME" \
+    "$TT_WSL_BRIDGE_PENDING_NS" "$TT_WSL_BRIDGE_PENDING_EXE" "" \
+    "$TT_WSL_BRIDGE_PENDING_PID" "$TT_WSL_BRIDGE_PENDING_STARTTIME" \
+    "$TT_WSL_BRIDGE_PENDING_NS" "$TT_WSL_BRIDGE_PENDING_EXE" >/dev/null || true
+  TT_WSL_BRIDGE_PENDING=0
 }
 
 wsl_bridge_ensure() {
-  local uid gid socket
+  local mode="${1:-explicit}"
+  local socket current_snapshot server_snapshot
+  local current_pid current_starttime current_namespace current_exe
+  local server_pid server_starttime server_namespace server_exe pane_pids
+  local result after_snapshot
 
   wsl_bridge_is_wsl || {
     echo "tt: wsl-bridge is available only inside WSL" >&2
@@ -75,82 +344,67 @@ wsl_bridge_ensure() {
     return 2
   }
 
-  uid="$(id -u)"
-  gid="$(id -g)"
-  [[ "$uid" =~ ^[0-9]+$ && "$gid" =~ ^[0-9]+$ ]] || {
-    echo "tt: could not determine numeric uid/gid for drvfs mount" >&2
+  current_snapshot="$(wsl_bridge_current_identity)" || {
+    echo "tt: could not validate the current WSL process identity" >&2
     return 2
   }
+  IFS='|' read -r current_pid current_starttime current_namespace current_exe <<<"$current_snapshot"
 
-  sudo -n flock -x /run/lock/tt-wsl-bridge.lock bash -c '
-    set -euo pipefail
-    uid="$1"
-    gid="$2"
-
-    mount_record() {
-      local record
-      record="$(findmnt -rn -M /mnt/c -o SOURCE,FSTYPE,OPTIONS 2>/dev/null || true)"
-      [[ -n "$record" ]] || return 1
-      [[ "$record" != *$'\''\n'\''* ]] || return 1
-      printf "%s\n" "$record"
+  if server_snapshot="$(wsl_bridge_server_snapshot)"; then
+    IFS='|' read -r server_pid server_starttime server_namespace server_exe pane_pids <<<"$server_snapshot"
+    result="$(wsl_bridge_root_action ensure server \
+      "$server_pid" "$server_starttime" "$server_namespace" "$server_exe" "$pane_pids" \
+      "$current_pid" "$current_starttime" "$current_namespace" "$current_exe")" || return
+    after_snapshot="$(wsl_bridge_server_snapshot)" || {
+      [[ "$result" == "created" || "$result" == "promoted" ]] &&
+        wsl_bridge_root_action rollback-server server \
+          "$server_pid" "$server_starttime" "$server_namespace" "$server_exe" "$pane_pids" \
+          "$current_pid" "$current_starttime" "$current_namespace" "$current_exe" >/dev/null || true
+      echo "tt: tmux server identity changed during bridge setup" >&2
+      return 2
     }
-
-    mount_valid() {
-      local record source fstype options extra
-      record="$(mount_record)" || return 1
-      read -r source fstype options extra <<<"$record"
-      [[ -z "${extra:-}" ]] || return 1
-      [[ "$source" == C:* ]] || return 1
-      case "$fstype" in
-        drvfs)
-          ;;
-        9p)
-          [[ ",$options," == *",aname=drvfs"* ]] || return 1
-          ;;
-        *)
-          return 1
-          ;;
-      esac
-      [[ ",$options," == *,ro,* ]]
+    if [[ "$after_snapshot" != "$server_snapshot" ]]; then
+      [[ "$result" == "created" || "$result" == "promoted" ]] &&
+        wsl_bridge_root_action rollback-server server \
+          "$server_pid" "$server_starttime" "$server_namespace" "$server_exe" "$pane_pids" \
+          "$current_pid" "$current_starttime" "$current_namespace" "$current_exe" >/dev/null || true
+      echo "tt: tmux pane set changed during bridge setup" >&2
+      return 2
+    fi
+    if ! "$TMUX_BIN" set-option -gq @tt_wsl_interop "$socket"; then
+      [[ "$result" == "created" || "$result" == "promoted" ]] &&
+        wsl_bridge_root_action rollback-server server \
+          "$server_pid" "$server_starttime" "$server_namespace" "$server_exe" "$pane_pids" \
+          "$current_pid" "$current_starttime" "$current_namespace" "$current_exe" >/dev/null || true
+      return 2
+    fi
+    TT_WSL_BRIDGE_PENDING=0
+    trap - EXIT
+  else
+    [[ "$mode" == "entry" ]] || {
+      echo "tt: wsl-bridge requires an existing tmux server; use a tt create/attach command" >&2
+      return 2
     }
+    result="$(wsl_bridge_root_action ensure current \
+      "$current_pid" "$current_starttime" "$current_namespace" "$current_exe" "" \
+      "$current_pid" "$current_starttime" "$current_namespace" "$current_exe")" || return
+    [[ "$result" == "prepared" || "$result" == "existing" ]] || return 2
+    TT_WSL_BRIDGE_PENDING=1
+    TT_WSL_BRIDGE_PENDING_PID="$current_pid"
+    TT_WSL_BRIDGE_PENDING_STARTTIME="$current_starttime"
+    TT_WSL_BRIDGE_PENDING_NS="$current_namespace"
+    TT_WSL_BRIDGE_PENDING_EXE="$current_exe"
+    trap wsl_bridge_cleanup_pending EXIT
+    return 0
+  fi
 
-    if findmnt -rn -M /mnt/c >/dev/null 2>&1; then
-      mount_valid || {
-        echo "tt: refusing unexpected /mnt/c mount; expected read-only C: drvfs" >&2
-        exit 2
-      }
-      exit 0
-    fi
-
-    if [[ -L /mnt/c || ( -e /mnt/c && ! -d /mnt/c ) ]]; then
-      echo "tt: refusing non-directory /mnt/c mountpoint" >&2
-      exit 2
-    fi
-    if [[ -d /mnt/c ]] && [[ -n "$(find /mnt/c -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
-      echo "tt: refusing nonempty unmounted /mnt/c" >&2
-      exit 2
-    fi
-
-    mkdir -p /mnt/c
-    mount -t drvfs -o "ro,uid=$uid,gid=$gid,umask=022,fmask=011" C: /mnt/c
-    mount_valid || {
-      echo "tt: /mnt/c failed post-mount validation" >&2
-      exit 2
-    }
-  ' tt-wsl-bridge "$uid" "$gid"
-
-  wsl_bridge_mount_valid || {
-    echo "tt: /mnt/c is not a read-only C: drvfs mount" >&2
-    return 2
-  }
-  "$TMUX_BIN" set-option -gq @tt_wsl_interop "$socket"
   TT_WSL_BRIDGE_READY=1
 }
 
 wsl_bridge_ensure_for_entry() {
   [[ "$TT_WSL_BRIDGE_READY" == "1" ]] && return 0
   if wsl_bridge_is_wsl && [[ -n "${WSL_INTEROP:-}" ]]; then
-    wsl_bridge_ensure
+    wsl_bridge_ensure entry
   fi
 }
 
@@ -525,11 +779,13 @@ create_plain() {
   if [[ -n "${TMUX:-}" ]]; then
     "$TMUX_BIN" new-session -d -s "$session"
     set_profile_metadata "$session" plain
+    wsl_bridge_ensure_for_entry
     exec "$TMUX_BIN" switch-client -t "$session"
   fi
 
   "$TMUX_BIN" new-session -d -s "$session"
   set_profile_metadata "$session" plain
+  wsl_bridge_ensure_for_entry
   exec "$TMUX_BIN" attach -t "$session"
 }
 
@@ -831,12 +1087,14 @@ create_mobile() {
     "$TMUX_BIN" new-session -d -s "$session"
     set_profile_metadata "$session" mobile
     "$TMUX_BIN" set-option -t "$session" -q status off
+    wsl_bridge_ensure_for_entry
     exec "$TMUX_BIN" switch-client -t "$session"
   fi
 
   "$TMUX_BIN" new -d -s "$session"
   set_profile_metadata "$session" mobile
   "$TMUX_BIN" set-option -t "$session" -q status off
+  wsl_bridge_ensure_for_entry
   exec "$TMUX_BIN" attach -t "$session"
 }
 
@@ -2737,6 +2995,7 @@ recover_agent_cockpit() {
     write_agent_cockpit_state "$(agent_cockpit_state_file)" --quiet
   fi
 
+  wsl_bridge_ensure_for_entry
   if [[ -n "${TMUX:-}" ]]; then
     exec "$TMUX_BIN" switch-client -t "$attach_session"
   fi
@@ -2859,6 +3118,7 @@ recover_cockpit() {
   finish_recovery_setup "$server_was_running"
   restore_cockpit_snapshot "$snapshot" "$session" --preserve-server
 
+  wsl_bridge_ensure_for_entry
   exec "$TMUX_BIN" attach -t "$session"
 }
 

--- a/bin/tt
+++ b/bin/tt
@@ -15,9 +15,149 @@ fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 DOTFILES_DIR="$(cd "$SCRIPT_DIR/.." && pwd -P)"
+TT_WSL_BRIDGE_READY=0
+
+wsl_bridge_is_wsl() {
+  [[ -n "${WSL_DISTRO_NAME:-}" ]] &&
+    [[ "$(uname -r 2>/dev/null || true)" =~ [Mm]icrosoft|WSL ]]
+}
+
+wsl_bridge_valid_socket() {
+  local socket="$1"
+
+  [[ "$socket" =~ ^/run/WSL/[0-9]+_interop$ ]] && [[ -S "$socket" ]]
+}
+
+wsl_bridge_mount_record() {
+  local record
+
+  record="$(findmnt -rn -M /mnt/c -o SOURCE,FSTYPE,OPTIONS 2>/dev/null || true)"
+  [[ -n "$record" ]] || return 1
+  [[ "$record" != *$'\n'* ]] || return 1
+  printf '%s\n' "$record"
+}
+
+wsl_bridge_mount_valid() {
+  local record source fstype options extra
+
+  record="$(wsl_bridge_mount_record)" || return 1
+  read -r source fstype options extra <<<"$record"
+  [[ -z "${extra:-}" ]] || return 1
+  [[ "$source" == C:* ]] || return 1
+  case "$fstype" in
+    drvfs)
+      ;;
+    9p)
+      [[ ",$options," == *",aname=drvfs"* ]] || return 1
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  [[ ",$options," == *,ro,* ]]
+}
+
+wsl_bridge_ensure() {
+  local uid gid socket
+
+  wsl_bridge_is_wsl || {
+    echo "tt: wsl-bridge is available only inside WSL" >&2
+    return 2
+  }
+
+  socket="${WSL_INTEROP:-}"
+  [[ -n "$socket" ]] || {
+    echo "tt: wsl-bridge requires WSL_INTEROP from a native wsl.exe launch" >&2
+    return 2
+  }
+  wsl_bridge_valid_socket "$socket" || {
+    echo "tt: refusing invalid or dead WSL_INTEROP socket: $socket" >&2
+    return 2
+  }
+
+  uid="$(id -u)"
+  gid="$(id -g)"
+  [[ "$uid" =~ ^[0-9]+$ && "$gid" =~ ^[0-9]+$ ]] || {
+    echo "tt: could not determine numeric uid/gid for drvfs mount" >&2
+    return 2
+  }
+
+  sudo -n flock -x /run/lock/tt-wsl-bridge.lock bash -c '
+    set -euo pipefail
+    uid="$1"
+    gid="$2"
+
+    mount_record() {
+      local record
+      record="$(findmnt -rn -M /mnt/c -o SOURCE,FSTYPE,OPTIONS 2>/dev/null || true)"
+      [[ -n "$record" ]] || return 1
+      [[ "$record" != *$'\''\n'\''* ]] || return 1
+      printf "%s\n" "$record"
+    }
+
+    mount_valid() {
+      local record source fstype options extra
+      record="$(mount_record)" || return 1
+      read -r source fstype options extra <<<"$record"
+      [[ -z "${extra:-}" ]] || return 1
+      [[ "$source" == C:* ]] || return 1
+      case "$fstype" in
+        drvfs)
+          ;;
+        9p)
+          [[ ",$options," == *",aname=drvfs"* ]] || return 1
+          ;;
+        *)
+          return 1
+          ;;
+      esac
+      [[ ",$options," == *,ro,* ]]
+    }
+
+    if findmnt -rn -M /mnt/c >/dev/null 2>&1; then
+      mount_valid || {
+        echo "tt: refusing unexpected /mnt/c mount; expected read-only C: drvfs" >&2
+        exit 2
+      }
+      exit 0
+    fi
+
+    if [[ -L /mnt/c || ( -e /mnt/c && ! -d /mnt/c ) ]]; then
+      echo "tt: refusing non-directory /mnt/c mountpoint" >&2
+      exit 2
+    fi
+    if [[ -d /mnt/c ]] && [[ -n "$(find /mnt/c -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+      echo "tt: refusing nonempty unmounted /mnt/c" >&2
+      exit 2
+    fi
+
+    mkdir -p /mnt/c
+    mount -t drvfs -o "ro,uid=$uid,gid=$gid,umask=022,fmask=011" C: /mnt/c
+    mount_valid || {
+      echo "tt: /mnt/c failed post-mount validation" >&2
+      exit 2
+    }
+  ' tt-wsl-bridge "$uid" "$gid"
+
+  wsl_bridge_mount_valid || {
+    echo "tt: /mnt/c is not a read-only C: drvfs mount" >&2
+    return 2
+  }
+  "$TMUX_BIN" set-option -gq @tt_wsl_interop "$socket"
+  TT_WSL_BRIDGE_READY=1
+}
+
+wsl_bridge_ensure_for_entry() {
+  [[ "$TT_WSL_BRIDGE_READY" == "1" ]] && return 0
+  if wsl_bridge_is_wsl && [[ -n "${WSL_INTEROP:-}" ]]; then
+    wsl_bridge_ensure
+  fi
+}
 
 attach_or_switch() {
   local session="$1"
+
+  wsl_bridge_ensure_for_entry
 
   if [[ -n "${TMUX:-}" ]]; then
     exec "$TMUX_BIN" switch-client -t "$session"
@@ -375,6 +515,7 @@ kill_server() {
 create_plain() {
   local session="$1"
 
+  wsl_bridge_ensure_for_entry
   ensure_tmux_default_shell
 
   if "$TMUX_BIN" has-session -t "$session" 2>/dev/null; then
@@ -528,6 +669,7 @@ create_ops() {
   local session="${1:-cockpit}"
   local start_dir="${2:-$PWD}"
 
+  wsl_bridge_ensure_for_entry
   create_ops_detached "$session" "$start_dir"
   attach_or_switch "$session"
 }
@@ -656,6 +798,7 @@ ensure_studio_layout() {
 create_studio() {
   local session="$1"
 
+  wsl_bridge_ensure_for_entry
   ensure_studio_layout "$session"
   install_agent_autosave_hooks
   write_agent_cockpit_state "$(agent_cockpit_state_file)" --quiet
@@ -679,6 +822,7 @@ create_studio_detached() {
 create_mobile() {
   local session="$1"
 
+  wsl_bridge_ensure_for_entry
   if "$TMUX_BIN" has-session -t "$session" 2>/dev/null; then
     attach_or_switch "$session"
   fi
@@ -812,6 +956,7 @@ attach_mobile_target() {
   local target="$1"
   local source_session target_suffix
 
+  wsl_bridge_ensure_for_entry
   source_session="${target%%:*}"
   target_suffix="${target#*:}"
 
@@ -2572,6 +2717,7 @@ recover_agent_cockpit() {
     exit 2
   fi
 
+  wsl_bridge_ensure_for_entry
   if [[ -z "$manifest" || "$manifest" == "--default" ]]; then
     manifest="$(agent_cockpit_manifest)"
   fi
@@ -2695,6 +2841,7 @@ recover_cockpit() {
     exit 2
   fi
 
+  wsl_bridge_ensure_for_entry
   snapshot="$(latest_cockpit_snapshot "$snapshot" "$session")" || exit 2
   printf 'tt recovering %s from %s\n' "$session" "$snapshot" >&2
 
@@ -3071,6 +3218,17 @@ case "${1:-}" in
   mosh-attn)
     sync_mosh_attention_panes "${2:-}"
     ;;
+  wsl-bridge)
+    case "${2:-ensure}" in
+      ensure)
+        wsl_bridge_ensure
+        ;;
+      *)
+        echo "usage: tt wsl-bridge ensure" >&2
+        exit 2
+        ;;
+    esac
+    ;;
   pane-menu)
     show_pane_menu "${2:-${TMUX_PANE:-}}" "${3:-P}" "${4:-P}" "${5:-}"
     ;;
@@ -3203,7 +3361,7 @@ case "${1:-}" in
     if "$TMUX_BIN" has-session -t "$1" 2>/dev/null; then
       attach_or_switch "$1"
     else
-      echo "usage: tt [ai [session]|ops [session]|shell [session]|mobile [session]|reset [ai|shell|mobile] [session]|restore [target]|restore-preview [snapshot]|recover [manifest] [attach-session]|snapshot [file] [--quiet]|codex-snapshot [file] [--quiet]|codex-snapshot-show [snapshot]|snapshot-history [codex-cockpit|agent-cockpit] [limit]|status|doctor [--fix|--check]|popup [snapshot|restore-preview|snapshot-history|status|doctor]|codex-restore [preview|all|pane <target>|window <session:window>] [snapshot] [--execute]|autosave [on|off]|refresh [agents]|sync [target|all]|note [set|clear|show|edit|prompt|sync|list]|marker [set|clear|sync|list]|title [target] <short-title>|colorfix|status-audit|titles [on|off] [target]|kill|attach <session>|ls]" >&2
+      echo "usage: tt [ai [session]|ops [session]|shell [session]|mobile [session]|reset [ai|shell|mobile] [session]|restore [target]|restore-preview [snapshot]|recover [manifest] [attach-session]|snapshot [file] [--quiet]|codex-snapshot [file] [--quiet]|codex-snapshot-show [snapshot]|snapshot-history [codex-cockpit|agent-cockpit] [limit]|status|doctor [--fix|--check]|popup [snapshot|restore-preview|snapshot-history|status|doctor]|codex-restore [preview|all|pane <target>|window <session:window>] [snapshot] [--execute]|autosave [on|off]|refresh [agents]|sync [target|all]|note [set|clear|show|edit|prompt|sync|list]|marker [set|clear|sync|list]|title [target] <short-title>|colorfix|status-audit|titles [on|off] [target]|wsl-bridge ensure|kill|attach <session>|ls]" >&2
       exit 2
     fi
     ;;

--- a/bin/tt
+++ b/bin/tt
@@ -57,8 +57,9 @@ wsl_bridge_current_identity() {
 }
 
 wsl_bridge_server_snapshot() {
-  local pid starttime namespace exe expected_exe owner pane pane_namespace panes
-  local -a pane_ids
+  local pid starttime namespace exe expected_exe owner socket_path
+  local pane_id pane pane_dead pane_namespace pane_entries
+  local -a pane_rows
 
   pid="$("$TMUX_BIN" display-message -p '#{pid}' 2>/dev/null || true)"
   [[ "$pid" =~ ^[0-9]+$ ]] || return 1
@@ -72,17 +73,30 @@ wsl_bridge_server_snapshot() {
   expected_exe="$(readlink -f "$TMUX_BIN")" || return 1
   [[ "$exe" == "$expected_exe" ]] || return 1
 
-  panes="$("$TMUX_BIN" list-panes -a -F '#{pane_pid}' 2>/dev/null | sort -nu | paste -sd, -)"
-  [[ -n "$panes" ]] || return 1
-  IFS=',' read -r -a pane_ids <<<"$panes"
-  for pane in "${pane_ids[@]}"; do
-    [[ "$pane" =~ ^[0-9]+$ ]] || return 1
-    [[ "$(stat -c %u "/proc/$pane")" == "$owner" ]] || return 1
-    pane_namespace="$(readlink "/proc/$pane/ns/mnt")" || return 1
-    [[ "$pane_namespace" == "$namespace" ]] || return 1
+  socket_path="$("$TMUX_BIN" display-message -p '#{socket_path}' 2>/dev/null || true)"
+  [[ -S "$socket_path" ]] || return 1
+  [[ "$(stat -c %u "$socket_path")" == "$owner" ]] || return 1
+
+  while IFS= read -r row; do
+    pane_rows+=("$row")
+  done < <("$TMUX_BIN" list-panes -a -F '#{pane_id}|#{pane_pid}|#{pane_dead}' 2>/dev/null | sort)
+  [[ "${#pane_rows[@]}" -gt 0 ]] || return 1
+  pane_entries=""
+  for row in "${pane_rows[@]}"; do
+    IFS='|' read -r pane_id pane pane_dead <<<"$row"
+    [[ "$pane_id" =~ ^%[0-9]+$ && "$pane" =~ ^[0-9]+$ && "$pane_dead" =~ ^[01]$ ]] || return 1
+    if [[ "$pane_dead" == "1" ]]; then
+      [[ ! -e "/proc/$pane" ]] || return 1
+    else
+      [[ "$(stat -c %u "/proc/$pane")" == "$owner" ]] || return 1
+      pane_namespace="$(readlink "/proc/$pane/ns/mnt")" || return 1
+      [[ "$pane_namespace" == "$namespace" ]] || return 1
+    fi
+    pane_entries+="${pane_entries:+,}$pane_id:$pane:$pane_dead"
   done
 
-  printf '%s|%s|%s|%s|%s\n' "$pid" "$starttime" "$namespace" "$exe" "$panes"
+  printf '%s|%s|%s|%s|%s|%s\n' \
+    "$pid" "$starttime" "$namespace" "$exe" "$socket_path" "$pane_entries"
 }
 
 wsl_bridge_root_action() {
@@ -92,11 +106,12 @@ wsl_bridge_root_action() {
   local target_starttime="$4"
   local target_namespace="$5"
   local target_exe="$6"
-  local pane_pids="$7"
-  local current_pid="$8"
-  local current_starttime="$9"
-  local current_namespace="${10}"
-  local current_exe="${11}"
+  local socket_path="$7"
+  local pane_entries="$8"
+  local current_pid="$9"
+  local current_starttime="${10}"
+  local current_namespace="${11}"
+  local current_exe="${12}"
   local uid gid
 
   uid="$(id -u)"
@@ -114,13 +129,14 @@ wsl_bridge_root_action() {
     target_starttime="$4"
     target_namespace="$5"
     target_exe="$6"
-    pane_pids="$7"
-    current_pid="$8"
-    current_starttime="$9"
-    current_namespace="${10}"
-    current_exe="${11}"
-    uid="${12}"
-    gid="${13}"
+    socket_path="$7"
+    pane_entries="$8"
+    current_pid="$9"
+    current_starttime="${10}"
+    current_namespace="${11}"
+    current_exe="${12}"
+    uid="${13}"
+    gid="${14}"
     marker_dir=/run/tt-wsl-bridge
     marker="$marker_dir/mount-$uid"
     pending="$marker_dir/pending-$uid"
@@ -155,14 +171,40 @@ wsl_bridge_root_action() {
     validate_process "$current_pid" "$current_starttime" "$current_namespace" "$current_exe"
     if [[ "$target_kind" == "server" ]]; then
       validate_process "$target_pid" "$target_starttime" "$target_namespace" "$target_exe" "tmux: server"
-      [[ -n "$pane_pids" ]] || {
-        echo "tt: tmux server has no validated panes" >&2
+      [[ -S "$socket_path" && "$(/usr/bin/stat -c %u "$socket_path")" == "$uid" ]] || {
+        echo "tt: tmux socket identity mismatch" >&2
         exit 2
       }
-      IFS=, read -r -a panes <<<"$pane_pids"
-      for pane in "${panes[@]}"; do
-        [[ "$pane" =~ ^[0-9]+$ && -d "/proc/$pane" ]] || {
-          echo "tt: tmux pane PID changed during bridge setup" >&2
+      [[ "$(/usr/bin/setpriv --reuid "$uid" --regid "$gid" --clear-groups "$target_exe" -S "$socket_path" display-message -p "#{pid}")" == "$target_pid" ]] || {
+        echo "tt: tmux socket points to a different server" >&2
+        exit 2
+      }
+      locked_panes="$(
+        /usr/bin/setpriv --reuid "$uid" --regid "$gid" --clear-groups \
+          "$target_exe" -S "$socket_path" list-panes -a -F "#{pane_id}|#{pane_pid}|#{pane_dead}" |
+          /usr/bin/sort |
+          /usr/bin/awk -F "|" '\''{printf "%s%s:%s:%s", sep, $1, $2, $3; sep=","} END {print ""}'\''
+      )"
+      [[ -n "$pane_entries" && "$locked_panes" == "$pane_entries" ]] || {
+        echo "tt: tmux pane set changed before bridge lock validation" >&2
+        exit 2
+      }
+      IFS=, read -r -a panes <<<"$pane_entries"
+      for pane_entry in "${panes[@]}"; do
+        IFS=: read -r pane_id pane pane_dead <<<"$pane_entry"
+        [[ "$pane_id" =~ ^%[0-9]+$ && "$pane" =~ ^[0-9]+$ && "$pane_dead" =~ ^[01]$ ]] || {
+          echo "tt: invalid tmux pane identity" >&2
+          exit 2
+        }
+        if [[ "$pane_dead" == "1" ]]; then
+          [[ ! -e "/proc/$pane" ]] || {
+            echo "tt: dead tmux pane PID was reused during bridge setup" >&2
+            exit 2
+          }
+          continue
+        fi
+        [[ -d "/proc/$pane" ]] || {
+          echo "tt: active tmux pane PID changed during bridge setup" >&2
           exit 2
         }
         [[ "$(/usr/bin/stat -c %u "/proc/$pane")" == "$uid" ]] || {
@@ -308,7 +350,7 @@ wsl_bridge_root_action() {
         ;;
     esac
   ' tt-wsl-bridge "$action" "$target_kind" "$target_pid" "$target_starttime" \
-    "$target_namespace" "$target_exe" "$pane_pids" "$current_pid" \
+    "$target_namespace" "$target_exe" "$socket_path" "$pane_entries" "$current_pid" \
     "$current_starttime" "$current_namespace" "$current_exe" "$uid" "$gid"
 }
 
@@ -316,7 +358,7 @@ wsl_bridge_cleanup_pending() {
   [[ "$TT_WSL_BRIDGE_PENDING" == "1" ]] || return 0
   wsl_bridge_root_action rollback-current current \
     "$TT_WSL_BRIDGE_PENDING_PID" "$TT_WSL_BRIDGE_PENDING_STARTTIME" \
-    "$TT_WSL_BRIDGE_PENDING_NS" "$TT_WSL_BRIDGE_PENDING_EXE" "" \
+    "$TT_WSL_BRIDGE_PENDING_NS" "$TT_WSL_BRIDGE_PENDING_EXE" "" "" \
     "$TT_WSL_BRIDGE_PENDING_PID" "$TT_WSL_BRIDGE_PENDING_STARTTIME" \
     "$TT_WSL_BRIDGE_PENDING_NS" "$TT_WSL_BRIDGE_PENDING_EXE" >/dev/null || true
   TT_WSL_BRIDGE_PENDING=0
@@ -326,7 +368,7 @@ wsl_bridge_ensure() {
   local mode="${1:-explicit}"
   local socket current_snapshot server_snapshot
   local current_pid current_starttime current_namespace current_exe
-  local server_pid server_starttime server_namespace server_exe pane_pids
+  local server_pid server_starttime server_namespace server_exe socket_path pane_entries
   local result after_snapshot
 
   wsl_bridge_is_wsl || {
@@ -351,14 +393,14 @@ wsl_bridge_ensure() {
   IFS='|' read -r current_pid current_starttime current_namespace current_exe <<<"$current_snapshot"
 
   if server_snapshot="$(wsl_bridge_server_snapshot)"; then
-    IFS='|' read -r server_pid server_starttime server_namespace server_exe pane_pids <<<"$server_snapshot"
+    IFS='|' read -r server_pid server_starttime server_namespace server_exe socket_path pane_entries <<<"$server_snapshot"
     result="$(wsl_bridge_root_action ensure server \
-      "$server_pid" "$server_starttime" "$server_namespace" "$server_exe" "$pane_pids" \
+      "$server_pid" "$server_starttime" "$server_namespace" "$server_exe" "$socket_path" "$pane_entries" \
       "$current_pid" "$current_starttime" "$current_namespace" "$current_exe")" || return
     after_snapshot="$(wsl_bridge_server_snapshot)" || {
       [[ "$result" == "created" || "$result" == "promoted" ]] &&
         wsl_bridge_root_action rollback-server server \
-          "$server_pid" "$server_starttime" "$server_namespace" "$server_exe" "$pane_pids" \
+          "$server_pid" "$server_starttime" "$server_namespace" "$server_exe" "$socket_path" "$pane_entries" \
           "$current_pid" "$current_starttime" "$current_namespace" "$current_exe" >/dev/null || true
       echo "tt: tmux server identity changed during bridge setup" >&2
       return 2
@@ -366,7 +408,7 @@ wsl_bridge_ensure() {
     if [[ "$after_snapshot" != "$server_snapshot" ]]; then
       [[ "$result" == "created" || "$result" == "promoted" ]] &&
         wsl_bridge_root_action rollback-server server \
-          "$server_pid" "$server_starttime" "$server_namespace" "$server_exe" "$pane_pids" \
+          "$server_pid" "$server_starttime" "$server_namespace" "$server_exe" "$socket_path" "$pane_entries" \
           "$current_pid" "$current_starttime" "$current_namespace" "$current_exe" >/dev/null || true
       echo "tt: tmux pane set changed during bridge setup" >&2
       return 2
@@ -374,7 +416,7 @@ wsl_bridge_ensure() {
     if ! "$TMUX_BIN" set-option -gq @tt_wsl_interop "$socket"; then
       [[ "$result" == "created" || "$result" == "promoted" ]] &&
         wsl_bridge_root_action rollback-server server \
-          "$server_pid" "$server_starttime" "$server_namespace" "$server_exe" "$pane_pids" \
+          "$server_pid" "$server_starttime" "$server_namespace" "$server_exe" "$socket_path" "$pane_entries" \
           "$current_pid" "$current_starttime" "$current_namespace" "$current_exe" >/dev/null || true
       return 2
     fi
@@ -386,7 +428,7 @@ wsl_bridge_ensure() {
       return 2
     }
     result="$(wsl_bridge_root_action ensure current \
-      "$current_pid" "$current_starttime" "$current_namespace" "$current_exe" "" \
+      "$current_pid" "$current_starttime" "$current_namespace" "$current_exe" "" "" \
       "$current_pid" "$current_starttime" "$current_namespace" "$current_exe")" || return
     [[ "$result" == "prepared" || "$result" == "existing" ]] || return 2
     TT_WSL_BRIDGE_PENDING=1

--- a/bin/tt
+++ b/bin/tt
@@ -56,10 +56,8 @@ wsl_bridge_current_identity() {
   printf '%s|%s|%s|%s\n' "$pid" "$starttime" "$namespace" "$exe"
 }
 
-wsl_bridge_server_snapshot() {
+wsl_bridge_server_identity() {
   local pid starttime namespace exe expected_exe owner socket_path
-  local pane_id pane pane_dead pane_namespace pane_entries
-  local -a pane_rows
 
   pid="$("$TMUX_BIN" display-message -p '#{pid}' 2>/dev/null || true)"
   [[ "$pid" =~ ^[0-9]+$ ]] || return 1
@@ -76,6 +74,18 @@ wsl_bridge_server_snapshot() {
   socket_path="$("$TMUX_BIN" display-message -p '#{socket_path}' 2>/dev/null || true)"
   [[ -S "$socket_path" ]] || return 1
   [[ "$(stat -c %u "$socket_path")" == "$owner" ]] || return 1
+
+  printf '%s|%s|%s|%s|%s\n' "$pid" "$starttime" "$namespace" "$exe" "$socket_path"
+}
+
+wsl_bridge_server_snapshot() {
+  local identity pid starttime namespace exe socket_path owner
+  local pane_id pane pane_dead pane_namespace pane_entries
+  local -a pane_rows
+
+  identity="$(wsl_bridge_server_identity)" || return 1
+  IFS='|' read -r pid starttime namespace exe socket_path <<<"$identity"
+  owner="$(id -u)"
 
   while IFS= read -r row; do
     pane_rows+=("$row")
@@ -179,43 +189,45 @@ wsl_bridge_root_action() {
         echo "tt: tmux socket points to a different server" >&2
         exit 2
       }
-      locked_panes="$(
-        /usr/bin/setpriv --reuid "$uid" --regid "$gid" --clear-groups \
-          "$target_exe" -S "$socket_path" list-panes -a -F "#{pane_id}|#{pane_pid}|#{pane_dead}" |
-          /usr/bin/sort |
-          /usr/bin/awk -F "|" '\''{printf "%s%s:%s:%s", sep, $1, $2, $3; sep=","} END {print ""}'\''
-      )"
-      [[ -n "$pane_entries" && "$locked_panes" == "$pane_entries" ]] || {
-        echo "tt: tmux pane set changed before bridge lock validation" >&2
-        exit 2
-      }
-      IFS=, read -r -a panes <<<"$pane_entries"
-      for pane_entry in "${panes[@]}"; do
-        IFS=: read -r pane_id pane pane_dead <<<"$pane_entry"
-        [[ "$pane_id" =~ ^%[0-9]+$ && "$pane" =~ ^[0-9]+$ && "$pane_dead" =~ ^[01]$ ]] || {
-          echo "tt: invalid tmux pane identity" >&2
+      if [[ "$action" == "ensure" ]]; then
+        locked_panes="$(
+          /usr/bin/setpriv --reuid "$uid" --regid "$gid" --clear-groups \
+            "$target_exe" -S "$socket_path" list-panes -a -F "#{pane_id}|#{pane_pid}|#{pane_dead}" |
+            /usr/bin/sort |
+            /usr/bin/awk -F "|" '\''{printf "%s%s:%s:%s", sep, $1, $2, $3; sep=","} END {print ""}'\''
+        )"
+        [[ -n "$pane_entries" && "$locked_panes" == "$pane_entries" ]] || {
+          echo "tt: tmux pane set changed before bridge lock validation" >&2
           exit 2
         }
-        if [[ "$pane_dead" == "1" ]]; then
-          [[ ! -e "/proc/$pane" ]] || {
-            echo "tt: dead tmux pane PID was reused during bridge setup" >&2
+        IFS=, read -r -a panes <<<"$pane_entries"
+        for pane_entry in "${panes[@]}"; do
+          IFS=: read -r pane_id pane pane_dead <<<"$pane_entry"
+          [[ "$pane_id" =~ ^%[0-9]+$ && "$pane" =~ ^[0-9]+$ && "$pane_dead" =~ ^[01]$ ]] || {
+            echo "tt: invalid tmux pane identity" >&2
             exit 2
           }
-          continue
-        fi
-        [[ -d "/proc/$pane" ]] || {
-          echo "tt: active tmux pane PID changed during bridge setup" >&2
-          exit 2
-        }
-        [[ "$(/usr/bin/stat -c %u "/proc/$pane")" == "$uid" ]] || {
-          echo "tt: tmux pane ownership mismatch" >&2
-          exit 2
-        }
-        [[ "$(/usr/bin/readlink "/proc/$pane/ns/mnt")" == "$target_namespace" ]] || {
-          echo "tt: tmux pane mount namespace mismatch" >&2
-          exit 2
-        }
-      done
+          if [[ "$pane_dead" == "1" ]]; then
+            [[ ! -e "/proc/$pane" ]] || {
+              echo "tt: dead tmux pane PID was reused during bridge setup" >&2
+              exit 2
+            }
+            continue
+          fi
+          [[ -d "/proc/$pane" ]] || {
+            echo "tt: active tmux pane PID changed during bridge setup" >&2
+            exit 2
+          }
+          [[ "$(/usr/bin/stat -c %u "/proc/$pane")" == "$uid" ]] || {
+            echo "tt: tmux pane ownership mismatch" >&2
+            exit 2
+          }
+          [[ "$(/usr/bin/readlink "/proc/$pane/ns/mnt")" == "$target_namespace" ]] || {
+            echo "tt: tmux pane mount namespace mismatch" >&2
+            exit 2
+          }
+        done
+      fi
     else
       [[ "$target_kind" == "current" ]] || exit 2
       target_pid="$current_pid"
@@ -254,15 +266,182 @@ wsl_bridge_root_action() {
       [[ ",$options," == *,ro,* && ",$options," != *,rw,* ]]
     }
 
+    mode_not_writable_by_group_or_world() {
+      local mode="$1"
+      [[ "$mode" =~ ^[0-7]{3,4}$ ]] || return 1
+      (( (8#$mode & 8#022) == 0 ))
+    }
+
+    validate_marker_dir() {
+      local owner mode
+      if [[ ! -e "$marker_dir" && ! -L "$marker_dir" ]]; then
+        /usr/bin/mkdir -m 0700 "$marker_dir"
+      fi
+      [[ -d "$marker_dir" && ! -L "$marker_dir" ]] || {
+        echo "tt: refusing unsafe WSL bridge marker directory" >&2
+        return 2
+      }
+      owner="$(/usr/bin/stat -c %u "$marker_dir")"
+      mode="$(/usr/bin/stat -c %a "$marker_dir")"
+      [[ "$owner" == "0" ]] && mode_not_writable_by_group_or_world "$mode" || {
+        echo "tt: WSL bridge marker directory must be root-owned and not group/world-writable" >&2
+        return 2
+      }
+    }
+
+    parse_record() {
+      local value="$1"
+      [[ "$value" =~ ^([0-9]+)\|([0-9]+)\|mnt:\[([0-9]+)\]$ ]] || return 1
+      RECORD_PID="${BASH_REMATCH[1]}"
+      RECORD_STARTTIME="${BASH_REMATCH[2]}"
+      RECORD_NAMESPACE="mnt:[${BASH_REMATCH[3]}]"
+    }
+
+    load_record() {
+      local path="$1"
+      local label="$2"
+      local owner mode size lines value
+      if [[ ! -e "$path" && ! -L "$path" ]]; then
+        return 1
+      fi
+      [[ -f "$path" && ! -L "$path" ]] || {
+        echo "tt: refusing unsafe $label record" >&2
+        return 2
+      }
+      owner="$(/usr/bin/stat -c %u "$path")"
+      mode="$(/usr/bin/stat -c %a "$path")"
+      size="$(/usr/bin/stat -c %s "$path")"
+      lines="$(/usr/bin/wc -l <"$path")"
+      lines="${lines//[[:space:]]/}"
+      [[ "$owner" == "0" ]] &&
+        mode_not_writable_by_group_or_world "$mode" &&
+        [[ "$size" =~ ^[0-9]+$ && "$size" -gt 0 && "$size" -le 128 && "$lines" == "1" ]] || {
+        echo "tt: $label record must be root-owned, bounded, and not group/world-writable" >&2
+        return 2
+      }
+      value="$(<"$path")"
+      parse_record "$value" || {
+        echo "tt: refusing malformed $label record" >&2
+        return 2
+      }
+      printf "%s\n" "$value"
+    }
+
+    atomic_write_record() {
+      local path="$1"
+      local value="$2"
+      local temp
+      parse_record "$value" || {
+        echo "tt: refusing to write malformed WSL bridge record" >&2
+        return 2
+      }
+      temp="$(/usr/bin/mktemp "$marker_dir/.record.XXXXXX")"
+      if ! /usr/bin/chmod 0600 "$temp"; then
+        echo "tt: failed to secure temporary WSL bridge record" >&2
+        /usr/bin/rm -f "$temp"
+        return 2
+      fi
+      if ! printf "%s\n" "$value" >"$temp"; then
+        echo "tt: failed to write temporary WSL bridge record" >&2
+        /usr/bin/rm -f "$temp"
+        return 2
+      fi
+      if ! /usr/bin/mv -fT "$temp" "$path"; then
+        echo "tt: failed to atomically publish WSL bridge record" >&2
+        /usr/bin/rm -f "$temp"
+        return 2
+      fi
+      load_record "$path" "WSL bridge" >/dev/null || return 2
+    }
+
+    record_is_exact_live() {
+      local value="$1"
+      local actual_starttime actual_namespace
+      parse_record "$value" || return 2
+      [[ -d "/proc/$RECORD_PID" ]] || return 1
+      actual_starttime="$(proc_starttime "$RECORD_PID")" || return 2
+      actual_namespace="$(/usr/bin/readlink "/proc/$RECORD_PID/ns/mnt")" || return 2
+      [[ "$actual_starttime" == "$RECORD_STARTTIME" && "$actual_namespace" == "$RECORD_NAMESPACE" ]]
+    }
+
+    namespace_unreferenced() {
+      local namespace="$1"
+      local proc_dir actual_namespace
+      local -a proc_dirs
+      [[ "$namespace" =~ ^mnt:\[[0-9]+\]$ ]] || return 2
+      shopt -s nullglob
+      proc_dirs=(/proc/[0-9]*)
+      shopt -u nullglob
+      [[ "${#proc_dirs[@]}" -gt 0 ]] || return 2
+      for proc_dir in "${proc_dirs[@]}"; do
+        [[ -d "$proc_dir" ]] || return 2
+        actual_namespace="$(/usr/bin/readlink "$proc_dir/ns/mnt")" || return 2
+        [[ "$actual_namespace" != "$namespace" ]] || return 1
+      done
+      return 0
+    }
+
+    remove_stale_record() {
+      local path="$1"
+      local label="$2"
+      local value="$3"
+      local target_ns="$4"
+      local live_status scan_status
+      parse_record "$value" || return 2
+      if record_is_exact_live "$value"; then
+        echo "tt: refusing to remove $label record for an exact live process" >&2
+        return 2
+      else
+        live_status=$?
+        [[ "$live_status" == "1" ]] || {
+          echo "tt: refusing ambiguous $label process identity" >&2
+          return 2
+        }
+      fi
+      if [[ "$RECORD_NAMESPACE" != "$target_ns" ]]; then
+        if namespace_unreferenced "$RECORD_NAMESPACE"; then
+          :
+        else
+          scan_status=$?
+          if [[ "$scan_status" == "1" ]]; then
+            echo "tt: refusing $label cleanup; recorded mount namespace is still referenced" >&2
+          else
+            echo "tt: refusing $label cleanup; mount namespace scan was ambiguous" >&2
+          fi
+          return 2
+        fi
+      fi
+      if ! /usr/bin/rm -- "$path"; then
+        echo "tt: failed to remove stale $label record" >&2
+        return 2
+      fi
+    }
+
     propagation="$(nsrun /usr/bin/findmnt -rn -M / -o PROPAGATION)"
     [[ "$propagation" != shared* ]] || {
       echo "tt: refusing bridge in a shared root mount namespace" >&2
       exit 2
     }
 
+    validate_marker_dir || exit 2
     marker_value="$target_pid|$target_starttime|$target_namespace"
     current_value="$current_pid|$current_starttime|$current_namespace"
-    /usr/bin/mkdir -p "$marker_dir"
+    marker_present=0
+    pending_present=0
+    if marker_record="$(load_record "$marker" "WSL bridge mount")"; then
+      marker_present=1
+    else
+      record_status=$?
+      [[ "$record_status" == "1" ]] || exit 2
+      marker_record=""
+    fi
+    if pending_record="$(load_record "$pending" "WSL bridge pending")"; then
+      pending_present=1
+    else
+      record_status=$?
+      [[ "$record_status" == "1" ]] || exit 2
+      pending_record=""
+    fi
 
     case "$action" in
       ensure)
@@ -271,28 +450,80 @@ wsl_bridge_root_action() {
             echo "tt: refusing unexpected /mnt/c mount; expected read-only C: drvfs" >&2
             exit 2
           }
-          if [[ -f "$marker" && "$(<"$marker")" != "$marker_value" ]]; then
-            echo "tt: refusing stale WSL bridge mount marker" >&2
+          [[ "$marker_present" != "1" || "$pending_present" != "1" ]] || {
+            echo "tt: refusing simultaneous mount and pending WSL bridge records" >&2
             exit 2
-          fi
-          if [[ "$target_kind" == "server" && -f "$pending" ]]; then
-            [[ "$(<"$pending")" == "$current_value" && "$current_namespace" == "$target_namespace" ]] || {
-              echo "tt: refusing stale WSL bridge pending marker" >&2
+          }
+          if [[ "$target_kind" == "server" && "$marker_present" == "1" ]]; then
+            parse_record "$marker_record" || exit 2
+            [[ "$RECORD_NAMESPACE" == "$target_namespace" ]] || {
+              echo "tt: valid /mnt/c mount record belongs to a different namespace; refusing adoption" >&2
               exit 2
             }
-            printf "%s\n" "$marker_value" >"$marker"
-            /usr/bin/rm "$pending"
-            printf "promoted\n"
-          else
-            printf "existing\n"
+            if [[ "$marker_record" != "$marker_value" ]]; then
+              if record_is_exact_live "$marker_record"; then
+                echo "tt: refusing adoption from an exact live mount owner" >&2
+                exit 2
+              else
+                live_status=$?
+                [[ "$live_status" == "1" ]] || {
+                  echo "tt: refusing ambiguous stale mount owner during adoption" >&2
+                  exit 2
+                }
+              fi
+              atomic_write_record "$marker" "$marker_value" || exit 2
+              printf "adopted\n"
+            else
+              printf "existing\n"
+            fi
+            exit 0
           fi
-          exit 0
+          if [[ "$target_kind" == "server" && "$pending_present" == "1" ]]; then
+            parse_record "$pending_record" || exit 2
+            [[ "$RECORD_NAMESPACE" == "$target_namespace" ]] || {
+              echo "tt: valid /mnt/c pending record belongs to a different namespace; refusing adoption" >&2
+              exit 2
+            }
+            if [[ "$pending_record" != "$current_value" ]]; then
+              if record_is_exact_live "$pending_record"; then
+                echo "tt: refusing adoption from an exact live pending owner" >&2
+                exit 2
+              else
+                live_status=$?
+                [[ "$live_status" == "1" ]] || {
+                  echo "tt: refusing ambiguous stale pending owner during adoption" >&2
+                  exit 2
+                }
+              fi
+            fi
+            [[ "$current_namespace" == "$target_namespace" ]] || {
+              echo "tt: current process namespace cannot promote the pending mount" >&2
+              exit 2
+            }
+            atomic_write_record "$marker" "$marker_value" || exit 2
+            if ! /usr/bin/rm -- "$pending"; then
+              echo "tt: failed to remove promoted pending record" >&2
+              exit 2
+            fi
+            printf "promoted\n"
+            exit 0
+          fi
+          if [[ "$target_kind" == "current" && "$pending_present" == "1" && "$pending_record" == "$current_value" ]]; then
+            printf "existing\n"
+            exit 0
+          fi
+          echo "tt: valid /mnt/c mount has no matching bridge record; refusing adoption" >&2
+          exit 2
         fi
 
-        [[ ! -e "$marker" && ! -e "$pending" ]] || {
-          echo "tt: refusing bridge mount with stale marker state" >&2
-          exit 2
-        }
+        if [[ "$marker_present" == "1" ]]; then
+          remove_stale_record "$marker" "mount" "$marker_record" "$target_namespace" || exit 2
+          marker_present=0
+        fi
+        if [[ "$pending_present" == "1" ]]; then
+          remove_stale_record "$pending" "pending" "$pending_record" "$target_namespace" || exit 2
+          pending_present=0
+        fi
         if [[ -L /mnt/c || ( -e /mnt/c && ! -d /mnt/c ) ]]; then
           echo "tt: refusing non-directory /mnt/c mountpoint" >&2
           exit 2
@@ -304,21 +535,28 @@ wsl_bridge_root_action() {
 
         nsrun /usr/bin/mkdir -p /mnt/c
         nsrun /usr/bin/mount -t drvfs -o "ro,uid=$uid,gid=$gid,umask=022,fmask=011" C: /mnt/c
-        mount_valid || {
-          nsrun /usr/bin/umount /mnt/c 2>/dev/null || true
-          echo "tt: /mnt/c failed post-mount validation" >&2
+        if ! mount_valid; then
+          echo "tt: /mnt/c failed post-mount validation; attempting normal cleanup" >&2
+          if ! nsrun /usr/bin/umount /mnt/c; then
+            echo "tt: WSL bridge cleanup failed after post-mount validation" >&2
+            exit 2
+          fi
+          if nsrun /usr/bin/findmnt -rn -M /mnt/c >/dev/null 2>&1; then
+            echo "tt: WSL bridge cleanup left /mnt/c mounted" >&2
+            exit 2
+          fi
           exit 2
-        }
+        fi
         if [[ "$target_kind" == "server" ]]; then
-          printf "%s\n" "$marker_value" >"$marker"
+          atomic_write_record "$marker" "$marker_value" || exit 2
           printf "created\n"
         else
-          printf "%s\n" "$current_value" >"$pending"
+          atomic_write_record "$pending" "$current_value" || exit 2
           printf "prepared\n"
         fi
         ;;
       rollback-server)
-        [[ "$target_kind" == "server" && -f "$marker" && "$(<"$marker")" == "$marker_value" ]] || {
+        [[ "$target_kind" == "server" && "$marker_present" == "1" && "$marker_record" == "$marker_value" && "$pending_present" == "0" ]] || {
           echo "tt: refusing rollback without exact server mount marker" >&2
           exit 2
         }
@@ -326,13 +564,53 @@ wsl_bridge_root_action() {
           echo "tt: refusing rollback of an unvalidated mount" >&2
           exit 2
         }
-        nsrun /usr/bin/umount /mnt/c
-        nsrun /usr/bin/findmnt -rn -M /mnt/c >/dev/null 2>&1 && exit 2
-        /usr/bin/rm "$marker"
+        if ! nsrun /usr/bin/umount /mnt/c; then
+          echo "tt: normal server mount rollback failed" >&2
+          exit 2
+        fi
+        if nsrun /usr/bin/findmnt -rn -M /mnt/c >/dev/null 2>&1; then
+          echo "tt: server mount remains after rollback" >&2
+          exit 2
+        fi
+        if ! /usr/bin/rm -- "$marker"; then
+          echo "tt: failed to remove rolled-back server marker" >&2
+          exit 2
+        fi
         printf "rolled-back\n"
         ;;
+      release-server)
+        [[ "$target_kind" == "server" ]] || exit 2
+        if nsrun /usr/bin/findmnt -rn -M /mnt/c >/dev/null 2>&1; then
+          [[ "$marker_present" == "1" && "$marker_record" == "$marker_value" && "$pending_present" == "0" ]] || {
+            echo "tt: refusing server release without exact mount ownership" >&2
+            exit 2
+          }
+          mount_valid || {
+            echo "tt: refusing server release of an unvalidated mount" >&2
+            exit 2
+          }
+          if ! nsrun /usr/bin/umount /mnt/c; then
+            echo "tt: normal server release unmount failed" >&2
+            exit 2
+          fi
+          if nsrun /usr/bin/findmnt -rn -M /mnt/c >/dev/null 2>&1; then
+            echo "tt: server mount remains after release" >&2
+            exit 2
+          fi
+          if ! /usr/bin/rm -- "$marker"; then
+            echo "tt: failed to remove released server marker" >&2
+            exit 2
+          fi
+          printf "released\n"
+        elif [[ "$marker_present" == "0" && "$pending_present" == "0" ]]; then
+          printf "absent\n"
+        else
+          echo "tt: refusing server release with records but no mount" >&2
+          exit 2
+        fi
+        ;;
       rollback-current)
-        [[ "$target_kind" == "current" && -f "$pending" && "$(<"$pending")" == "$current_value" ]] || {
+        [[ "$target_kind" == "current" && "$pending_present" == "1" && "$pending_record" == "$current_value" && "$marker_present" == "0" ]] || {
           echo "tt: refusing rollback without exact pending mount marker" >&2
           exit 2
         }
@@ -340,9 +618,18 @@ wsl_bridge_root_action() {
           echo "tt: refusing rollback of an unvalidated pending mount" >&2
           exit 2
         }
-        nsrun /usr/bin/umount /mnt/c
-        nsrun /usr/bin/findmnt -rn -M /mnt/c >/dev/null 2>&1 && exit 2
-        /usr/bin/rm "$pending"
+        if ! nsrun /usr/bin/umount /mnt/c; then
+          echo "tt: normal pending mount rollback failed" >&2
+          exit 2
+        fi
+        if nsrun /usr/bin/findmnt -rn -M /mnt/c >/dev/null 2>&1; then
+          echo "tt: pending mount remains after rollback" >&2
+          exit 2
+        fi
+        if ! /usr/bin/rm -- "$pending"; then
+          echo "tt: failed to remove rolled-back pending marker" >&2
+          exit 2
+        fi
         printf "rolled-back\n"
         ;;
       *)
@@ -354,14 +641,65 @@ wsl_bridge_root_action() {
     "$current_starttime" "$current_namespace" "$current_exe" "$uid" "$gid"
 }
 
+wsl_bridge_cleanup_server_mount() {
+  local context="$1"
+  shift
+  local output
+
+  if ! output="$(wsl_bridge_root_action rollback-server "$@" 2>&1)"; then
+    echo "tt: WSL bridge cleanup failed after $context: ${output:-unknown rollback failure}" >&2
+    return 1
+  fi
+}
+
 wsl_bridge_cleanup_pending() {
+  local output
+
   [[ "$TT_WSL_BRIDGE_PENDING" == "1" ]] || return 0
-  wsl_bridge_root_action rollback-current current \
-    "$TT_WSL_BRIDGE_PENDING_PID" "$TT_WSL_BRIDGE_PENDING_STARTTIME" \
-    "$TT_WSL_BRIDGE_PENDING_NS" "$TT_WSL_BRIDGE_PENDING_EXE" "" "" \
-    "$TT_WSL_BRIDGE_PENDING_PID" "$TT_WSL_BRIDGE_PENDING_STARTTIME" \
-    "$TT_WSL_BRIDGE_PENDING_NS" "$TT_WSL_BRIDGE_PENDING_EXE" >/dev/null || true
+  if ! output="$(
+    wsl_bridge_root_action rollback-current current \
+      "$TT_WSL_BRIDGE_PENDING_PID" "$TT_WSL_BRIDGE_PENDING_STARTTIME" \
+      "$TT_WSL_BRIDGE_PENDING_NS" "$TT_WSL_BRIDGE_PENDING_EXE" "" "" \
+      "$TT_WSL_BRIDGE_PENDING_PID" "$TT_WSL_BRIDGE_PENDING_STARTTIME" \
+      "$TT_WSL_BRIDGE_PENDING_NS" "$TT_WSL_BRIDGE_PENDING_EXE" 2>&1
+  )"; then
+    echo "tt: WSL bridge pending cleanup failed: ${output:-unknown rollback failure}" >&2
+  fi
   TT_WSL_BRIDGE_PENDING=0
+}
+
+wsl_bridge_release_server_mount() {
+  local server_identity current_identity output
+  local server_pid server_starttime server_namespace server_exe socket_path
+  local current_pid current_starttime current_namespace current_exe
+
+  wsl_bridge_is_wsl || return 0
+  if ! server_identity="$(wsl_bridge_server_identity)"; then
+    if tmux_server_running; then
+      echo "tt: refusing tmux reset because the live server identity could not be validated" >&2
+      return 2
+    fi
+    return 0
+  fi
+  current_identity="$(wsl_bridge_current_identity)" || {
+    echo "tt: could not validate current process before tmux bridge release" >&2
+    return 2
+  }
+  IFS='|' read -r server_pid server_starttime server_namespace server_exe socket_path <<<"$server_identity"
+  IFS='|' read -r current_pid current_starttime current_namespace current_exe <<<"$current_identity"
+  if ! output="$(
+    wsl_bridge_root_action release-server server \
+      "$server_pid" "$server_starttime" "$server_namespace" "$server_exe" "$socket_path" "" \
+      "$current_pid" "$current_starttime" "$current_namespace" "$current_exe" 2>&1
+  )"; then
+    echo "tt: refusing tmux reset because WSL bridge release failed: ${output:-unknown release failure}" >&2
+    return 2
+  fi
+  "$TMUX_BIN" set-option -gu @tt_wsl_interop 2>/dev/null || {
+    echo "tt: failed to clear released WSL bridge socket option" >&2
+    return 2
+  }
+  TT_WSL_BRIDGE_READY=0
 }
 
 wsl_bridge_ensure() {
@@ -398,26 +736,35 @@ wsl_bridge_ensure() {
       "$server_pid" "$server_starttime" "$server_namespace" "$server_exe" "$socket_path" "$pane_entries" \
       "$current_pid" "$current_starttime" "$current_namespace" "$current_exe")" || return
     after_snapshot="$(wsl_bridge_server_snapshot)" || {
-      [[ "$result" == "created" || "$result" == "promoted" ]] &&
-        wsl_bridge_root_action rollback-server server \
+      if [[ "$result" == "created" || "$result" == "promoted" ]]; then
+        if ! wsl_bridge_cleanup_server_mount "tmux server identity change" server \
           "$server_pid" "$server_starttime" "$server_namespace" "$server_exe" "$socket_path" "$pane_entries" \
-          "$current_pid" "$current_starttime" "$current_namespace" "$current_exe" >/dev/null || true
+          "$current_pid" "$current_starttime" "$current_namespace" "$current_exe"; then
+          :
+        fi
+      fi
       echo "tt: tmux server identity changed during bridge setup" >&2
       return 2
     }
     if [[ "$after_snapshot" != "$server_snapshot" ]]; then
-      [[ "$result" == "created" || "$result" == "promoted" ]] &&
-        wsl_bridge_root_action rollback-server server \
+      if [[ "$result" == "created" || "$result" == "promoted" ]]; then
+        if ! wsl_bridge_cleanup_server_mount "tmux pane churn" server \
           "$server_pid" "$server_starttime" "$server_namespace" "$server_exe" "$socket_path" "$pane_entries" \
-          "$current_pid" "$current_starttime" "$current_namespace" "$current_exe" >/dev/null || true
+          "$current_pid" "$current_starttime" "$current_namespace" "$current_exe"; then
+          :
+        fi
+      fi
       echo "tt: tmux pane set changed during bridge setup" >&2
       return 2
     fi
     if ! "$TMUX_BIN" set-option -gq @tt_wsl_interop "$socket"; then
-      [[ "$result" == "created" || "$result" == "promoted" ]] &&
-        wsl_bridge_root_action rollback-server server \
+      if [[ "$result" == "created" || "$result" == "promoted" ]]; then
+        if ! wsl_bridge_cleanup_server_mount "tmux socket option update" server \
           "$server_pid" "$server_starttime" "$server_namespace" "$server_exe" "$socket_path" "$pane_entries" \
-          "$current_pid" "$current_starttime" "$current_namespace" "$current_exe" >/dev/null || true
+          "$current_pid" "$current_starttime" "$current_namespace" "$current_exe"; then
+          :
+        fi
+      fi
       return 2
     fi
     TT_WSL_BRIDGE_PENDING=0
@@ -3168,6 +3515,7 @@ reset_to_profile() {
   local profile="$1"
   local session="${2:-}"
 
+  wsl_bridge_release_server_mount
   kill_server force
 
   case "$profile" in

--- a/tests/fixtures/tt-wsl-bridge/findmnt
+++ b/tests/fixtures/tt-wsl-bridge/findmnt
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"-M / -o PROPAGATION"* ]]; then
+  printf '%s\n' "${TT_TEST_PROPAGATION:-private}"
+  exit 0
+fi
+state="${TT_TEST_MOUNT_STATE:?}"
+value="$(cat "$state" 2>/dev/null || printf absent)"
+[[ "$value" != "absent" ]] || exit 1
+if [[ "$*" == *"-o SOURCE,FSTYPE,OPTIONS"* ]]; then
+  case "$value" in
+    valid) printf 'C: drvfs ro,uid=1000,gid=1000,umask=022,fmask=011\n' ;;
+    valid9p) printf 'C: 9p ro,aname=drvfs;path=C:;uid=1000\n' ;;
+    wrong-source) printf 'D: drvfs ro,uid=1000,gid=1000\n' ;;
+    writable) printf 'C: drvfs rw,uid=1000,gid=1000\n' ;;
+    *) printf '%s\n' "$value" ;;
+  esac
+fi

--- a/tests/fixtures/tt-wsl-bridge/stat
+++ b/tests/fixtures/tt-wsl-bridge/stat
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "-c" ]]; then
+  case "${2:-}" in
+    %u)
+      if [[ "${3:-}" == "${TT_TEST_INIT_PATH:-}" || "${3:-}" == "${TT_TEST_MARKER_ROOT:-}"* ]]; then
+        printf '0\n'
+      else
+        printf '1000\n'
+      fi
+      exit 0
+      ;;
+    %a)
+      if /usr/bin/stat -c %a "$3" >/dev/null 2>&1; then
+        /usr/bin/stat -c %a "$3"
+      else
+        /usr/bin/stat -f %Lp "$3"
+      fi
+      exit 0
+      ;;
+    %s)
+      if /usr/bin/stat -c %s "$3" >/dev/null 2>&1; then
+        /usr/bin/stat -c %s "$3"
+      else
+        /usr/bin/stat -f %z "$3"
+      fi
+      exit 0
+      ;;
+  esac
+fi
+exec /usr/bin/stat "$@"

--- a/tests/fixtures/tt-wsl-bridge/tmux
+++ b/tests/fixtures/tt-wsl-bridge/tmux
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${TT_TEST_TMUX_LOG:?}"
+if [[ "${1:-}" == "-S" ]]; then
+  shift 2
+fi
+server_state="$(cat "${TT_TEST_SERVER_STATE:?}" 2>/dev/null || printf none)"
+case "$*" in
+  "display-message -p #{pid}")
+    [[ "$server_state" == "live" ]] || exit 1
+    printf '2222\n'
+    ;;
+  "display-message -p #{socket_path}")
+    [[ "$server_state" == "live" ]] || exit 1
+    printf '%s\n' "${TT_TEST_TMUX_SOCKET:?}"
+    ;;
+  "list-panes -a -F #{pane_id}|#{pane_pid}|#{pane_dead}")
+    [[ "$server_state" == "live" ]] || exit 1
+    count=0
+    if [[ -n "${TT_TEST_PANE_CALLS:-}" ]]; then
+      count="$(cat "$TT_TEST_PANE_CALLS" 2>/dev/null || printf 0)"
+      count=$((count + 1))
+      printf '%s\n' "$count" >"$TT_TEST_PANE_CALLS"
+    fi
+    if [[ "${TT_TEST_PANE_CHURN:-}" == "1" && "$count" -ge 3 ]]; then
+      printf '%%1|3333|0\n%%9|9999|1\n'
+    else
+      printf '%b\n' "${TT_TEST_PANE_ROWS:-%1|3333|0}"
+    fi
+    ;;
+  "show-option -gqv @tt_wsl_interop")
+    printf '%s\n' "${TT_TEST_STORED_SOCKET:-}"
+    ;;
+  new-session*|"new -d "*)
+    printf 'live\n' >"${TT_TEST_SERVER_STATE:?}"
+    ;;
+  "has-session "*)
+    exit 1
+    ;;
+  "list-sessions")
+    [[ "$server_state" == "live" ]] || exit 1
+    printf 'test: 1 windows\n'
+    ;;
+  "kill-server")
+    printf 'none\n' >"${TT_TEST_SERVER_STATE:?}"
+    ;;
+  "set-option -gq @tt_wsl_interop "*)
+    if [[ "${TT_TEST_SET_OPTION_FAIL:-}" == "1" ]]; then
+      if [[ -n "${TT_TEST_SERVER_STAT:-}" ]]; then
+        sed 's/ 222222 0$/ 999999 0/' "$TT_TEST_SERVER_STAT" >"$TT_TEST_SERVER_STAT.tmp"
+        /bin/mv -f "$TT_TEST_SERVER_STAT.tmp" "$TT_TEST_SERVER_STAT"
+      fi
+      exit 1
+    fi
+    ;;
+esac

--- a/tests/tt-wsl-bridge-test.sh
+++ b/tests/tt-wsl-bridge-test.sh
@@ -36,6 +36,7 @@ sed \
   -e "s#/usr/bin/umount#$fakebin/umount#g" \
   -e "s#/usr/bin/stat#$fakebin/stat#g" \
   -e "s#/usr/bin/readlink#$fakebin/readlink#g" \
+  -e "s#/usr/bin/setpriv#$fakebin/setpriv#g" \
   -e "s#/usr/bin/bash#/bin/bash#g" \
   -e "s#/usr/bin/mkdir#/bin/mkdir#g" \
   -e "s#/usr/bin/rm#/bin/rm#g" \
@@ -187,19 +188,45 @@ fi
 exec /usr/bin/readlink "$@"
 SH
 
+cat >"$fakebin/setpriv" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+while [[ "${1:-}" == --* ]]; do
+  case "$1" in
+    --reuid|--regid)
+      shift 2
+      ;;
+    --clear-groups)
+      shift
+      ;;
+    *)
+      exit 2
+      ;;
+  esac
+done
+exec "$@"
+SH
+
 cat >"$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>"${TT_TEST_TMUX_LOG:?}"
+if [[ "${1:-}" == "-S" ]]; then
+  shift 2
+fi
 server_state="$(cat "${TT_TEST_SERVER_STATE:?}" 2>/dev/null || printf none)"
 case "$*" in
   "display-message -p #{pid}")
     [[ "$server_state" == "live" ]] || exit 1
     printf '2222\n'
     ;;
-  "list-panes -a -F #{pane_pid}")
+  "display-message -p #{socket_path}")
     [[ "$server_state" == "live" ]] || exit 1
-    printf '3333\n'
+    printf '%s\n' "${TT_TEST_TMUX_SOCKET:?}"
+    ;;
+  "list-panes -a -F #{pane_id}|#{pane_pid}|#{pane_dead}")
+    [[ "$server_state" == "live" ]] || exit 1
+    printf '%b\n' "${TT_TEST_PANE_ROWS:-%1|3333|0}"
     ;;
   "show-option -gqv @tt_wsl_interop")
     printf '%s\n' "${TT_TEST_STORED_SOCKET:-}"
@@ -228,6 +255,7 @@ export TT_TEST_MOUNT_LOG="$mount_log"
 export TT_TEST_UMOUNT_LOG="$umount_log"
 export TT_TEST_SUDO_LOG="$sudo_log"
 export TT_TEST_TMUX_LOG="$tmux_log"
+export TT_TEST_TMUX_SOCKET="$socket"
 export WSL_DISTRO_NAME=Ubuntu
 
 expect_failure() {
@@ -268,6 +296,9 @@ if grep -Eq 'set-environment.*(WSL_INTEROP|WSLENV)' "$tmux_log"; then
   printf 'bridge wrote forbidden tmux global environment\n' >&2
   exit 1
 fi
+
+TT_TEST_PANE_ROWS=$'%1|3333|0\n%2|4444|1' \
+  WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
 
 for bad_state in wrong-source writable; do
   rm -rf "$markerroot"

--- a/tests/tt-wsl-bridge-test.sh
+++ b/tests/tt-wsl-bridge-test.sh
@@ -6,6 +6,8 @@ temporary="/tmp/tt-wsl-bridge-test-$$"
 runtime="$temporary/run/WSL"
 croot="$temporary/mnt/c"
 lockroot="$temporary/run/lock"
+markerroot="$temporary/run/tt-wsl-bridge"
+procroot="$temporary/proc"
 fakebin="$temporary/fakebin"
 socket="$runtime/4242_interop"
 socket_pid=""
@@ -19,11 +21,24 @@ cleanup() {
 }
 trap cleanup EXIT
 
-mkdir -p "$runtime" "$lockroot" "$fakebin"
+mkdir -p "$runtime" "$lockroot" "$markerroot" "$procroot" "$fakebin"
 sed \
   -e "s#/run/WSL#$runtime#g" \
   -e "s#/mnt/c#$croot#g" \
   -e "s#/run/lock#$lockroot#g" \
+  -e "s#/run/tt-wsl-bridge#$markerroot#g" \
+  -e "s#/proc#$procroot#g" \
+  -e 's/local pid="[$][$]"/local pid="1234"/' \
+  -e "s#/usr/bin/flock#$fakebin/flock#g" \
+  -e "s#/usr/bin/nsenter#$fakebin/nsenter#g" \
+  -e "s#/usr/bin/findmnt#$fakebin/findmnt#g" \
+  -e "s#/usr/bin/mount#$fakebin/mount#g" \
+  -e "s#/usr/bin/umount#$fakebin/umount#g" \
+  -e "s#/usr/bin/stat#$fakebin/stat#g" \
+  -e "s#/usr/bin/readlink#$fakebin/readlink#g" \
+  -e "s#/usr/bin/bash#/bin/bash#g" \
+  -e "s#/usr/bin/mkdir#/bin/mkdir#g" \
+  -e "s#/usr/bin/rm#/bin/rm#g" \
   "$repo/bin/tt" >"$temporary/tt"
 sed \
   -e "s#/run/WSL#$runtime#g" \
@@ -34,6 +49,28 @@ sed \
   -e "s#/mnt/c#$croot#g" \
   "$repo/bin/pwsh.exe" >"$temporary/pwsh.exe"
 chmod +x "$temporary/tt" "$temporary/powershell.exe" "$temporary/pwsh.exe"
+
+make_proc() {
+  local pid="$1"
+  local comm="$2"
+  local starttime="$3"
+  local namespace="$4"
+  local exe="$5"
+
+  mkdir -p "$procroot/$pid/ns"
+  printf '%s\n' "$comm" >"$procroot/$pid/comm"
+  printf '%s (%s) S' "$pid" "$comm" >"$procroot/$pid/stat"
+  for i in {1..18}; do
+    printf ' 0' >>"$procroot/$pid/stat"
+  done
+  printf ' %s 0\n' "$starttime" >>"$procroot/$pid/stat"
+  ln -s "$namespace" "$procroot/$pid/ns/mnt"
+  ln -s "$exe" "$procroot/$pid/exe"
+}
+
+make_proc 1234 bash 111111 'mnt:[7001]' /usr/bin/bash
+make_proc 2222 'tmux: server' 222222 'mnt:[7001]' "$fakebin/tmux"
+make_proc 3333 bash 333333 'mnt:[7001]' /usr/bin/bash
 
 python3 - "$socket" <<'PY' &
 import os
@@ -73,13 +110,17 @@ SH
 cat >"$fakebin/findmnt" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
+if [[ "$*" == *"-M / -o PROPAGATION"* ]]; then
+  printf '%s\n' "${TT_TEST_PROPAGATION:-private}"
+  exit 0
+fi
 state="${TT_TEST_MOUNT_STATE:?}"
 value="$(cat "$state" 2>/dev/null || printf absent)"
 [[ "$value" != "absent" ]] || exit 1
 if [[ "$*" == *"-o SOURCE,FSTYPE,OPTIONS"* ]]; then
   case "$value" in
     valid) printf 'C: drvfs ro,uid=1000,gid=1000,umask=022,fmask=011\n' ;;
-    valid9p) printf 'C:\\134 9p ro,aname=drvfs;path=C:\\;uid=1000\n' ;;
+    valid9p) printf 'C: 9p ro,aname=drvfs;path=C:;uid=1000\n' ;;
     wrong-source) printf 'D: drvfs ro,uid=1000,gid=1000\n' ;;
     writable) printf 'C: drvfs rw,uid=1000,gid=1000\n' ;;
     *) printf '%s\n' "$value" ;;
@@ -92,6 +133,13 @@ cat >"$fakebin/mount" <<'SH'
 set -euo pipefail
 printf '%s\n' "$*" >>"${TT_TEST_MOUNT_LOG:?}"
 printf 'valid\n' >"${TT_TEST_MOUNT_STATE:?}"
+SH
+
+cat >"$fakebin/umount" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${TT_TEST_UMOUNT_LOG:?}"
+printf 'absent\n' >"${TT_TEST_MOUNT_STATE:?}"
 SH
 
 cat >"$fakebin/sudo" <<'SH'
@@ -110,24 +158,74 @@ shift
 exec "$@"
 SH
 
+cat >"$fakebin/nsenter" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" == "-t" ]] && shift 2
+[[ "${1:-}" == "-m" ]] && shift
+[[ "${1:-}" == "--" ]] && shift
+exec "$@"
+SH
+
+cat >"$fakebin/stat" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "-c" && "${2:-}" == "%u" ]]; then
+  printf '1000\n'
+  exit 0
+fi
+exec /usr/bin/stat "$@"
+SH
+
+cat >"$fakebin/readlink" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "-f" ]]; then
+  printf '%s\n' "$2"
+  exit 0
+fi
+exec /usr/bin/readlink "$@"
+SH
+
 cat >"$fakebin/tmux" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$*" >>"${TT_TEST_TMUX_LOG:?}"
-if [[ "$*" == "show-option -gqv @tt_wsl_interop" ]]; then
-  printf '%s\n' "${TT_TEST_STORED_SOCKET:-}"
-fi
+server_state="$(cat "${TT_TEST_SERVER_STATE:?}" 2>/dev/null || printf none)"
+case "$*" in
+  "display-message -p #{pid}")
+    [[ "$server_state" == "live" ]] || exit 1
+    printf '2222\n'
+    ;;
+  "list-panes -a -F #{pane_pid}")
+    [[ "$server_state" == "live" ]] || exit 1
+    printf '3333\n'
+    ;;
+  "show-option -gqv @tt_wsl_interop")
+    printf '%s\n' "${TT_TEST_STORED_SOCKET:-}"
+    ;;
+  new-session*|"new -d "*)
+    printf 'live\n' >"${TT_TEST_SERVER_STATE:?}"
+    ;;
+  "has-session "*)
+    exit 1
+    ;;
+esac
 SH
 chmod +x "$fakebin"/*
 
 state="$temporary/mount.state"
+server_state="$temporary/server.state"
 mount_log="$temporary/mount.log"
+umount_log="$temporary/umount.log"
 sudo_log="$temporary/sudo.log"
 tmux_log="$temporary/tmux.log"
 export PATH="$fakebin:$PATH"
 export TT_TMUX_BIN="$fakebin/tmux"
 export TT_TEST_MOUNT_STATE="$state"
+export TT_TEST_SERVER_STATE="$server_state"
 export TT_TEST_MOUNT_LOG="$mount_log"
+export TT_TEST_UMOUNT_LOG="$umount_log"
 export TT_TEST_SUDO_LOG="$sudo_log"
 export TT_TEST_TMUX_LOG="$tmux_log"
 export WSL_DISTRO_NAME=Ubuntu
@@ -140,28 +238,39 @@ expect_failure() {
 }
 
 : >"$mount_log"
+: >"$umount_log"
 : >"$sudo_log"
 : >"$tmux_log"
 printf 'absent\n' >"$state"
+printf 'live\n' >"$server_state"
 expect_failure env -u WSL_DISTRO_NAME WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
 expect_failure env -u WSL_INTEROP "$temporary/tt" wsl-bridge ensure
 expect_failure env WSL_INTEROP="$runtime/9999_interop" "$temporary/tt" wsl-bridge ensure
 
+printf 'none\n' >"$server_state"
+expect_failure env WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
+[[ ! -s "$mount_log" ]]
+
 rm -rf "$croot"
+rm -rf "$markerroot"
 : >"$mount_log"
+: >"$umount_log"
 : >"$sudo_log"
 : >"$tmux_log"
 printf 'absent\n' >"$state"
+printf 'live\n' >"$server_state"
 WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
-grep -Fq -- "-x $lockroot/tt-wsl-bridge.lock bash -c" "$sudo_log"
+grep -Fq -- "-x $lockroot/tt-wsl-bridge.lock /bin/bash -c" "$sudo_log"
 grep -Fqx -- "-t drvfs -o ro,uid=1000,gid=1000,umask=022,fmask=011 C: $croot" "$mount_log"
 grep -Fqx -- "set-option -gq @tt_wsl_interop $socket" "$tmux_log"
+grep -Fqx -- "2222|222222|mnt:[7001]" "$markerroot/mount-1000"
 if grep -Eq 'set-environment.*(WSL_INTEROP|WSLENV)' "$tmux_log"; then
   printf 'bridge wrote forbidden tmux global environment\n' >&2
   exit 1
 fi
 
 for bad_state in wrong-source writable; do
+  rm -rf "$markerroot"
   : >"$tmux_log"
   printf '%s\n' "$bad_state" >"$state"
   expect_failure env WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
@@ -171,7 +280,30 @@ for bad_state in wrong-source writable; do
   fi
 done
 
+rm -rf "$croot" "$markerroot"
+: >"$mount_log"
+printf 'absent\n' >"$state"
+expect_failure env TT_TEST_PROPAGATION=shared:42 WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
+[[ ! -s "$mount_log" ]]
+
+rm "$procroot/3333/ns/mnt"
+ln -s 'mnt:[7002]' "$procroot/3333/ns/mnt"
+expect_failure env WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
+rm "$procroot/3333/ns/mnt"
+ln -s 'mnt:[7001]' "$procroot/3333/ns/mnt"
+
+rm -rf "$croot" "$markerroot"
+: >"$mount_log"
+: >"$tmux_log"
+printf 'absent\n' >"$state"
+printf 'none\n' >"$server_state"
+WSL_INTEROP="$socket" TT_LOGIN_SHELL=/bin/sh "$temporary/tt" shell bridge-create >/dev/null
+grep -Fqx -- "set-option -gq @tt_wsl_interop $socket" "$tmux_log"
+grep -Fqx -- "2222|222222|mnt:[7001]" "$markerroot/mount-1000"
+[[ ! -e "$markerroot/pending-1000" ]]
+
 printf 'valid\n' >"$state"
+printf 'live\n' >"$server_state"
 for command in ls status sync; do
   : >"$sudo_log"
   WSL_INTEROP="$socket" "$temporary/tt" "$command" >/dev/null 2>&1 || true

--- a/tests/tt-wsl-bridge-test.sh
+++ b/tests/tt-wsl-bridge-test.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+temporary="/tmp/tt-wsl-bridge-test-$$"
+runtime="$temporary/run/WSL"
+croot="$temporary/mnt/c"
+lockroot="$temporary/run/lock"
+fakebin="$temporary/fakebin"
+socket="$runtime/4242_interop"
+socket_pid=""
+
+cleanup() {
+  if [[ -n "$socket_pid" ]]; then
+    kill "$socket_pid" 2>/dev/null || true
+    wait "$socket_pid" 2>/dev/null || true
+  fi
+  rm -rf "$temporary"
+}
+trap cleanup EXIT
+
+mkdir -p "$runtime" "$lockroot" "$fakebin"
+sed \
+  -e "s#/run/WSL#$runtime#g" \
+  -e "s#/mnt/c#$croot#g" \
+  -e "s#/run/lock#$lockroot#g" \
+  "$repo/bin/tt" >"$temporary/tt"
+sed \
+  -e "s#/run/WSL#$runtime#g" \
+  -e "s#/mnt/c#$croot#g" \
+  "$repo/bin/powershell.exe" >"$temporary/powershell.exe"
+sed \
+  -e "s#/run/WSL#$runtime#g" \
+  -e "s#/mnt/c#$croot#g" \
+  "$repo/bin/pwsh.exe" >"$temporary/pwsh.exe"
+chmod +x "$temporary/tt" "$temporary/powershell.exe" "$temporary/pwsh.exe"
+
+python3 - "$socket" <<'PY' &
+import os
+import socket
+import sys
+import time
+
+path = sys.argv[1]
+os.makedirs(os.path.dirname(path), exist_ok=True)
+server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+server.bind(path)
+server.listen(1)
+while True:
+    time.sleep(60)
+PY
+socket_pid="$!"
+for _ in 1 2 3 4 5; do
+  [[ -S "$socket" ]] && break
+  sleep 0.1
+done
+[[ -S "$socket" ]]
+
+cat >"$fakebin/uname" <<'SH'
+#!/usr/bin/env bash
+[[ "${1:-}" == "-r" ]] && printf '6.6.87.2-microsoft-standard-WSL2\n'
+SH
+
+cat >"$fakebin/id" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+  -u) printf '1000\n' ;;
+  -g) printf '1000\n' ;;
+  *) exit 2 ;;
+esac
+SH
+
+cat >"$fakebin/findmnt" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+state="${TT_TEST_MOUNT_STATE:?}"
+value="$(cat "$state" 2>/dev/null || printf absent)"
+[[ "$value" != "absent" ]] || exit 1
+if [[ "$*" == *"-o SOURCE,FSTYPE,OPTIONS"* ]]; then
+  case "$value" in
+    valid) printf 'C: drvfs ro,uid=1000,gid=1000,umask=022,fmask=011\n' ;;
+    valid9p) printf 'C:\\134 9p ro,aname=drvfs;path=C:\\;uid=1000\n' ;;
+    wrong-source) printf 'D: drvfs ro,uid=1000,gid=1000\n' ;;
+    writable) printf 'C: drvfs rw,uid=1000,gid=1000\n' ;;
+    *) printf '%s\n' "$value" ;;
+  esac
+fi
+SH
+
+cat >"$fakebin/mount" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${TT_TEST_MOUNT_LOG:?}"
+printf 'valid\n' >"${TT_TEST_MOUNT_STATE:?}"
+SH
+
+cat >"$fakebin/sudo" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${TT_TEST_SUDO_LOG:?}"
+[[ "${1:-}" == "-n" ]] && shift
+exec "$@"
+SH
+
+cat >"$fakebin/flock" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${1:-}" == "-x" ]] && shift
+shift
+exec "$@"
+SH
+
+cat >"$fakebin/tmux" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"${TT_TEST_TMUX_LOG:?}"
+if [[ "$*" == "show-option -gqv @tt_wsl_interop" ]]; then
+  printf '%s\n' "${TT_TEST_STORED_SOCKET:-}"
+fi
+SH
+chmod +x "$fakebin"/*
+
+state="$temporary/mount.state"
+mount_log="$temporary/mount.log"
+sudo_log="$temporary/sudo.log"
+tmux_log="$temporary/tmux.log"
+export PATH="$fakebin:$PATH"
+export TT_TMUX_BIN="$fakebin/tmux"
+export TT_TEST_MOUNT_STATE="$state"
+export TT_TEST_MOUNT_LOG="$mount_log"
+export TT_TEST_SUDO_LOG="$sudo_log"
+export TT_TEST_TMUX_LOG="$tmux_log"
+export WSL_DISTRO_NAME=Ubuntu
+
+expect_failure() {
+  if "$@" >/dev/null 2>&1; then
+    printf 'expected command to fail: %s\n' "$*" >&2
+    exit 1
+  fi
+}
+
+: >"$mount_log"
+: >"$sudo_log"
+: >"$tmux_log"
+printf 'absent\n' >"$state"
+expect_failure env -u WSL_DISTRO_NAME WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
+expect_failure env -u WSL_INTEROP "$temporary/tt" wsl-bridge ensure
+expect_failure env WSL_INTEROP="$runtime/9999_interop" "$temporary/tt" wsl-bridge ensure
+
+rm -rf "$croot"
+: >"$mount_log"
+: >"$sudo_log"
+: >"$tmux_log"
+printf 'absent\n' >"$state"
+WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
+grep -Fq -- "-x $lockroot/tt-wsl-bridge.lock bash -c" "$sudo_log"
+grep -Fqx -- "-t drvfs -o ro,uid=1000,gid=1000,umask=022,fmask=011 C: $croot" "$mount_log"
+grep -Fqx -- "set-option -gq @tt_wsl_interop $socket" "$tmux_log"
+if grep -Eq 'set-environment.*(WSL_INTEROP|WSLENV)' "$tmux_log"; then
+  printf 'bridge wrote forbidden tmux global environment\n' >&2
+  exit 1
+fi
+
+for bad_state in wrong-source writable; do
+  : >"$tmux_log"
+  printf '%s\n' "$bad_state" >"$state"
+  expect_failure env WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
+  if grep -Fq '@tt_wsl_interop' "$tmux_log"; then
+    printf 'bridge stored socket after invalid mount: %s\n' "$bad_state" >&2
+    exit 1
+  fi
+done
+
+printf 'valid\n' >"$state"
+for command in ls status sync; do
+  : >"$sudo_log"
+  WSL_INTEROP="$socket" "$temporary/tt" "$command" >/dev/null 2>&1 || true
+  [[ ! -s "$sudo_log" ]] || {
+    printf 'read-only tt command invoked wsl bridge: %s\n' "$command" >&2
+    exit 1
+  }
+done
+
+mkdir -p "$croot/Windows/System32/WindowsPowerShell/v1.0"
+cat >"$croot/Windows/System32/WindowsPowerShell/v1.0/powershell.exe" <<'SH'
+#!/usr/bin/env bash
+printf 'interop=%s\n' "${WSL_INTEROP:-}" >"${TT_TEST_EXE_LOG:?}"
+printf '<%s>\n' "$@" >>"${TT_TEST_EXE_LOG:?}"
+exit "${TT_TEST_EXE_STATUS:-0}"
+SH
+chmod +x "$croot/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+
+exe_log="$temporary/exe.log"
+export TT_TEST_EXE_LOG="$exe_log"
+export TT_TEST_STORED_SOCKET="$socket"
+export TT_TEST_EXE_STATUS=37
+: >"$tmux_log"
+if WSL_INTEROP="$socket" "$temporary/powershell.exe" "two words" '*' ';'; then
+  printf 'powershell wrapper lost child exit status\n' >&2
+  exit 1
+else
+  status="$?"
+fi
+[[ "$status" == "37" ]]
+grep -Fqx "interop=$socket" "$exe_log"
+grep -Fqx '<two words>' "$exe_log"
+grep -Fqx '<*>' "$exe_log"
+grep -Fqx '<;>' "$exe_log"
+if grep -Fq 'show-option' "$tmux_log"; then
+  printf 'powershell wrapper ignored live current socket\n' >&2
+  exit 1
+fi
+
+export TT_TEST_EXE_STATUS=0
+unset WSL_INTEROP
+"$temporary/powershell.exe" fallback
+grep -Fqx "interop=$socket" "$exe_log"
+grep -Fqx '<fallback>' "$exe_log"
+
+rm -rf "$croot/Program Files"
+mkdir -p "$croot/Program Files/WindowsApps/Microsoft.PowerShell_7.6.4.0_arm64__8wekyb3d8bbwe"
+cp "$croot/Windows/System32/WindowsPowerShell/v1.0/powershell.exe" \
+  "$croot/Program Files/WindowsApps/Microsoft.PowerShell_7.6.4.0_arm64__8wekyb3d8bbwe/pwsh.exe"
+chmod +x "$croot/Program Files/WindowsApps/Microsoft.PowerShell_7.6.4.0_arm64__8wekyb3d8bbwe/pwsh.exe"
+"$temporary/pwsh.exe" appx
+grep -Fqx '<appx>' "$exe_log"
+
+mkdir -p "$croot/Program Files/WindowsApps/Microsoft.PowerShell_7.7.0.0_arm64__8wekyb3d8bbwe"
+cp "$croot/Windows/System32/WindowsPowerShell/v1.0/powershell.exe" \
+  "$croot/Program Files/WindowsApps/Microsoft.PowerShell_7.7.0.0_arm64__8wekyb3d8bbwe/pwsh.exe"
+chmod +x "$croot/Program Files/WindowsApps/Microsoft.PowerShell_7.7.0.0_arm64__8wekyb3d8bbwe/pwsh.exe"
+expect_failure "$temporary/pwsh.exe" ambiguous
+
+printf 'writable\n' >"$state"
+expect_failure "$temporary/powershell.exe" bad-mount
+
+printf 'tt_wsl_bridge_test=passed\n'

--- a/tests/tt-wsl-bridge-test.sh
+++ b/tests/tt-wsl-bridge-test.sh
@@ -2,6 +2,40 @@
 set -euo pipefail
 
 repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ -z "${TT_WSL_BRIDGE_BASH_MATRIX_CHILD:-}" ]]; then
+  python3 - "$repo/tests/tt-wsl-bridge-test.sh" <<'PY'
+import os
+import shutil
+import subprocess
+import sys
+
+script = os.path.abspath(sys.argv[1])
+candidates = [shutil.which("bash"), "/bin/bash"]
+seen = set()
+interpreters = []
+
+for candidate in candidates:
+    if not candidate or not os.path.isfile(candidate) or not os.access(candidate, os.X_OK):
+        continue
+    real = os.path.realpath(candidate)
+    if real in seen:
+        continue
+    seen.add(real)
+    interpreters.append(candidate)
+
+if not interpreters:
+    raise SystemExit("tt-wsl-bridge-test: no executable bash interpreter found")
+
+for interpreter in interpreters:
+    env = os.environ.copy()
+    env["TT_WSL_BRIDGE_BASH_MATRIX_CHILD"] = "1"
+    subprocess.run([interpreter, script], check=True, env=env, timeout=120)
+
+print("tt_wsl_bridge_bash_matrix=passed")
+PY
+  exit 0
+fi
+
 temporary="/tmp/tt-wsl-bridge-test-$$"
 runtime="$temporary/run/WSL"
 croot="$temporary/mnt/c"
@@ -142,27 +176,6 @@ shift
 exec /bin/bash "$target" "$@"
 SH
 
-cat >"$fakebin/findmnt" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-if [[ "$*" == *"-M / -o PROPAGATION"* ]]; then
-  printf '%s\n' "${TT_TEST_PROPAGATION:-private}"
-  exit 0
-fi
-state="${TT_TEST_MOUNT_STATE:?}"
-value="$(cat "$state" 2>/dev/null || printf absent)"
-[[ "$value" != "absent" ]] || exit 1
-if [[ "$*" == *"-o SOURCE,FSTYPE,OPTIONS"* ]]; then
-  case "$value" in
-    valid) printf 'C: drvfs ro,uid=1000,gid=1000,umask=022,fmask=011\n' ;;
-    valid9p) printf 'C: 9p ro,aname=drvfs;path=C:;uid=1000\n' ;;
-    wrong-source) printf 'D: drvfs ro,uid=1000,gid=1000\n' ;;
-    writable) printf 'C: drvfs rw,uid=1000,gid=1000\n' ;;
-    *) printf '%s\n' "$value" ;;
-  esac
-fi
-SH
-
 cat >"$fakebin/mount" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -200,40 +213,6 @@ set -euo pipefail
 [[ "${1:-}" == "-m" ]] && shift
 [[ "${1:-}" == "--" ]] && shift
 exec "$@"
-SH
-
-cat >"$fakebin/stat" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-if [[ "${1:-}" == "-c" ]]; then
-  case "${2:-}" in
-    %u)
-      if [[ "${3:-}" == "${TT_TEST_INIT_PATH:-}" || "${3:-}" == "${TT_TEST_MARKER_ROOT:-}"* ]]; then
-        printf '0\n'
-      else
-        printf '1000\n'
-      fi
-      exit 0
-      ;;
-    %a)
-      if /usr/bin/stat -c %a "$3" >/dev/null 2>&1; then
-        /usr/bin/stat -c %a "$3"
-      else
-        /usr/bin/stat -f %Lp "$3"
-      fi
-      exit 0
-      ;;
-    %s)
-      if /usr/bin/stat -c %s "$3" >/dev/null 2>&1; then
-        /usr/bin/stat -c %s "$3"
-      else
-        /usr/bin/stat -f %z "$3"
-      fi
-      exit 0
-      ;;
-  esac
-fi
-exec /usr/bin/stat "$@"
 SH
 
 cat >"$fakebin/mv" <<'SH'
@@ -274,64 +253,13 @@ done
 exec "$@"
 SH
 
-cat >"$fakebin/tmux" <<'SH'
-#!/usr/bin/env bash
-set -euo pipefail
-printf '%s\n' "$*" >>"${TT_TEST_TMUX_LOG:?}"
-if [[ "${1:-}" == "-S" ]]; then
-  shift 2
-fi
-server_state="$(cat "${TT_TEST_SERVER_STATE:?}" 2>/dev/null || printf none)"
-case "$*" in
-  "display-message -p #{pid}")
-    [[ "$server_state" == "live" ]] || exit 1
-    printf '2222\n'
-    ;;
-  "display-message -p #{socket_path}")
-    [[ "$server_state" == "live" ]] || exit 1
-    printf '%s\n' "${TT_TEST_TMUX_SOCKET:?}"
-    ;;
-  "list-panes -a -F #{pane_id}|#{pane_pid}|#{pane_dead}")
-    [[ "$server_state" == "live" ]] || exit 1
-    count=0
-    if [[ -n "${TT_TEST_PANE_CALLS:-}" ]]; then
-      count="$(cat "$TT_TEST_PANE_CALLS" 2>/dev/null || printf 0)"
-      count=$((count + 1))
-      printf '%s\n' "$count" >"$TT_TEST_PANE_CALLS"
-    fi
-    if [[ "${TT_TEST_PANE_CHURN:-}" == "1" && "$count" -ge 3 ]]; then
-      printf '%%1|3333|0\n%%9|9999|1\n'
-    else
-      printf '%b\n' "${TT_TEST_PANE_ROWS:-%1|3333|0}"
-    fi
-    ;;
-  "show-option -gqv @tt_wsl_interop")
-    printf '%s\n' "${TT_TEST_STORED_SOCKET:-}"
-    ;;
-  new-session*|"new -d "*)
-    printf 'live\n' >"${TT_TEST_SERVER_STATE:?}"
-    ;;
-  "has-session "*)
-    exit 1
-    ;;
-  "list-sessions")
-    [[ "$server_state" == "live" ]] || exit 1
-    printf 'test: 1 windows\n'
-    ;;
-  "kill-server")
-    printf 'none\n' >"${TT_TEST_SERVER_STATE:?}"
-    ;;
-  "set-option -gq @tt_wsl_interop "*)
-    if [[ "${TT_TEST_SET_OPTION_FAIL:-}" == "1" ]]; then
-      if [[ -n "${TT_TEST_SERVER_STAT:-}" ]]; then
-        sed 's/ 222222 0$/ 999999 0/' "$TT_TEST_SERVER_STAT" >"$TT_TEST_SERVER_STAT.tmp"
-        /bin/mv -f "$TT_TEST_SERVER_STAT.tmp" "$TT_TEST_SERVER_STAT"
-      fi
-      exit 1
-    fi
-    ;;
-esac
-SH
+fixture_dir="$repo/tests/fixtures/tt-wsl-bridge"
+install -m 0755 "$fixture_dir/findmnt" "$fakebin/findmnt"
+install -m 0755 "$fixture_dir/stat" "$fakebin/stat"
+install -m 0755 "$fixture_dir/tmux" "$fakebin/tmux"
+[[ -x "$fakebin/findmnt" ]]
+[[ -x "$fakebin/stat" ]]
+[[ -x "$fakebin/tmux" ]]
 chmod +x "$fakebin"/*
 
 state="$temporary/mount.state"

--- a/tests/tt-wsl-bridge-test.sh
+++ b/tests/tt-wsl-bridge-test.sh
@@ -87,6 +87,14 @@ write_proc_stat() {
   printf ' %s 0\n' "$starttime" >>"$procroot/$pid/stat"
 }
 
+file_mode() {
+  if /usr/bin/stat -c %a "$1" >/dev/null 2>&1; then
+    /usr/bin/stat -c %a "$1"
+  else
+    /usr/bin/stat -f %Lp "$1"
+  fi
+}
+
 make_proc 1234 bash 111111 'mnt:[7001]' /usr/bin/bash
 make_proc 2222 'tmux: server' 222222 'mnt:[7001]' "$fakebin/tmux"
 make_proc 3333 bash 333333 'mnt:[7001]' /usr/bin/bash
@@ -208,11 +216,19 @@ if [[ "${1:-}" == "-c" ]]; then
       exit 0
       ;;
     %a)
-      /usr/bin/stat -f %Lp "$3"
+      if /usr/bin/stat -c %a "$3" >/dev/null 2>&1; then
+        /usr/bin/stat -c %a "$3"
+      else
+        /usr/bin/stat -f %Lp "$3"
+      fi
       exit 0
       ;;
     %s)
-      /usr/bin/stat -f %z "$3"
+      if /usr/bin/stat -c %s "$3" >/dev/null 2>&1; then
+        /usr/bin/stat -c %s "$3"
+      else
+        /usr/bin/stat -f %z "$3"
+      fi
       exit 0
       ;;
   esac
@@ -395,8 +411,8 @@ grep -Fq -- "-x $lockroot/tt-wsl-bridge.lock /bin/bash -c" "$sudo_log"
 grep -Fqx -- "-t drvfs -o ro,uid=1000,gid=1000,umask=022,fmask=011 C: $croot" "$mount_log"
 grep -Fqx -- "set-option -gq @tt_wsl_interop $socket" "$tmux_log"
 grep -Fqx -- "2222|222222|mnt:[7001]" "$markerroot/mount-1000"
-[[ "$(/usr/bin/stat -f %Lp "$markerroot/mount-1000")" == "600" ]]
-marker_mode="$(/usr/bin/stat -f %Lp "$markerroot")"
+[[ "$(file_mode "$markerroot/mount-1000")" == "600" ]]
+marker_mode="$(file_mode "$markerroot")"
 (( (8#$marker_mode & 8#022) == 0 ))
 [[ ! -L "$markerroot" ]]
 [[ -z "$(find "$markerroot" -maxdepth 1 -name '.record.*' -print -quit)" ]]

--- a/tests/tt-wsl-bridge-test.sh
+++ b/tests/tt-wsl-bridge-test.sh
@@ -40,6 +40,8 @@ sed \
   -e "s#/usr/bin/bash#/bin/bash#g" \
   -e "s#/usr/bin/mkdir#/bin/mkdir#g" \
   -e "s#/usr/bin/rm#/bin/rm#g" \
+  -e "s#/usr/bin/chmod#/bin/chmod#g" \
+  -e "s#/usr/bin/mv#$fakebin/mv#g" \
   "$repo/bin/tt" >"$temporary/tt"
 sed \
   -e "s#/run/WSL#$runtime#g" \
@@ -71,6 +73,18 @@ make_proc() {
   printf ' %s 0\n' "$starttime" >>"$procroot/$pid/stat"
   ln -s "$namespace" "$procroot/$pid/ns/mnt"
   ln -s "$exe" "$procroot/$pid/exe"
+}
+
+write_proc_stat() {
+  local pid="$1"
+  local comm="$2"
+  local starttime="$3"
+
+  printf '%s (%s) S' "$pid" "$comm" >"$procroot/$pid/stat"
+  for _ in {1..18}; do
+    printf ' 0' >>"$procroot/$pid/stat"
+  done
+  printf ' %s 0\n' "$starttime" >>"$procroot/$pid/stat"
 }
 
 make_proc 1234 bash 111111 'mnt:[7001]' /usr/bin/bash
@@ -183,15 +197,36 @@ SH
 cat >"$fakebin/stat" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
-if [[ "${1:-}" == "-c" && "${2:-}" == "%u" ]]; then
-  if [[ "${3:-}" == "${TT_TEST_INIT_PATH:-}" ]]; then
-    printf '0\n'
-  else
-    printf '1000\n'
-  fi
-  exit 0
+if [[ "${1:-}" == "-c" ]]; then
+  case "${2:-}" in
+    %u)
+      if [[ "${3:-}" == "${TT_TEST_INIT_PATH:-}" || "${3:-}" == "${TT_TEST_MARKER_ROOT:-}"* ]]; then
+        printf '0\n'
+      else
+        printf '1000\n'
+      fi
+      exit 0
+      ;;
+    %a)
+      /usr/bin/stat -f %Lp "$3"
+      exit 0
+      ;;
+    %s)
+      /usr/bin/stat -f %z "$3"
+      exit 0
+      ;;
+  esac
 fi
 exec /usr/bin/stat "$@"
+SH
+
+cat >"$fakebin/mv" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "-fT" ]]; then
+  shift
+fi
+exec /bin/mv -f "$@"
 SH
 
 cat >"$fakebin/readlink" <<'SH'
@@ -242,7 +277,17 @@ case "$*" in
     ;;
   "list-panes -a -F #{pane_id}|#{pane_pid}|#{pane_dead}")
     [[ "$server_state" == "live" ]] || exit 1
-    printf '%b\n' "${TT_TEST_PANE_ROWS:-%1|3333|0}"
+    count=0
+    if [[ -n "${TT_TEST_PANE_CALLS:-}" ]]; then
+      count="$(cat "$TT_TEST_PANE_CALLS" 2>/dev/null || printf 0)"
+      count=$((count + 1))
+      printf '%s\n' "$count" >"$TT_TEST_PANE_CALLS"
+    fi
+    if [[ "${TT_TEST_PANE_CHURN:-}" == "1" && "$count" -ge 3 ]]; then
+      printf '%%1|3333|0\n%%9|9999|1\n'
+    else
+      printf '%b\n' "${TT_TEST_PANE_ROWS:-%1|3333|0}"
+    fi
     ;;
   "show-option -gqv @tt_wsl_interop")
     printf '%s\n' "${TT_TEST_STORED_SOCKET:-}"
@@ -252,6 +297,22 @@ case "$*" in
     ;;
   "has-session "*)
     exit 1
+    ;;
+  "list-sessions")
+    [[ "$server_state" == "live" ]] || exit 1
+    printf 'test: 1 windows\n'
+    ;;
+  "kill-server")
+    printf 'none\n' >"${TT_TEST_SERVER_STATE:?}"
+    ;;
+  "set-option -gq @tt_wsl_interop "*)
+    if [[ "${TT_TEST_SET_OPTION_FAIL:-}" == "1" ]]; then
+      if [[ -n "${TT_TEST_SERVER_STAT:-}" ]]; then
+        sed 's/ 222222 0$/ 999999 0/' "$TT_TEST_SERVER_STAT" >"$TT_TEST_SERVER_STAT.tmp"
+        /bin/mv -f "$TT_TEST_SERVER_STAT.tmp" "$TT_TEST_SERVER_STAT"
+      fi
+      exit 1
+    fi
     ;;
 esac
 SH
@@ -273,6 +334,8 @@ export TT_TEST_SUDO_LOG="$sudo_log"
 export TT_TEST_TMUX_LOG="$tmux_log"
 export TT_TEST_TMUX_SOCKET="$socket"
 export TT_TEST_INIT_PATH="$fakebin/init"
+export TT_TEST_MARKER_ROOT="$markerroot"
+export TT_TEST_SERVER_STAT="$procroot/2222/stat"
 export WSL_DISTRO_NAME=Ubuntu
 
 expect_failure() {
@@ -280,6 +343,29 @@ expect_failure() {
     printf 'expected command to fail: %s\n' "$*" >&2
     exit 1
   fi
+}
+
+write_record() {
+  local path="$1"
+  local value="$2"
+  local mode="${3:-600}"
+
+  mkdir -p "$markerroot"
+  printf '%s\n' "$value" >"$path"
+  chmod "$mode" "$path"
+}
+
+reset_bridge_fixture() {
+  rm -rf "$croot" "$markerroot" "$procroot/4444" "$procroot/5555"
+  mkdir -p "$markerroot"
+  chmod 700 "$markerroot"
+  : >"$mount_log"
+  : >"$umount_log"
+  : >"$sudo_log"
+  : >"$tmux_log"
+  printf 'absent\n' >"$state"
+  printf 'live\n' >"$server_state"
+  write_proc_stat 2222 'tmux: server' 222222
 }
 
 : >"$mount_log"
@@ -309,6 +395,11 @@ grep -Fq -- "-x $lockroot/tt-wsl-bridge.lock /bin/bash -c" "$sudo_log"
 grep -Fqx -- "-t drvfs -o ro,uid=1000,gid=1000,umask=022,fmask=011 C: $croot" "$mount_log"
 grep -Fqx -- "set-option -gq @tt_wsl_interop $socket" "$tmux_log"
 grep -Fqx -- "2222|222222|mnt:[7001]" "$markerroot/mount-1000"
+[[ "$(/usr/bin/stat -f %Lp "$markerroot/mount-1000")" == "600" ]]
+marker_mode="$(/usr/bin/stat -f %Lp "$markerroot")"
+(( (8#$marker_mode & 8#022) == 0 ))
+[[ ! -L "$markerroot" ]]
+[[ -z "$(find "$markerroot" -maxdepth 1 -name '.record.*' -print -quit)" ]]
 if grep -Eq 'set-environment.*(WSL_INTEROP|WSLENV)' "$tmux_log"; then
   printf 'bridge wrote forbidden tmux global environment\n' >&2
   exit 1
@@ -349,6 +440,137 @@ WSL_INTEROP="$socket" TT_LOGIN_SHELL=/bin/sh "$temporary/tt" shell bridge-create
 grep -Fqx -- "set-option -gq @tt_wsl_interop $socket" "$tmux_log"
 grep -Fqx -- "2222|222222|mnt:[7001]" "$markerroot/mount-1000"
 [[ ! -e "$markerroot/pending-1000" ]]
+
+reset_bridge_fixture
+chmod 777 "$markerroot"
+expect_failure env WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
+[[ ! -s "$mount_log" ]]
+chmod 700 "$markerroot"
+
+write_record "$markerroot/mount-1000" 'garbage'
+expect_failure env WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
+[[ ! -s "$mount_log" ]]
+
+write_record "$markerroot/mount-1000" '5555|555555|mnt:[8000]' 666
+expect_failure env WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
+[[ ! -s "$mount_log" ]]
+
+write_record "$markerroot/real-record" '5555|555555|mnt:[8000]'
+rm -f "$markerroot/mount-1000"
+ln -s "$markerroot/real-record" "$markerroot/mount-1000"
+expect_failure env WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
+[[ ! -s "$mount_log" ]]
+
+reset_bridge_fixture
+printf 'valid\n' >"$state"
+write_record "$markerroot/mount-1000" '5555|555555|mnt:[7001]'
+WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
+grep -Fqx -- '2222|222222|mnt:[7001]' "$markerroot/mount-1000"
+[[ ! -s "$umount_log" ]]
+
+reset_bridge_fixture
+printf 'valid\n' >"$state"
+write_record "$markerroot/pending-1000" '5555|555555|mnt:[7001]'
+WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
+grep -Fqx -- '2222|222222|mnt:[7001]' "$markerroot/mount-1000"
+[[ ! -e "$markerroot/pending-1000" ]]
+[[ ! -s "$umount_log" ]]
+
+reset_bridge_fixture
+printf 'valid\n' >"$state"
+write_record "$markerroot/mount-1000" '5555|555555|mnt:[8000]'
+expect_failure env WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
+grep -Fqx -- '5555|555555|mnt:[8000]' "$markerroot/mount-1000"
+[[ ! -s "$umount_log" ]]
+
+reset_bridge_fixture
+write_record "$markerroot/mount-1000" '5555|555555|mnt:[7001]'
+WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
+grep -Fqx -- '2222|222222|mnt:[7001]' "$markerroot/mount-1000"
+[[ -s "$mount_log" ]]
+
+reset_bridge_fixture
+make_proc 4444 bash 444444 'mnt:[8000]' /usr/bin/bash
+write_record "$markerroot/mount-1000" '4444|444444|mnt:[8000]'
+expect_failure env WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
+grep -Fqx -- '4444|444444|mnt:[8000]' "$markerroot/mount-1000"
+[[ ! -s "$mount_log" ]]
+
+reset_bridge_fixture
+make_proc 4444 bash 444444 'mnt:[8000]' /usr/bin/bash
+write_record "$markerroot/mount-1000" '5555|555555|mnt:[8000]'
+expect_failure env WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
+grep -Fqx -- '5555|555555|mnt:[8000]' "$markerroot/mount-1000"
+[[ ! -s "$mount_log" ]]
+
+rm -rf "$procroot/4444"
+WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
+grep -Fqx -- '2222|222222|mnt:[7001]' "$markerroot/mount-1000"
+[[ -s "$mount_log" ]]
+
+reset_bridge_fixture
+write_record "$markerroot/pending-1000" '5555|555555|mnt:[8000]'
+WSL_INTEROP="$socket" "$temporary/tt" wsl-bridge ensure
+grep -Fqx -- '2222|222222|mnt:[7001]' "$markerroot/mount-1000"
+[[ ! -e "$markerroot/pending-1000" ]]
+
+reset_bridge_fixture
+pane_calls="$temporary/pane.calls"
+pane_stderr="$temporary/pane.stderr"
+printf '0\n' >"$pane_calls"
+if TT_TEST_PANE_CALLS="$pane_calls" TT_TEST_PANE_CHURN=1 WSL_INTEROP="$socket" \
+  "$temporary/tt" wsl-bridge ensure >/dev/null 2>"$pane_stderr"; then
+  printf 'pane churn unexpectedly succeeded\n' >&2
+  exit 1
+fi
+grep -Fq -- 'tmux pane set changed during bridge setup' "$pane_stderr"
+if grep -Fq -- 'WSL bridge cleanup failed' "$pane_stderr"; then
+  printf 'pane churn rollback reported a cleanup failure\n' >&2
+  exit 1
+fi
+grep -Fqx -- 'absent' "$state"
+[[ ! -e "$markerroot/mount-1000" ]]
+[[ -s "$umount_log" ]]
+
+reset_bridge_fixture
+identity_stderr="$temporary/identity.stderr"
+if TT_TEST_SET_OPTION_FAIL=1 WSL_INTEROP="$socket" \
+  "$temporary/tt" wsl-bridge ensure >/dev/null 2>"$identity_stderr"; then
+  printf 'server identity mutation unexpectedly succeeded\n' >&2
+  exit 1
+fi
+grep -Fq -- 'WSL bridge cleanup failed after tmux socket option update' "$identity_stderr"
+grep -Fqx -- 'valid' "$state"
+grep -Fqx -- '2222|222222|mnt:[7001]' "$markerroot/mount-1000"
+[[ ! -s "$umount_log" ]]
+write_proc_stat 2222 'tmux: server' 222222
+
+reset_bridge_fixture
+printf 'valid\n' >"$state"
+write_record "$markerroot/mount-1000" '2222|222222|mnt:[7001]'
+write_proc_stat 2222 'tmux: server' 999999
+expect_failure env WSL_INTEROP="$socket" TT_LOGIN_SHELL=/bin/sh \
+  "$temporary/tt" reset shell reset-proof
+grep -Fqx -- 'valid' "$state"
+grep -Fqx -- '2222|222222|mnt:[7001]' "$markerroot/mount-1000"
+if grep -Fqx -- 'kill-server' "$tmux_log"; then
+  printf 'reset killed a server whose identity could not be validated\n' >&2
+  exit 1
+fi
+write_proc_stat 2222 'tmux: server' 222222
+
+reset_bridge_fixture
+printf 'valid\n' >"$state"
+write_record "$markerroot/mount-1000" '2222|222222|mnt:[7001]'
+WSL_INTEROP="$socket" TT_LOGIN_SHELL=/bin/sh \
+  "$temporary/tt" reset shell reset-proof >/dev/null
+grep -Fqx -- 'valid' "$state"
+grep -Fqx -- 'live' "$server_state"
+grep -Fqx -- '2222|222222|mnt:[7001]' "$markerroot/mount-1000"
+[[ ! -e "$markerroot/pending-1000" ]]
+[[ -s "$mount_log" ]]
+[[ -s "$umount_log" ]]
+grep -Fqx -- 'kill-server' "$tmux_log"
 
 printf 'valid\n' >"$state"
 printf 'live\n' >"$server_state"

--- a/tests/tt-wsl-bridge-test.sh
+++ b/tests/tt-wsl-bridge-test.sh
@@ -48,6 +48,10 @@ sed \
 sed \
   -e "s#/run/WSL#$runtime#g" \
   -e "s#/mnt/c#$croot#g" \
+  -e "s#exec /init#exec $fakebin/init#g" \
+  -e "s#stat -c %u /init#stat -c %u $fakebin/init#g" \
+  -e "s#-x /init#-x $fakebin/init#g" \
+  -e "s#! -L /init#! -L $fakebin/init#g" \
   "$repo/bin/pwsh.exe" >"$temporary/pwsh.exe"
 chmod +x "$temporary/tt" "$temporary/powershell.exe" "$temporary/pwsh.exe"
 
@@ -61,7 +65,7 @@ make_proc() {
   mkdir -p "$procroot/$pid/ns"
   printf '%s\n' "$comm" >"$procroot/$pid/comm"
   printf '%s (%s) S' "$pid" "$comm" >"$procroot/$pid/stat"
-  for i in {1..18}; do
+  for _ in {1..18}; do
     printf ' 0' >>"$procroot/$pid/stat"
   done
   printf ' %s 0\n' "$starttime" >>"$procroot/$pid/stat"
@@ -106,6 +110,14 @@ case "${1:-}" in
   -g) printf '1000\n' ;;
   *) exit 2 ;;
 esac
+SH
+
+cat >"$fakebin/init" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+target="$1"
+shift
+exec /bin/bash "$target" "$@"
 SH
 
 cat >"$fakebin/findmnt" <<'SH'
@@ -172,7 +184,11 @@ cat >"$fakebin/stat" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 if [[ "${1:-}" == "-c" && "${2:-}" == "%u" ]]; then
-  printf '1000\n'
+  if [[ "${3:-}" == "${TT_TEST_INIT_PATH:-}" ]]; then
+    printf '0\n'
+  else
+    printf '1000\n'
+  fi
   exit 0
 fi
 exec /usr/bin/stat "$@"
@@ -256,6 +272,7 @@ export TT_TEST_UMOUNT_LOG="$umount_log"
 export TT_TEST_SUDO_LOG="$sudo_log"
 export TT_TEST_TMUX_LOG="$tmux_log"
 export TT_TEST_TMUX_SOCKET="$socket"
+export TT_TEST_INIT_PATH="$fakebin/init"
 export WSL_DISTRO_NAME=Ubuntu
 
 expect_failure() {
@@ -348,7 +365,10 @@ mkdir -p "$croot/Windows/System32/WindowsPowerShell/v1.0"
 cat >"$croot/Windows/System32/WindowsPowerShell/v1.0/powershell.exe" <<'SH'
 #!/usr/bin/env bash
 printf 'interop=%s\n' "${WSL_INTEROP:-}" >"${TT_TEST_EXE_LOG:?}"
-printf '<%s>\n' "$@" >>"${TT_TEST_EXE_LOG:?}"
+printf 'argc=%s\n' "$#" >>"${TT_TEST_EXE_LOG:?}"
+if [[ "$#" -gt 0 ]]; then
+  printf '<%s>\n' "$@" >>"${TT_TEST_EXE_LOG:?}"
+fi
 exit "${TT_TEST_EXE_STATUS:-0}"
 SH
 chmod +x "$croot/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
@@ -384,15 +404,58 @@ rm -rf "$croot/Program Files"
 mkdir -p "$croot/Program Files/WindowsApps/Microsoft.PowerShell_7.6.4.0_arm64__8wekyb3d8bbwe"
 cp "$croot/Windows/System32/WindowsPowerShell/v1.0/powershell.exe" \
   "$croot/Program Files/WindowsApps/Microsoft.PowerShell_7.6.4.0_arm64__8wekyb3d8bbwe/pwsh.exe"
-chmod +x "$croot/Program Files/WindowsApps/Microsoft.PowerShell_7.6.4.0_arm64__8wekyb3d8bbwe/pwsh.exe"
-"$temporary/pwsh.exe" appx
-grep -Fqx '<appx>' "$exe_log"
+chmod 444 "$croot/Program Files/WindowsApps/Microsoft.PowerShell_7.6.4.0_arm64__8wekyb3d8bbwe/pwsh.exe"
+"$temporary/pwsh.exe"
+[[ "$(wc -l <"$exe_log" | tr -d ' ')" == "2" ]]
+grep -Fqx "interop=$socket" "$exe_log"
+grep -Fqx 'argc=0' "$exe_log"
+
+# shellcheck disable=SC1003,SC2016
+args=(
+  ""
+  "two words"
+  "single'quote"
+  'double"quote'
+  'trailing\\'
+  '$dollar'
+  ';semicolon'
+  '*wildcard'
+  $'line one\nline two'
+  'naive-cafe'
+  '日本語'
+)
+"$temporary/pwsh.exe" "${args[@]}"
+expected="$temporary/expected-args"
+{
+  printf 'interop=%s\n' "$socket"
+  printf 'argc=%s\n' "${#args[@]}"
+  printf '<%s>\n' "${args[@]}"
+} >"$expected"
+cmp "$expected" "$exe_log"
+
+export TT_TEST_EXE_STATUS=29
+if "$temporary/pwsh.exe" exit-status; then
+  printf 'pwsh wrapper lost child exit status\n' >&2
+  exit 1
+else
+  status="$?"
+fi
+[[ "$status" == "29" ]]
+export TT_TEST_EXE_STATUS=0
+
+saved_socket="$TT_TEST_STORED_SOCKET"
+export TT_TEST_STORED_SOCKET="$runtime/9999_interop"
+expect_failure env -u WSL_INTEROP "$temporary/pwsh.exe" stale-socket
+export TT_TEST_STORED_SOCKET="$saved_socket"
 
 mkdir -p "$croot/Program Files/WindowsApps/Microsoft.PowerShell_7.7.0.0_arm64__8wekyb3d8bbwe"
 cp "$croot/Windows/System32/WindowsPowerShell/v1.0/powershell.exe" \
   "$croot/Program Files/WindowsApps/Microsoft.PowerShell_7.7.0.0_arm64__8wekyb3d8bbwe/pwsh.exe"
-chmod +x "$croot/Program Files/WindowsApps/Microsoft.PowerShell_7.7.0.0_arm64__8wekyb3d8bbwe/pwsh.exe"
+chmod 444 "$croot/Program Files/WindowsApps/Microsoft.PowerShell_7.7.0.0_arm64__8wekyb3d8bbwe/pwsh.exe"
 expect_failure "$temporary/pwsh.exe" ambiguous
+
+rm -rf "$croot/Program Files/WindowsApps/Microsoft.PowerShell_"*
+expect_failure "$temporary/pwsh.exe" missing
 
 printf 'writable\n' >"$state"
 expect_failure "$temporary/powershell.exe" bad-mount

--- a/tests/windows-wsl-test.sh
+++ b/tests/windows-wsl-test.sh
@@ -12,4 +12,5 @@ grep -q 'vincent-dotfiles' "$root/windows/install.ps1"
 grep -q 'Documents\\PowerShell' "$root/windows/install.ps1"
 grep -q 'WSL2 is the canonical Unix development environment' "$root/README.md"
 "$root/tests/windows-native-operator-test.sh"
+"$root/tests/tt-wsl-bridge-test.sh"
 echo windows_wsl_test=passed


### PR DESCRIPTION
## Summary

- add explicit, idempotent `tt wsl-bridge ensure` support for native WSL launches
- mount `C:` read-only inside the exact tmux server mount namespace with locked identity checks and scoped rollback markers
- add strict `powershell.exe` and `pwsh.exe` wrappers that validate the live interop socket and mount before launching fixed Windows targets
- harden root-owned bridge records with exact parsing, atomic `0600` publication, conservative stale cleanup, and valid-mount adoption
- release an exactly owned bridge mount before `tt reset` replaces its tmux server
- keep the focused bridge harness portable with executable command fixtures and guarded multi-bash coverage

## Safety

- never writes `WSL_INTEROP` or `WSLENV` into the tmux global environment
- rejects unsafe marker paths, malformed records, referenced stale namespaces, live recorded owners, and identity-mismatched mounts
- rejects unexpected, writable, shared-propagation, or identity-mismatched mounts
- validates active and stable dead pane state before, under, and after the root lock
- rollback validates the exact server identity and reports cleanup failures without force or lazy unmounts
- does not change WSL configuration, restart WSL/tmux, or discover sockets by globbing

## Verification

- `tests/tt-wsl-bridge-test.sh`
- `tests/windows-wsl-test.sh`
- `tests/windows-native-operator-test.sh`
- `tests/tt-lifecycle-test.sh`
- `tests/tt-recovery-test.sh`
- extracted `findmnt`, `stat`, and `tmux` fakes are byte-for-byte moves, checked in as executable `0755` fixtures
- full focused suite passed under PATH-selected Bash 5.3.12 and `/bin/bash` 3.2.57 on macOS
- guarded interpreter matrix deduplicated the identical PATH-selected and `/bin/bash` executable on WSL
- focused bridge suite passed on both macOS and WSL
- live native-launch adoption of an intentionally stale same-namespace record without unmounting or restarting WSL/tmux
- live Windows PowerShell 5.1 and PowerShell 7.6.4 wrapper probes with exact child exit propagation
- existing tmux topology and pane PIDs remained unchanged after disposable proof-session cleanup

Current head `ca9dfbfc3ca5abc96de6936a6eae8588d03f6252` is deployed and verified. The fixture-only follow-up did not change `bin/tt`, the existing read-only `C:` mount, tmux server identity, mount namespace, or original pane topology; all temporary deployment artifacts were removed.
