### PR TITLE
fix(shell): keep GitHub auth out of startup

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -34,11 +34,6 @@ if [[ -r "$DOTFILES_ENV" ]]; then
 fi
 unset DOTFILES_ENV
 
-# Codex GitHub integrations reuse the authenticated CLI token without persisting it.
-if [[ -z "${GITHUB_PAT_TOKEN:-}" ]] && command -v gh >/dev/null 2>&1; then
-	export GITHUB_PAT_TOKEN="$(gh auth token 2>/dev/null)"
-fi
-
 # Interactive shells should not inherit agent/no-color defaults. They break TUIs
 # like Codex, especially when launched directly instead of through wrappers.
 if [[ "${DOTFILES_PRESERVE_NO_COLOR:-0}" != "1" ]]; then

--- a/bin/codex
+++ b/bin/codex
@@ -53,15 +53,14 @@ fi
 
 if [[ -z "${GITHUB_PAT_TOKEN:-}" ]]; then
   token=""
-  if command -v ghx >/dev/null 2>&1; then
-    token="$(ghx auth token 2>/dev/null || true)"
-  elif command -v gh >/dev/null 2>&1; then
-    token="$(gh auth token 2>/dev/null || true)"
+  gh_bin="$(PATH="$lookup_path" command -v gh || true)"
+  if [[ -n "$gh_bin" && -x "$gh_bin" ]]; then
+    token="$("$gh_bin" auth token 2>/dev/null || true)"
   fi
   if [[ -n "$token" ]]; then
     export GITHUB_PAT_TOKEN="$token"
   fi
-  unset token
+  unset gh_bin token
 fi
 
 exec "$real_codex" "$@"

--- a/bin/gh
+++ b/bin/gh
@@ -3,20 +3,34 @@
 set -euo pipefail
 
 wrapper_dir="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+lookup_path=""
+IFS=: read -r -a path_entries <<< "${PATH:-}"
+for path_entry in "${path_entries[@]}"; do
+  path_entry="${path_entry:-.}"
+  if [[ -d "$path_entry" ]] && [[ "$(cd -P -- "$path_entry" && pwd)" == "$wrapper_dir" ]]; then
+    continue
+  fi
+  lookup_path+="${lookup_path:+:}$path_entry"
+done
+gh_bin="$(PATH="$lookup_path" command -v gh || true)"
+
+run_native_gh() {
+  if [[ -z "$gh_bin" || ! -x "$gh_bin" ]]; then
+    printf 'gh: GitHub CLI is not installed\n' >&2
+    exit 127
+  fi
+  exec env NO_COLOR=1 CLICOLOR=0 CLICOLOR_FORCE=0 GH_FORCE_TTY=0 "$gh_bin" "$@"
+}
+
+# Authentication may prompt, read credentials, or consult the keychain. Keep it
+# out of ghx's daemon protocol and its IPC timeout entirely.
+if [[ "${1:-}" == "auth" ]]; then
+  run_native_gh "$@"
+fi
 
 # API consumers need byte-clean JSON. ghx's cache renderer colorizes object
 # responses, which breaks jq and ClawSweeper's line-oriented parsers.
 if [[ "${1:-}" == "api" ]]; then
