### PR TITLE
fix(shell): avoid Bash PATH here-string deadlock

### DIFF
--- a/bin/codex
+++ b/bin/codex
@@ -26,14 +26,26 @@ case "$(uname -s)" in
 esac
 
 lookup_path=""
-IFS=: read -r -a path_entries <<< "${PATH:-}"
-for path_entry in "${path_entries[@]}"; do
+path_remaining="${PATH:-}"
+path_done=""
+while :; do
+  case "$path_remaining" in
+    *:*)
+      path_entry="${path_remaining%%:*}"
+      path_remaining="${path_remaining#*:}"
+      ;;
+    *)
+      path_entry="$path_remaining"
+      path_done=1
+      ;;
+  esac
   path_entry="${path_entry:-.}"
-  if [[ -d "$path_entry" ]] && [[ "$(cd -P -- "$path_entry" && pwd)" == "$wrapper_dir" ]]; then
-    continue
+  if [[ ! -d "$path_entry" || ! "$path_entry" -ef "$wrapper_dir" ]]; then
+    lookup_path+="${lookup_path:+:}$path_entry"
   fi
-  lookup_path+="${lookup_path:+:}$path_entry"
+  [[ -z "${path_done:-}" ]] || break
 done
+unset path_done path_entry path_remaining
 
 if [[ -z "$real_codex" ]]; then
   real_codex="$(PATH="$lookup_path" command -v codex || true)"

--- a/bin/gh
+++ b/bin/gh
@@ -4,14 +4,26 @@ set -euo pipefail
 
 wrapper_dir="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 lookup_path=""
-IFS=: read -r -a path_entries <<< "${PATH:-}"
-for path_entry in "${path_entries[@]}"; do
+path_remaining="${PATH:-}"
+path_done=""
+while :; do
+  case "$path_remaining" in
+    *:*)
+      path_entry="${path_remaining%%:*}"
+      path_remaining="${path_remaining#*:}"
+      ;;
+    *)
+      path_entry="$path_remaining"
+      path_done=1
+      ;;
+  esac
   path_entry="${path_entry:-.}"
-  if [[ -d "$path_entry" ]] && [[ "$(cd -P -- "$path_entry" && pwd)" == "$wrapper_dir" ]]; then
-    continue
+  if [[ ! -d "$path_entry" || ! "$path_entry" -ef "$wrapper_dir" ]]; then
+    lookup_path+="${lookup_path:+:}$path_entry"
   fi
-  lookup_path+="${lookup_path:+:}$path_entry"
+  [[ -z "${path_done:-}" ]] || break
 done
+unset path_done path_entry path_remaining
 gh_bin="$(PATH="$lookup_path" command -v gh || true)"
 
 run_native_gh() {

--- a/bin/ghx
+++ b/bin/ghx
@@ -3,15 +3,26 @@ set -euo pipefail
 
 wrapper_dir="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 lookup_path=""
-IFS=: read -r -a path_entries <<< "${PATH:-}"
-
-for path_entry in "${path_entries[@]}"; do
+path_remaining="${PATH:-}"
+path_done=""
+while :; do
+  case "$path_remaining" in
+    *:*)
+      path_entry="${path_remaining%%:*}"
+      path_remaining="${path_remaining#*:}"
+      ;;
+    *)
+      path_entry="$path_remaining"
+      path_done=1
+      ;;
+  esac
   path_entry="${path_entry:-.}"
-  if [[ -d "$path_entry" ]] && [[ "$(cd -P -- "$path_entry" && pwd)" == "$wrapper_dir" ]]; then
-    continue
+  if [[ ! -d "$path_entry" || ! "$path_entry" -ef "$wrapper_dir" ]]; then
+    lookup_path+="${lookup_path:+:}$path_entry"
   fi
-  lookup_path+="${lookup_path:+:}$path_entry"
+  [[ -z "${path_done:-}" ]] || break
 done
+unset path_done path_entry path_remaining
 
 ghx_bin="$(PATH="$lookup_path" command -v ghx || true)"
 gh_bin="$(PATH="$lookup_path" command -v gh || true)"

