### PR TITLE
fix(tt): harden Codex snapshot writer

### DIFF
--- a/bin/tt
+++ b/bin/tt
@@ -2174,7 +2174,7 @@ record_snapshot_history() {
   local source="$1"
   local label="$2"
   local max="${TT_SNAPSHOT_HISTORY_MAX:-864}"
-  local dir ts dest newest file count
+  local dir ts dest tmp newest file count
   local -a files=()
 
   [[ -f "$source" ]] || return 0
@@ -2186,7 +2186,7 @@ record_snapshot_history() {
   (( max > 0 )) || return 0
 
   dir="$(snapshot_history_dir "$label")"
-  mkdir -p "$dir"
+  mkdir -p "$dir" || return 1
   newest="$(ls -1t "$dir"/*.tsv 2>/dev/null | head -n 1 || true)"
   if [[ -n "$newest" ]] && cmp -s "$source" "$newest"; then
     return 0
@@ -2197,7 +2197,19 @@ record_snapshot_history() {
   if [[ -e "$dest" ]]; then
     dest="$dir/$ts.$$.tsv"
   fi
-  cp "$source" "$dest"
+  tmp="$(mktemp "$dir/.${ts}.XXXXXX")" || return 1
+  if ! cp "$source" "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  if ! python3 -c 'import os, sys; fd = os.open(sys.argv[1], os.O_RDONLY); os.fsync(fd); os.close(fd)' "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  if ! mv "$tmp" "$dest"; then
+    rm -f "$tmp"
+    return 1
+  fi
 
   while IFS= read -r file; do
     [[ -n "$file" ]] && files+=("$file")
@@ -2383,124 +2395,35 @@ write_agent_cockpit_state() {
 write_codex_cockpit_snapshot() {
   local output="${1:-}"
   local quiet="${2:-}"
+  local writer status
 
   [[ -n "$output" ]] || output="$(codex_cockpit_snapshot_file)"
   mkdir -p "$(dirname "$output")"
 
-  TT_TMUX_BIN="$TMUX_BIN" TT_LOGIN_SHELL="$(default_login_shell)" python3 - "$output" <<'PY'
-import os
-import pathlib
-import re
-import shlex
-import subprocess
-import sys
-import tempfile
-from collections import defaultdict
+  writer="$SCRIPT_DIR/tt-codex-snapshot-writer"
+  if [[ ! -x "$writer" ]]; then
+    printf 'tt codex snapshot failed: missing writer %s\n' "$writer" >&2
+    return 1
+  fi
 
-output = pathlib.Path(sys.argv[1])
-tmux = os.environ.get("TT_TMUX_BIN", "tmux")
-login_shell = os.environ.get("TT_LOGIN_SHELL") or "/bin/zsh"
-sid_re = re.compile(r"\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b")
+  if TT_TMUX_BIN="$TMUX_BIN" TT_LOGIN_SHELL="$(default_login_shell)" "$writer" "$output"; then
+    status=0
+  else
+    status=$?
+  fi
 
+  # EX_TEMPFAIL means a live writer owns the host-local flock. It has already
+  # left the current TSV/history untouched, so autosave should simply coalesce.
+  if (( status == 75 )); then
+    if [[ "$quiet" != "--quiet" ]]; then
+      printf 'tt codex snapshot skipped: another writer is active\n' >&2
+    fi
+    return 0
+  fi
+  if (( status != 0 )); then
+    return "$status"
+  fi
 
-def run(args):
-    try:
-        return subprocess.check_output(args, text=True, stderr=subprocess.DEVNULL)
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        return ""
-
-
-def clean(value):
-    return (value or "").replace("\t", " ").replace("\n", " ").strip()
-
-
-def descendants(root, children):
-    result = []
-    stack = list(children.get(root, []))
-    while stack:
-        pid = stack.pop(0)
-        result.append(pid)
-        stack.extend(children.get(pid, []))
-    return result
-
-
-ps_children = defaultdict(list)
-ps_command = {}
-for line in run(["ps", "-axo", "pid=,ppid=,command="]).splitlines():
-    match = re.match(r"\s*(\d+)\s+(\d+)\s+(.*)", line)
-    if not match:
-        continue
-    pid, ppid, command = match.groups()
-    pid = int(pid)
-    ppid = int(ppid)
-    ps_children[ppid].append(pid)
-    ps_command[pid] = command
-
-rows = []
-pane_format = "#{session_name}:#{window_index}.#{pane_index}\t#{pane_pid}\t#{pane_title}\t#{pane_current_command}\t#{pane_current_path}"
-for line in run([tmux, "list-panes", "-a", "-F", pane_format]).splitlines():
-    try:
-        target, pane_pid, title, current_command, cwd = line.split("\t", 4)
-    except ValueError:
-        continue
-
-    pane_pid_int = int(pane_pid)
-    codex_commands = []
-    claude_commands = []
-    ids = []
-
-    for pid in [pane_pid_int] + descendants(pane_pid_int, ps_children):
-        command = ps_command.get(pid, "")
-        if "codex" in command and "tokenjuice" not in command:
-            codex_commands.append(command)
-            command_ids = sid_re.findall(command)
-            ids.extend(command_ids)
-            if not command_ids:
-                for lsof_line in run(["lsof", "-w", "-F", "n", "-p", str(pid)]).splitlines():
-                    if not lsof_line.startswith("n/Users/vincentkoc/.codex/sessions/"):
-                        continue
-                    ids.extend(sid_re.findall(lsof_line[1:]))
-        elif re.search(r"(^|/)claude(\s|$)|Claude Code", command):
-            claude_commands.append(command)
-
-    ids = list(dict.fromkeys(ids))
-    kind = "shell"
-    status = "shell"
-    session_id = ""
-    restore = f"cd {shlex.quote(cwd)} && exec {shlex.quote(login_shell)} -il"
-
-    if codex_commands:
-        kind = "codex"
-        command_text = " ".join(codex_commands)
-        dangerous = " --dangerously-bypass-approvals-and-sandbox" if "--dangerously-bypass-approvals-and-sandbox" in command_text else ""
-        if ids:
-            session_id = ids[0]
-            status = "exact"
-            restore = f"cd {shlex.quote(cwd)} && codex resume{dangerous} --no-alt-screen {session_id}"
-        elif "resume --all" in command_text:
-            status = "picker"
-            restore = f"cd {shlex.quote(cwd)} && codex resume --all --no-alt-screen"
-        else:
-            status = "unresolved"
-            restore = f"cd {shlex.quote(cwd)} && codex --no-alt-screen"
-    elif claude_commands:
-        kind = "claude"
-        status = "resume"
-        dangerous = " --dangerously-skip-permissions" if "--dangerously-skip-permissions" in " ".join(claude_commands) else ""
-        restore = f"cd {shlex.quote(cwd)} && claude{dangerous} resume"
-
-    rows.append([target, kind, cwd, title, current_command, session_id, status, restore])
-
-output.parent.mkdir(parents=True, exist_ok=True)
-fd, tmp_name = tempfile.mkstemp(prefix=output.name + ".", dir=str(output.parent))
-with os.fdopen(fd, "w") as handle:
-    handle.write("# target\tkind\tcwd\ttitle\tcurrent_command\tsession_id\tstatus\trestore\n")
-    for row in rows:
-        handle.write("\t".join(clean(value) for value in row) + "\n")
-os.replace(tmp_name, output)
-PY
-
-  record_snapshot_history "$output" "codex-cockpit"
   if [[ "$quiet" != "--quiet" ]]; then
     printf 'tt codex snapshot saved: %s\n' "$output" >&2
   fi

--- a/bin/tt-codex-snapshot-writer
+++ b/bin/tt-codex-snapshot-writer
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""Build one Codex cockpit restore map without disturbing tmux."""
+
+import os
+import pathlib
+import re
+import shlex
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from collections import defaultdict
+from shutil import copyfileobj
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+
+
+class SnapshotError(RuntimeError):
+    """Collection failed before a complete replacement snapshot existed."""
+
+
+def positive_env(name, default, minimum=1):
+    value = os.environ.get(name, str(default))
+    try:
+        value = int(value)
+    except ValueError:
+        return default
+    return max(minimum, value)
+
+
+COMMAND_TIMEOUT_SECONDS = positive_env("TT_SNAPSHOT_COMMAND_TIMEOUT_SECONDS", 5)
+TOTAL_TIMEOUT_SECONDS = positive_env("TT_SNAPSHOT_TOTAL_TIMEOUT_SECONDS", 30)
+DEADLINE = time.monotonic() + TOTAL_TIMEOUT_SECONDS
+
+OUTPUT = pathlib.Path(sys.argv[1])
+TMUX = os.environ.get("TT_TMUX_BIN", "tmux")
+LOGIN_SHELL = os.environ.get("TT_LOGIN_SHELL") or "/bin/zsh"
+CODEX_SESSIONS_DIR = pathlib.Path.home() / ".codex" / "sessions"
+STATE_HOME = pathlib.Path(
+    os.environ.get("XDG_STATE_HOME", str(pathlib.Path.home() / ".local" / "state"))
+)
+LOCK_PATH = STATE_HOME / "tt" / "codex-cockpit.lock"
+HISTORY_DIR = STATE_HOME / "tt" / "history" / "codex-cockpit"
+SID_RE = re.compile(
+    r"\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b"
+)
+
+
+def run(args, *, required=True):
+    remaining = DEADLINE - time.monotonic()
+    if remaining <= 0:
+        raise SnapshotError("snapshot collection exceeded its total time budget")
+
+    timeout = min(COMMAND_TIMEOUT_SECONDS, remaining)
+    try:
+        process = subprocess.Popen(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            start_new_session=True,
+        )
+    except OSError as error:
+        if required:
+            raise SnapshotError(f"missing collector {args[0]}") from error
+        return ""
+    try:
+        stdout, _ = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired as error:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            process.communicate(timeout=1)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            process.communicate()
+        raise SnapshotError(f"timed out collecting {' '.join(args[:2])}") from error
+    if process.returncode != 0:
+        if required:
+            raise SnapshotError(f"collector failed: {' '.join(args[:2])}")
+        return ""
+    return stdout
+
+
+def snapshot_history_limit():
+    value = os.environ.get("TT_SNAPSHOT_HISTORY_MAX", "864")
+    try:
+        return max(0, int(value))
+    except ValueError:
+        return 864
+
+
+def files_match(first, second):
+    with first.open("rb") as left, second.open("rb") as right:
+        while True:
+            left_chunk = left.read(1024 * 1024)
+            right_chunk = right.read(1024 * 1024)
+            if left_chunk != right_chunk:
+                return False
+            if not left_chunk:
+                return True
+
+
+def record_snapshot_history():
+    max_history = snapshot_history_limit()
+    if max_history == 0:
+        return
+
+    HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+    files = sorted(
+        HISTORY_DIR.glob("*.tsv"), key=lambda path: path.stat().st_mtime, reverse=True
+    )
+    if files and files_match(OUTPUT, files[0]):
+        return
+
+    timestamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    destination = HISTORY_DIR / f"{timestamp}.tsv"
+    if destination.exists():
+        destination = HISTORY_DIR / f"{timestamp}.{os.getpid()}.tsv"
+
+    temporary_name = None
+    try:
+        fd, temporary_name = tempfile.mkstemp(
+            prefix=f".{timestamp}.", dir=str(HISTORY_DIR)
+        )
+        with os.fdopen(fd, "wb") as temporary, OUTPUT.open("rb") as source:
+            copyfileobj(source, temporary)
+            temporary.flush()
+            os.fsync(temporary.fileno())
+        os.replace(temporary_name, destination)
+        temporary_name = None
+    finally:
+        if temporary_name:
+            pathlib.Path(temporary_name).unlink(missing_ok=True)
+
+    files = sorted(
+        HISTORY_DIR.glob("*.tsv"), key=lambda path: path.stat().st_mtime, reverse=True
+    )
+    for stale in files[max_history:]:
+        stale.unlink(missing_ok=True)
+
+
+def clean(value):
+    return (value or "").replace("\t", " ").replace("\n", " ").strip()
+
+
+def descendants(root, children):
+    result = []
+    stack = list(children.get(root, []))
+    while stack:
+        pid = stack.pop(0)
+        result.append(pid)
+        stack.extend(children.get(pid, []))
+    return result
+
+
+def build_rows():
+    ps_children = defaultdict(list)
+    ps_command = {}
+    for line in run(["ps", "-axo", "pid=,ppid=,command="]).splitlines():
+        match = re.match(r"\s*(\d+)\s+(\d+)\s+(.*)", line)
+        if not match:
+            continue
+        pid, ppid, command = match.groups()
+        pid = int(pid)
+        ppid = int(ppid)
+        ps_children[ppid].append(pid)
+        ps_command[pid] = command
+
+    rows = []
+    pane_format = (
+        "#{session_name}:#{window_index}.#{pane_index}\t#{pane_pid}\t"
+        "#{pane_title}\t#{pane_current_command}\t#{pane_current_path}"
+    )
+    for line in run([TMUX, "list-panes", "-a", "-F", pane_format]).splitlines():
+        try:
+            target, pane_pid, title, current_command, cwd = line.split("\t", 4)
+            pane_pid_int = int(pane_pid)
+        except ValueError:
+            raise SnapshotError("tmux returned an invalid pane record") from None
+
+        codex_commands = []
+        claude_commands = []
+        ids = []
+
+        for pid in [pane_pid_int] + descendants(pane_pid_int, ps_children):
+            command = ps_command.get(pid, "")
+            if "codex" in command and "tokenjuice" not in command:
+                codex_commands.append(command)
+                command_ids = SID_RE.findall(command)
+                ids.extend(command_ids)
+                if not command_ids:
+                    for lsof_line in run(
+                        ["lsof", "-w", "-F", "n", "-p", str(pid)], required=False
+                    ).splitlines():
+                        if not lsof_line.startswith(f"n{CODEX_SESSIONS_DIR}/"):
+                            continue
+                        ids.extend(SID_RE.findall(lsof_line[1:]))
+            elif re.search(r"(^|/)claude(\s|$)|Claude Code", command):
+                claude_commands.append(command)
+
+        ids = list(dict.fromkeys(ids))
+        kind = "shell"
+        status = "shell"
+        session_id = ""
+        restore = f"cd {shlex.quote(cwd)} && exec {shlex.quote(LOGIN_SHELL)} -il"
+
+        if codex_commands:
+            kind = "codex"
+            command_text = " ".join(codex_commands)
+            dangerous = (
+                " --dangerously-bypass-approvals-and-sandbox"
+                if "--dangerously-bypass-approvals-and-sandbox" in command_text
+                else ""
+            )
+            if ids:
+                session_id = ids[0]
+                status = "exact"
+                restore = (
+                    f"cd {shlex.quote(cwd)} && codex resume{dangerous} "
+                    f"--no-alt-screen {session_id}"
+                )
+            elif "resume --all" in command_text:
+                status = "picker"
+                restore = f"cd {shlex.quote(cwd)} && codex resume --all --no-alt-screen"
+            else:
+                status = "unresolved"
+                restore = f"cd {shlex.quote(cwd)} && codex --no-alt-screen"
+        elif claude_commands:
+            kind = "claude"
+            status = "resume"
+            dangerous = (
+                " --dangerously-skip-permissions"
+                if "--dangerously-skip-permissions" in " ".join(claude_commands)
+                else ""
+            )
+            restore = f"cd {shlex.quote(cwd)} && claude{dangerous} resume"
+
+        rows.append(
+            [target, kind, cwd, title, current_command, session_id, status, restore]
+        )
+    return rows
+
+
+def write_snapshot(rows):
+    OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    tmp_name = None
+    try:
+        fd, tmp_name = tempfile.mkstemp(prefix=f"{OUTPUT.name}.", dir=str(OUTPUT.parent))
+        with os.fdopen(fd, "w") as handle:
+            handle.write(
+                "# target\tkind\tcwd\ttitle\tcurrent_command\tsession_id\tstatus\trestore\n"
+            )
+            for row in rows:
+                handle.write("\t".join(clean(value) for value in row) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, OUTPUT)
+        tmp_name = None
+    finally:
+        if tmp_name:
+            pathlib.Path(tmp_name).unlink(missing_ok=True)
+
+
+def acquire_snapshot_lock():
+    if fcntl is None:
+        raise SnapshotError("advisory file locking is unavailable")
+
+    LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+    handle = LOCK_PATH.open("a+")
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except BlockingIOError:
+        handle.close()
+        return None
+
+    handle.seek(0)
+    handle.truncate()
+    handle.write(f"{os.getpid()}\t{int(time.time())}\n")
+    handle.flush()
+    os.fsync(handle.fileno())
+    return handle
+
+
+def main():
+    lock = None
+    try:
+        lock = acquire_snapshot_lock()
+        if lock is None:
+            return 75
+        rows = build_rows()
+        write_snapshot(rows)
+        record_snapshot_history()
+    except SnapshotError as error:
+        print(f"tt codex snapshot failed: {error}", file=sys.stderr)
+        return 1
+    except OSError as error:
+        print(f"tt codex snapshot failed: {error}", file=sys.stderr)
+        return 1
+    finally:
+        if lock is not None:
+            lock.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/tt-recovery/tmux
+++ b/tests/fixtures/tt-recovery/tmux
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$TT_TEST_TMUX_LOG"
+
+command="${1:-}"
+case "$command" in
+  list-sessions)
+    if [[ "${TT_TEST_TMUX_SERVER_RUNNING:-}" == "1" ]]; then
+      printf 'unrelated: 1 windows\n'
+    else
+      exit 1
+    fi
+    ;;
+  has-session)
+    if [[ "${TT_TEST_TMUX_EXISTING_SESSION:-}" == "${*: -1}" ]]; then
+      exit 0
+    fi
+    exit 1
+    ;;
+  new-session)
+    if [[ " $* " == *" -P "* ]]; then
+      printf '@1\n'
+    fi
+    ;;
+  list-windows)
+    if [[ " $* " == *" #{window_index}"* ]]; then
+      printf '1\t@1\n'
+    elif [[ " $* " == *" #{window_id}"* ]]; then
+      printf '@1\n'
+    fi
+    ;;
+  list-panes)
+    if [[ " $* " == *" #{pane_index}"* ]]; then
+      printf '0\t%%1\n'
+    elif [[ " $* " == *" #{pane_current_command} "* ]]; then
+      printf 'zsh\n'
+    elif [[ " $* " == *" #{pane_id} "* ]]; then
+      printf '%%1\n'
+    else
+      printf '0: [80x24]\n'
+    fi
+    ;;
+esac

--- a/tests/tt-codex-snapshot-live-test.sh
+++ b/tests/tt-codex-snapshot-live-test.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tt="$repo/bin/tt"
+temporary="$(mktemp -d)"
+tmux_bin="${TT_TEST_REAL_TMUX_BIN:-$(command -v tmux || true)}"
+
+if [[ -z "$tmux_bin" ]]; then
+  printf 'tt_codex_snapshot_live_test=skipped (tmux unavailable)\n'
+  exit 0
+fi
+
+socket="tt-codex-snapshot-test-$$"
+wrapper="$temporary/tmux"
+snapshot="$temporary/codex-cockpit.tsv"
+normal_before="$("$tmux_bin" list-sessions 2>/dev/null || true)"
+
+cleanup() {
+  "$tmux_bin" -L "$socket" kill-server 2>/dev/null || true
+  rm -rf "$temporary"
+}
+trap cleanup EXIT
+
+cat >"$wrapper" <<SH
+#!/usr/bin/env bash
+exec $(printf '%q' "$tmux_bin") -L $(printf '%q' "$socket") "\$@"
+SH
+chmod +x "$wrapper"
+
+"$tmux_bin" -L "$socket" new-session -d -s snapshot-test 'exec sleep 30'
+target="$("$tmux_bin" -L "$socket" list-panes -t snapshot-test -F '#{session_name}:#{window_index}.#{pane_index}')"
+
+HOME="$temporary/home" \
+  XDG_STATE_HOME="$temporary/state" \
+  TT_LOGIN_SHELL=/bin/sh \
+  TT_TMUX_BIN="$wrapper" \
+  "$tt" codex-snapshot "$snapshot" --quiet
+
+"$tmux_bin" -L "$socket" has-session -t snapshot-test
+grep -Fq "$target"$'\tshell' "$snapshot"
+
+normal_after="$("$tmux_bin" list-sessions 2>/dev/null || true)"
+if [[ "$normal_before" != "$normal_after" ]]; then
+  printf 'snapshot changed the caller tmux server instead of the disposable socket\n' >&2
+  exit 1
+fi
+
+printf 'tt_codex_snapshot_live_test=passed\n'

--- a/tests/tt-codex-snapshot-test.sh
+++ b/tests/tt-codex-snapshot-test.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tt="$repo/bin/tt"
+writer="$repo/bin/tt-codex-snapshot-writer"
+temporary="$(mktemp -d)"
+trap 'rm -rf "$temporary"' EXIT
+
+fake_bin="$temporary/bin"
+mkdir -p "$fake_bin"
+
+fake_tmux="$temporary/tmux"
+tmux_log="$temporary/tmux.log"
+snapshot="$temporary/codex-cockpit.tsv"
+state_home="$temporary/state"
+session_id="11111111-1111-1111-1111-111111111111"
+
+cat >"$fake_tmux" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >>"$TT_TEST_TMUX_LOG"
+case "${1:-}" in
+  list-panes)
+    if [[ "${TT_TEST_TMUX_MODE:-normal}" == "hang" ]]; then
+      sleep 3 &
+      child=$!
+      [[ -z "${TT_TEST_CHILD_PID_FILE:-}" ]] || printf '%s\n' "$child" >"$TT_TEST_CHILD_PID_FILE"
+      wait "$child"
+    fi
+    printf 'cockpit:1.1\t100\tcode mode\tcodex\t/tmp/work\n'
+    ;;
+  list-windows)
+    printf '@1\n'
+    ;;
+esac
+SH
+chmod +x "$fake_tmux"
+
+cat >"$fake_bin/ps" <<SH
+#!/usr/bin/env bash
+printf '  100     1 /usr/local/bin/codex --no-alt-screen %s\\n' '$session_id'
+SH
+chmod +x "$fake_bin/ps"
+
+cat >"$fake_bin/lsof" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${TT_TEST_LSOF_MODE:-id}" == "hang" ]]; then
+  sleep 3 &
+  child=$!
+  [[ -z "${TT_TEST_CHILD_PID_FILE:-}" ]] || printf '%s\n' "$child" >"$TT_TEST_CHILD_PID_FILE"
+  wait "$child"
+fi
+printf 'n%s/.codex/sessions/22222222-2222-2222-2222-222222222222.jsonl\n' "$HOME"
+SH
+chmod +x "$fake_bin/lsof"
+
+bash -n "$tt"
+python3 -m py_compile "$writer"
+[[ -x "$writer" ]]
+if grep -Eq 'python3 - .*<<' "$tt"; then
+  printf 'tt still embeds the snapshot writer in a heredoc\n' >&2
+  exit 1
+fi
+
+PATH="$fake_bin:$PATH" \
+  HOME="$temporary/home" \
+  XDG_STATE_HOME="$state_home" \
+  TT_LOGIN_SHELL=/bin/sh \
+  TT_TMUX_BIN="$fake_tmux" \
+  TT_TEST_TMUX_LOG="$tmux_log" \
+  "$tt" codex-snapshot "$snapshot" --quiet
+
+grep -Fq $'cockpit:1.1\tcodex\t/tmp/work\tcode mode\tcodex\t11111111-1111-1111-1111-111111111111\texact' "$snapshot"
+history_dir="$state_home/tt/history/codex-cockpit"
+[[ "$(find "$history_dir" -maxdepth 1 -type f -name '*.tsv' | wc -l | tr -d ' ')" == "1" ]]
+[[ -f "$state_home/tt/codex-cockpit.lock" ]]
+
+# Codex session IDs missing from the process command still come from the
+# opened session file. This keeps exact recovery behavior without relying on
+# an inline Python subprocess.
+cat >"$fake_bin/ps" <<'SH'
+#!/usr/bin/env bash
+printf '  100     1 /usr/local/bin/codex --no-alt-screen\n'
+SH
+chmod +x "$fake_bin/ps"
+
+PATH="$fake_bin:$PATH" \
+  HOME="$temporary/home" \
+  XDG_STATE_HOME="$state_home" \
+  TT_LOGIN_SHELL=/bin/sh \
+  TT_TMUX_BIN="$fake_tmux" \
+  TT_TEST_TMUX_LOG="$tmux_log" \
+  "$tt" codex-snapshot "$snapshot" --quiet
+
+grep -Fq $'cockpit:1.1\tcodex\t/tmp/work\tcode mode\tcodex\t22222222-2222-2222-2222-222222222222\texact' "$snapshot"
+
+# Advisory locks are released by the kernel when a previous writer dies, even
+# when its old PID metadata remains in the lock file.
+printf '999999\t0\n' >"$state_home/tt/codex-cockpit.lock"
+PATH="$fake_bin:$PATH" \
+  HOME="$temporary/home" \
+  XDG_STATE_HOME="$state_home" \
+  TT_LOGIN_SHELL=/bin/sh \
+  TT_TMUX_BIN="$fake_tmux" \
+  TT_TEST_TMUX_LOG="$tmux_log" \
+  "$tt" codex-snapshot "$snapshot" --quiet
+[[ -f "$state_home/tt/codex-cockpit.lock" ]]
+
+before_snapshot="$(cksum "$snapshot")"
+before_history="$(find "$history_dir" -maxdepth 1 -type f -name '*.tsv' | wc -l | tr -d ' ')"
+lock_ready="$temporary/lock-ready"
+python3 - "$state_home/tt/codex-cockpit.lock" "$lock_ready" <<'PY' &
+import fcntl
+import pathlib
+import sys
+import time
+
+lock = pathlib.Path(sys.argv[1])
+lock.parent.mkdir(parents=True, exist_ok=True)
+with lock.open("a+") as handle:
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+    pathlib.Path(sys.argv[2]).touch()
+    time.sleep(2)
+PY
+lock_holder=$!
+for _ in $(seq 1 20); do
+  [[ -f "$lock_ready" ]] && break
+  sleep 0.1
+done
+[[ -f "$lock_ready" ]]
+: >"$tmux_log"
+PATH="$fake_bin:$PATH" \
+  HOME="$temporary/home" \
+  XDG_STATE_HOME="$state_home" \
+  TT_LOGIN_SHELL=/bin/sh \
+  TT_TMUX_BIN="$fake_tmux" \
+  TT_TEST_TMUX_LOG="$tmux_log" \
+  "$tt" codex-snapshot "$snapshot" --quiet
+[[ "$(cksum "$snapshot")" == "$before_snapshot" ]]
+[[ "$(find "$history_dir" -maxdepth 1 -type f -name '*.tsv' | wc -l | tr -d ' ')" == "$before_history" ]]
+[[ ! -s "$tmux_log" ]]
+wait "$lock_holder"
+
+# A timed-out collection does not replace the current TSV or create history.
+printf 'known-good\n' >"$snapshot"
+rm -rf "$history_dir"
+mkdir -p "$history_dir"
+printf 'known-good\n' >"$history_dir/old.tsv"
+before_snapshot="$(cksum "$snapshot")"
+before_history="$(find "$history_dir" -maxdepth 1 -type f -name '*.tsv' | wc -l | tr -d ' ')"
+timeout_child="$temporary/tmux-timeout-child"
+if PATH="$fake_bin:$PATH" \
+  HOME="$temporary/home" \
+  XDG_STATE_HOME="$state_home" \
+  TT_LOGIN_SHELL=/bin/sh \
+  TT_SNAPSHOT_COMMAND_TIMEOUT_SECONDS=1 \
+  TT_SNAPSHOT_TOTAL_TIMEOUT_SECONDS=1 \
+  TT_TMUX_BIN="$fake_tmux" \
+  TT_TEST_TMUX_LOG="$tmux_log" \
+  TT_TEST_TMUX_MODE=hang \
+  TT_TEST_CHILD_PID_FILE="$timeout_child" \
+  "$tt" codex-snapshot "$snapshot" --quiet; then
+  printf 'timed-out snapshot unexpectedly succeeded\n' >&2
+  exit 1
+fi
+[[ "$(cksum "$snapshot")" == "$before_snapshot" ]]
+[[ "$(find "$history_dir" -maxdepth 1 -type f -name '*.tsv' | wc -l | tr -d ' ')" == "$before_history" ]]
+[[ -f "$state_home/tt/codex-cockpit.lock" ]]
+[[ -f "$timeout_child" ]]
+if kill -0 "$(cat "$timeout_child")" 2>/dev/null; then
+  printf 'tmux timeout leaked a collector child\n' >&2
+  exit 1
+fi
+
+# The optional lsof lookup is also deadline-bound. A timeout is not treated as
+# "unresolved": it preserves the last complete map so recovery never loses IDs.
+if PATH="$fake_bin:$PATH" \
+  HOME="$temporary/home" \
+  XDG_STATE_HOME="$state_home" \
+  TT_LOGIN_SHELL=/bin/sh \
+  TT_SNAPSHOT_COMMAND_TIMEOUT_SECONDS=1 \
+  TT_SNAPSHOT_TOTAL_TIMEOUT_SECONDS=3 \
+  TT_TMUX_BIN="$fake_tmux" \
+  TT_TEST_TMUX_LOG="$tmux_log" \
+  TT_TEST_LSOF_MODE=hang \
+  TT_TEST_CHILD_PID_FILE="$temporary/lsof-timeout-child" \
+  "$tt" codex-snapshot "$snapshot" --quiet; then
+  printf 'timed-out lsof lookup unexpectedly succeeded\n' >&2
+  exit 1
+fi
+[[ "$(cksum "$snapshot")" == "$before_snapshot" ]]
+[[ "$(find "$history_dir" -maxdepth 1 -type f -name '*.tsv' | wc -l | tr -d ' ')" == "$before_history" ]]
+[[ -f "$state_home/tt/codex-cockpit.lock" ]]
+if kill -0 "$(cat "$temporary/lsof-timeout-child")" 2>/dev/null; then
+  printf 'lsof timeout leaked a collector child\n' >&2
+  exit 1
+fi
+
+printf 'tt_codex_snapshot_test=passed\n'

--- a/tests/tt-recovery-test.sh
+++ b/tests/tt-recovery-test.sh
@@ -5,26 +5,27 @@ repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 tt="$repo/bin/tt"
 temporary="$(mktemp -d)"
 trap 'rm -rf "$temporary"' EXIT
-recovery_section="$(awk '
+recovery_section="$temporary/recovery-section.sh"
+awk '
   /^tmux_server_running\(\)/ { in_recovery = 1 }
   /^reset_to_profile\(\)/ { in_recovery = 0 }
   in_recovery { print }
-' "$tt")"
+' "$tt" >"$recovery_section"
 
 bash -n "$tt"
 
-if grep -Eq '(^|[^[:alnum:]_])(kill-server|kill_server|kill-session|kill_session)([^[:alnum:]_]|$)' <<<"$recovery_section"; then
+if grep -Eq '(^|[^[:alnum:]_])(kill-server|kill_server|kill-session|kill_session)([^[:alnum:]_]|$)' "$recovery_section"; then
   printf 'recovery code must not delete the tmux server or a session\n' >&2
   exit 1
 fi
 
-grep -Fq 'require_recovery_session_absent "$session" || exit 2' <<<"$recovery_section"
-grep -Fq 'require_recovery_session_absent "ops" || exit 2' <<<"$recovery_section"
-grep -Fq 'require_recovery_manifest_sessions_absent "$manifest" || exit 2' <<<"$recovery_section"
-grep -Fq 'restore_cockpit_snapshot "$snapshot" "$session" --preserve-server' <<<"$recovery_section"
-grep -Fq 'restore_agent_cockpit_layouts "$manifest"' <<<"$recovery_section"
-grep -Fq 'create_ops_detached "$session" "$HOME" --no-shell-upgrade "$preserve_server" --recovery-session' <<<"$recovery_section"
-grep -Fq 'create_agent_cockpit_sessions "$manifest" "$preserve_server" --recovery-session' <<<"$recovery_section"
+grep -Fq 'require_recovery_session_absent "$session" || exit 2' "$recovery_section"
+grep -Fq 'require_recovery_session_absent "ops" || exit 2' "$recovery_section"
+grep -Fq 'require_recovery_manifest_sessions_absent "$manifest" || exit 2' "$recovery_section"
+grep -Fq 'restore_cockpit_snapshot "$snapshot" "$session" --preserve-server' "$recovery_section"
+grep -Fq 'restore_agent_cockpit_layouts "$manifest"' "$recovery_section"
+grep -Fq 'create_ops_detached "$session" "$HOME" --no-shell-upgrade "$preserve_server" --recovery-session' "$recovery_section"
+grep -Fq 'create_agent_cockpit_sessions "$manifest" "$preserve_server" --recovery-session' "$recovery_section"
 grep -Fq 'set_recovery_session_indices "$session" "$window_id"' "$tt"
 grep -Fq 'recovery_pane_target "$session" 1 "$pane"' "$tt"
 
@@ -34,52 +35,7 @@ snapshot="$temporary/cockpit.tsv"
 
 # Model a live server whose first pane was created at base index 0. Recovery
 # must move its first window to :1 and map logical snapshot pane 1 to %1.
-cat >"$fake_tmux" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-
-printf '%s\n' "$*" >>"$TT_TEST_TMUX_LOG"
-
-command="${1:-}"
-case "$command" in
-  list-sessions)
-    if [[ "${TT_TEST_TMUX_SERVER_RUNNING:-}" == "1" ]]; then
-      printf 'unrelated: 1 windows\n'
-    else
-      exit 1
-    fi
-    ;;
-  has-session)
-    if [[ "${TT_TEST_TMUX_EXISTING_SESSION:-}" == "${*: -1}" ]]; then
-      exit 0
-    fi
-    exit 1
-    ;;
-  new-session)
-    if [[ " $* " == *" -P "* ]]; then
-      printf '@1\n'
-    fi
-    ;;
-  list-windows)
-    if [[ " $* " == *" #{window_index}"* ]]; then
-      printf '1\t@1\n'
-    elif [[ " $* " == *" #{window_id}"* ]]; then
-      printf '@1\n'
-    fi
-    ;;
-  list-panes)
-    if [[ " $* " == *" #{pane_index}"* ]]; then
-      printf '0\t%%1\n'
-    elif [[ " $* " == *" #{pane_current_command} "* ]]; then
-      printf 'zsh\n'
-    elif [[ " $* " == *" #{pane_id} "* ]]; then
-      printf '%%1\n'
-    else
-      printf '0: [80x24]\n'
-    fi
-    ;;
-esac
-EOF
+cp "$repo/tests/fixtures/tt-recovery/tmux" "$fake_tmux"
 chmod +x "$fake_tmux"
 
 printf 'cockpit:1.1\tcodex\t%s\tL1.1\tcodex\tfake-session\texact\tfake-session\n' "$temporary" >"$snapshot"


### PR DESCRIPTION
## Summary
- move Codex cockpit collection into a bounded writer process
- serialize host-local writers and preserve the prior snapshot on collection failure
- atomically publish current and history snapshots

## Verification
- `bash tests/tt-codex-snapshot-test.sh`
- `bash tests/tt-codex-snapshot-live-test.sh`
- `bash tests/tt-recovery-test.sh`