-  lookup_path=""
-  IFS=: read -r -a path_entries <<< "${PATH:-}"
-  for path_entry in "${path_entries[@]}"; do
-    path_entry="${path_entry:-.}"
-    if [[ -d "$path_entry" ]] && [[ "$(cd -P -- "$path_entry" && pwd)" == "$wrapper_dir" ]]; then
-      continue
-    fi
-    lookup_path+="${lookup_path:+:}$path_entry"
-  done
-  gh_bin="$(PATH="$lookup_path" command -v gh || true)"
   if [[ -n "$gh_bin" && -x "$gh_bin" ]]; then
     jq_expression=""
     for ((index = 1; index < $#; index += 1)); do
@@ -35,7 +49,7 @@ if [[ "${1:-}" == "api" ]]; then
       exit "${PIPESTATUS[0]}"
     fi
 
-    exec env NO_COLOR=1 CLICOLOR=0 CLICOLOR_FORCE=0 GH_FORCE_TTY=0 "$gh_bin" "$@"
+    run_native_gh "$@"
   fi
 fi
 

--- a/bin/ghx
+++ b/bin/ghx
@@ -16,6 +16,14 @@ done
 ghx_bin="$(PATH="$lookup_path" command -v ghx || true)"
 gh_bin="$(PATH="$lookup_path" command -v gh || true)"
 
+run_native_gh() {
+  if [[ -z "$gh_bin" || ! -x "$gh_bin" ]]; then
+    printf 'ghx: command requires the real GitHub CLI\n' >&2
+    exit 127
+  fi
+  exec env NO_COLOR=1 CLICOLOR=0 CLICOLOR_FORCE=0 GH_FORCE_TTY=0 "$gh_bin" "$@"
+}
+
 uses_stdin_payload() {
   local arg
   for arg in "$@"; do
@@ -28,14 +36,16 @@ uses_stdin_payload() {
   return 1
 }
 
+# Authentication may prompt, read credentials, or consult the keychain. Keep it
+# out of ghx's daemon protocol and its IPC timeout entirely.
+if [[ "${1:-}" == "auth" ]]; then
+  run_native_gh "$@"
+fi
+
 # ghx's daemon protocol forwards argv, cwd, and output, but not stdin. Sending
 # stdin-backed mutations through it can turn a valid payload into an empty one.
 if uses_stdin_payload "$@"; then
-  if [[ -z "$gh_bin" || ! -x "$gh_bin" ]]; then
-    printf 'ghx: stdin-backed commands require the real GitHub CLI\n' >&2
-    exit 127
-  fi
-  exec env NO_COLOR=1 CLICOLOR=0 CLICOLOR_FORCE=0 GH_FORCE_TTY=0 "$gh_bin" "$@"
+  run_native_gh "$@"
 fi
 
 if [[ -n "$ghx_bin" && -x "$ghx_bin" ]]; then
@@ -51,4 +61,4 @@ if [[ -z "$gh_bin" || ! -x "$gh_bin" ]]; then
   exit 127
 fi
 
-exec env NO_COLOR=1 CLICOLOR=0 CLICOLOR_FORCE=0 GH_FORCE_TTY=0 "$gh_bin" "$@"
+run_native_gh "$@"

--- a/tests/codex-wrapper-test.sh
+++ b/tests/codex-wrapper-test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+temporary="$(mktemp -d)"
+trap 'rm -rf "$temporary"' EXIT
+
+wrapper_dir="$temporary/wrapper"
+backend_dir="$temporary/backend"
+mkdir -p "$wrapper_dir" "$backend_dir"
+cp "$repo_root/bin/codex" "$wrapper_dir/codex"
+
+cat >"$backend_dir/uname" <<'EOF'
+#!/usr/bin/env bash
+printf 'TestOS\n'
+EOF
+
+cat >"$backend_dir/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "auth token" ]]; then
+  printf 'native-token\n'
+  exit 0
+fi
+exit 64
+EOF
+
+cat >"$backend_dir/ghx" <<'EOF'
+#!/usr/bin/env bash
+printf 'ghx must not be called\n' >&2
+exit 65
+EOF
+
+cat >"$backend_dir/codex" <<'EOF'
+#!/usr/bin/env bash
+printf 'version:%s\n' "$*"
+if [[ "${GITHUB_PAT_TOKEN:-}" == "native-token" ]]; then
+  printf 'token:injected\n'
+else
+  printf 'token:missing\n'
+  exit 66
+fi
+EOF
+
+chmod +x "$wrapper_dir/codex" "$backend_dir/uname" "$backend_dir/gh" "$backend_dir/ghx" "$backend_dir/codex"
+
+output="$(env -u GITHUB_PAT_TOKEN PATH="$wrapper_dir:$backend_dir:/usr/bin:/bin" "$wrapper_dir/codex" --version)"
+grep -Fq 'version:--version' <<<"$output"
+grep -Fq 'token:injected' <<<"$output"
+
+if grep -Fq 'gh auth token' "$repo_root/.zshrc"; then
+  printf '.zshrc must not fetch GitHub credentials during startup\n' >&2
+  exit 1
+fi
+
+printf 'codex wrapper tests passed\n'

--- a/tests/ghx-test.sh
+++ b/tests/ghx-test.sh
@@ -9,6 +9,7 @@ wrapper_dir="$temporary/wrapper"
 backend_dir="$temporary/backend"
 mkdir -p "$wrapper_dir" "$backend_dir"
 cp "$repo_root/bin/ghx" "$wrapper_dir/ghx"
+cp "$repo_root/bin/gh" "$wrapper_dir/gh"
 
 cat >"$backend_dir/ghx" <<'EOF'
 #!/usr/bin/env bash
@@ -22,11 +23,29 @@ printf 'gh:%s\n' "$*"
 cat
 EOF
 
-chmod +x "$wrapper_dir/ghx" "$backend_dir/ghx" "$backend_dir/gh"
+chmod +x "$wrapper_dir/ghx" "$wrapper_dir/gh" "$backend_dir/ghx" "$backend_dir/gh"
 
 normal_output="$(PATH="$wrapper_dir:$backend_dir:/usr/bin:/bin" "$wrapper_dir/ghx" pr view 123)"
 grep -Fq 'ghx:pr view 123' <<<"$normal_output"
 grep -Fq "backend:$backend_dir/gh" <<<"$normal_output"
+
+gh_normal_output="$(PATH="$wrapper_dir:$backend_dir:/usr/bin:/bin" "$wrapper_dir/gh" pr view 456)"
+grep -Fq 'ghx:pr view 456' <<<"$gh_normal_output"
+grep -Fq "backend:$backend_dir/gh" <<<"$gh_normal_output"
+
+auth_output="$(PATH="$wrapper_dir:$backend_dir:/usr/bin:/bin" "$wrapper_dir/ghx" auth token)"
+grep -Fq 'gh:auth token' <<<"$auth_output"
+if grep -Fq 'ghx:' <<<"$auth_output"; then
+  printf 'ghx auth command unexpectedly used the ghx backend\n' >&2
+  exit 1
+fi
+
+gh_auth_output="$(PATH="$wrapper_dir:$backend_dir:/usr/bin:/bin" "$wrapper_dir/gh" auth status)"
+grep -Fq 'gh:auth status' <<<"$gh_auth_output"
+if grep -Fq 'ghx:' <<<"$gh_auth_output"; then
+  printf 'gh auth command unexpectedly used the ghx backend\n' >&2
+  exit 1
+fi
 
 stdin_output="$(printf 'preserved body' | PATH="$wrapper_dir:$backend_dir:/usr/bin:/bin" "$wrapper_dir/ghx" pr edit 123 --body-file -)"
 grep -Fq 'gh:pr edit 123 --body-file -' <<<"$stdin_output"


### PR DESCRIPTION
## Summary

- stop interactive zsh startup from synchronously fetching a GitHub token
- route all `gh auth` and `ghx auth` commands directly to the native GitHub CLI
- let the Codex launcher inject GitHub auth from native `gh` without entering ghx IPC
- cover auth bypass, normal caching, stdin preservation, and Codex token injection

## Verification

- `bash -n bin/codex bin/gh bin/ghx tests/ghx-test.sh tests/codex-wrapper-test.sh`
- `zsh -n .zshrc`
- `shellcheck bin/codex bin/gh bin/ghx tests/ghx-test.sh tests/codex-wrapper-test.sh`
- `./tests/ghx-test.sh`
- `./tests/codex-wrapper-test.sh`
- five token-free Ghostty-style cold starts: 0.12-0.14s
- no new `ghxd` process during cold starts or Codex version verification