--- a/tests/codex-wrapper-test.sh
+++ b/tests/codex-wrapper-test.sh
@@ -7,7 +7,9 @@ trap 'rm -rf "$temporary"' EXIT
 
 wrapper_dir="$temporary/wrapper"
 backend_dir="$temporary/backend"
+symlink_dir="$temporary/symlink-bin"
 mkdir -p "$wrapper_dir" "$backend_dir"
+ln -s "$wrapper_dir" "$symlink_dir"
 cp "$repo_root/bin/codex" "$wrapper_dir/codex"
 
 cat >"$backend_dir/uname" <<'EOF'
@@ -43,9 +45,21 @@ EOF
 
 chmod +x "$wrapper_dir/codex" "$backend_dir/uname" "$backend_dir/gh" "$backend_dir/ghx" "$backend_dir/codex"
 
-output="$(env -u GITHUB_PAT_TOKEN PATH="$wrapper_dir:$backend_dir:/usr/bin:/bin" "$wrapper_dir/codex" --version)"
-grep -Fq 'version:--version' <<<"$output"
-grep -Fq 'token:injected' <<<"$output"
+long_path="$symlink_dir"
+path_entry_count=1
+for index in {1..41}; do
+  filler="$temporary/filler-$index-with-a-deliberately-long-path-segment"
+  mkdir -p "$filler"
+  long_path="$long_path:$filler"
+  path_entry_count=$((path_entry_count + 1))
+done
+long_path="$long_path:$backend_dir:/usr/bin:/bin"
+path_entry_count=$((path_entry_count + 3))
+[[ "$path_entry_count" -eq 45 ]]
+
+output="$(env -u GITHUB_PAT_TOKEN PATH="$long_path" "$symlink_dir/codex" --version)"
+[[ "$output" == *"version:--version"* ]]
+[[ "$output" == *"token:injected"* ]]
 
 if grep -Fq 'gh auth token' "$repo_root/.zshrc"; then
   printf '.zshrc must not fetch GitHub credentials during startup\n' >&2

--- a/tests/ghx-test.sh
+++ b/tests/ghx-test.sh
@@ -7,7 +7,9 @@ trap 'rm -rf "$temporary"' EXIT
 
 wrapper_dir="$temporary/wrapper"
 backend_dir="$temporary/backend"
+symlink_dir="$temporary/symlink-bin"
 mkdir -p "$wrapper_dir" "$backend_dir"
+ln -s "$wrapper_dir" "$symlink_dir"
 cp "$repo_root/bin/ghx" "$wrapper_dir/ghx"
 cp "$repo_root/bin/gh" "$wrapper_dir/gh"
 
@@ -25,38 +27,50 @@ EOF
 
 chmod +x "$wrapper_dir/ghx" "$wrapper_dir/gh" "$backend_dir/ghx" "$backend_dir/gh"
 
-normal_output="$(PATH="$wrapper_dir:$backend_dir:/usr/bin:/bin" "$wrapper_dir/ghx" pr view 123)"
-grep -Fq 'ghx:pr view 123' <<<"$normal_output"
-grep -Fq "backend:$backend_dir/gh" <<<"$normal_output"
+long_path="$symlink_dir"
+path_entry_count=1
+for index in {1..41}; do
+  filler="$temporary/filler-$index-with-a-deliberately-long-path-segment"
+  mkdir -p "$filler"
+  long_path="$long_path:$filler"
+  path_entry_count=$((path_entry_count + 1))
+done
+long_path="$long_path:$backend_dir:/usr/bin:/bin"
+path_entry_count=$((path_entry_count + 3))
+[[ "$path_entry_count" -eq 45 ]]
 
-gh_normal_output="$(PATH="$wrapper_dir:$backend_dir:/usr/bin:/bin" "$wrapper_dir/gh" pr view 456)"
-grep -Fq 'ghx:pr view 456' <<<"$gh_normal_output"
-grep -Fq "backend:$backend_dir/gh" <<<"$gh_normal_output"
+normal_output="$(PATH="$long_path" "$symlink_dir/ghx" pr view 123)"
+[[ "$normal_output" == *"ghx:pr view 123"* ]]
+[[ "$normal_output" == *"backend:$backend_dir/gh"* ]]
 
-auth_output="$(PATH="$wrapper_dir:$backend_dir:/usr/bin:/bin" "$wrapper_dir/ghx" auth token)"
-grep -Fq 'gh:auth token' <<<"$auth_output"
-if grep -Fq 'ghx:' <<<"$auth_output"; then
+gh_normal_output="$(PATH="$long_path" "$symlink_dir/gh" pr view 456)"
+[[ "$gh_normal_output" == *"ghx:pr view 456"* ]]
+[[ "$gh_normal_output" == *"backend:$backend_dir/gh"* ]]
+
+auth_output="$(PATH="$long_path" "$symlink_dir/ghx" auth token)"
+[[ "$auth_output" == *"gh:auth token"* ]]
+if [[ "$auth_output" == *"ghx:"* ]]; then
   printf 'ghx auth command unexpectedly used the ghx backend\n' >&2
   exit 1
 fi
 
-gh_auth_output="$(PATH="$wrapper_dir:$backend_dir:/usr/bin:/bin" "$wrapper_dir/gh" auth status)"
-grep -Fq 'gh:auth status' <<<"$gh_auth_output"
-if grep -Fq 'ghx:' <<<"$gh_auth_output"; then
+gh_auth_output="$(PATH="$long_path" "$symlink_dir/gh" auth status)"
+[[ "$gh_auth_output" == *"gh:auth status"* ]]
+if [[ "$gh_auth_output" == *"ghx:"* ]]; then
   printf 'gh auth command unexpectedly used the ghx backend\n' >&2
   exit 1
 fi
 
-stdin_output="$(printf 'preserved body' | PATH="$wrapper_dir:$backend_dir:/usr/bin:/bin" "$wrapper_dir/ghx" pr edit 123 --body-file -)"
-grep -Fq 'gh:pr edit 123 --body-file -' <<<"$stdin_output"
-grep -Fq 'preserved body' <<<"$stdin_output"
-if grep -Fq 'ghx:' <<<"$stdin_output"; then
+stdin_output="$(printf 'preserved body' | PATH="$long_path" "$symlink_dir/ghx" pr edit 123 --body-file -)"
+[[ "$stdin_output" == *"gh:pr edit 123 --body-file -"* ]]
+[[ "$stdin_output" == *"preserved body"* ]]
+if [[ "$stdin_output" == *"ghx:"* ]]; then
   printf 'stdin-backed command unexpectedly used ghx\n' >&2
   exit 1
 fi
 
-token_output="$(printf 'token-value' | PATH="$wrapper_dir:$backend_dir:/usr/bin:/bin" "$wrapper_dir/ghx" auth login --with-token)"
-grep -Fq 'gh:auth login --with-token' <<<"$token_output"
-grep -Fq 'token-value' <<<"$token_output"
+token_output="$(printf 'token-value' | PATH="$long_path" "$symlink_dir/ghx" auth login --with-token)"
+[[ "$token_output" == *"gh:auth login --with-token"* ]]
+[[ "$token_output" == *"token-value"* ]]
 
 printf 'ghx wrapper tests passed\n'


### PR DESCRIPTION
## Summary

- replace wrapper PATH here-string parsing with pure Bash parameter expansion
- compare PATH entries to the wrapper directory with `-ef`, including symlinked installs
- cover all wrappers with a symlinked 45-entry PATH under both supported macOS Bash versions

## Verification

- Homebrew Bash 5.3.12 syntax and focused wrapper tests
- Apple Bash 3.2.57 syntax and focused wrapper tests
- `shellcheck bin/codex bin/gh bin/ghx tests/ghx-test.sh tests/codex-wrapper-test.sh`
- live native auth and Codex version checks with a 45-entry PATH
- five token-free Ghostty-style cold starts: 0.13-0.25s
- no new `ghxd` process during validation
