### PR TITLE
fix(gwt): scope cleanup to registered worktrees

### DIFF
--- a/Library/LaunchAgents/com.vincentkoc.agent-worktree-ops.plist
+++ b/Library/LaunchAgents/com.vincentkoc.agent-worktree-ops.plist
@@ -10,7 +10,7 @@
     <string>/usr/bin/nice</string>
     <string>-n</string>
     <string>20</string>
-    <string>/Users/vincentkoc/Library/Application Support/agent-worktree-ops/agent-worktree-maintain</string>
+    <string>__AGENT_WORKTREE_MAINTAIN__</string>
   </array>
 
   <key>StartInterval</key>

--- a/bin/agent-worktree-ops/README.md
+++ b/bin/agent-worktree-ops/README.md
@@ -16,7 +16,7 @@ Bins in this folder:
   - background purge of entries left in the legacy quarantine directory
 - `install-agent-worktree-ops`
   - atomically install runtime copies, render a machine-local plist, and reload launchd
-  - pass `--install-only` to leave the LaunchAgent unloaded
+  - pass `--install-only` to install and ensure the LaunchAgent is unloaded
 
 Neither audit nor apply mode prunes Git worktree metadata. Use explicit
 `git worktree prune` or `gwt prune` only after reviewing stale registrations.

--- a/bin/agent-worktree-ops/README.md
+++ b/bin/agent-worktree-ops/README.md
@@ -6,9 +6,17 @@ Bins in this folder:
 
 - `agent-worktree-clean`
   - dry-run/apply cleanup of idle worktrees and stale artifacts
+  - only registered, non-main worktrees from the selected Git common dir are actionable
+  - foreign, unregistered, non-Git, and stale-registration paths are report-only
+  - apply mode revalidates dirtiness, reachability, sessions, tmux panes, and process CWDs
+  - removals are serial, non-force `git worktree remove` operations
 - `agent-worktree-maintain`
-  - pressure-aware maintenance runner for launchd/manual use
+  - pressure-aware maintenance runner using the cleaner's registered inventory
 - `agent-worktree-purge`
-  - background purge of quarantined worktrees
+  - background purge of entries left in the legacy quarantine directory
 - `install-agent-worktree-ops`
-  - install runtime copies and reload launchd
+  - atomically install runtime copies, render a machine-local plist, and reload launchd
+  - pass `--install-only` to leave the LaunchAgent unloaded
+
+Neither audit nor apply mode prunes Git worktree metadata. Use explicit
+`git worktree prune` or `gwt prune` only after reviewing stale registrations.

--- a/bin/agent-worktree-ops/agent-worktree-clean
+++ b/bin/agent-worktree-ops/agent-worktree-clean
@@ -2,12 +2,10 @@
 
 import argparse
 import os
-import shutil
 import sqlite3
 import subprocess
 import sys
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -34,6 +32,22 @@ class Worktree:
     branch_ref: Optional[str]
     detached: bool
     age_days: float
+    locked: bool = False
+
+
+@dataclass(frozen=True)
+class ReportOnlyPath:
+    path: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class Inventory:
+    repo_root: str
+    common_dir: str
+    main_path: str
+    worktrees: list[Worktree]
+    report_only: list[ReportOnlyPath]
 
 
 def parse_args() -> argparse.Namespace:
@@ -102,6 +116,11 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="shared repo node_modules directory to symlink stale worktrees back to",
     )
+    parser.add_argument(
+        "--list-registered",
+        action="store_true",
+        help="print registered non-main worktree paths and exit",
+    )
     return parser.parse_args()
 
 
@@ -159,17 +178,17 @@ def main() -> int:
     args = parse_args()
     repo_root = normalize_path(resolve_repo_root(args.repo))
     codex_home = normalize_path(args.codex_home)
-    codex_worktrees_root = normalize_path(os.path.join(codex_home, "worktrees"))
-    repo_slug = resolve_repo_slug(repo_root)
-    codex_repo_root = normalize_path(os.path.join(codex_worktrees_root, repo_slug))
     quarantine_root = normalize_path(args.quarantine_root)
     shared_node_modules_source = normalize_path(
         args.shared_node_modules_source or os.path.join(repo_root, "node_modules")
     )
-    run(["git", "-C", repo_root, "worktree", "prune", "--expire", "now"])
-    codex_repo_worktrees = discover_directory_worktrees(codex_repo_root)
-    local_repo_worktrees = discover_local_repo_worktrees(repo_root)
-    managed_worktrees = dedupe_worktrees([*codex_repo_worktrees, *local_repo_worktrees])
+    inventory = build_inventory(repo_root, codex_home)
+    managed_worktrees = inventory.worktrees
+    if args.list_registered:
+        for worktree in managed_worktrees:
+            print(worktree.path)
+        return 0
+
     state_db = find_latest_state_db(codex_home)
     recent_session_cwds = (
         read_recent_session_cwds(
@@ -183,7 +202,7 @@ def main() -> int:
         else []
     )
     keep_paths = select_session_backed_worktrees(managed_worktrees, recent_session_cwds)
-    busy_paths = collect_busy_worktree_paths(managed_worktrees)
+    busy_paths = collect_owned_worktree_paths(managed_worktrees)
     dirty_candidates = [
         worktree
         for worktree in managed_worktrees
@@ -215,12 +234,19 @@ def main() -> int:
         if worktree.path in busy_paths:
             kept_for_safety.append((worktree, "busy"))
             continue
+        if worktree.locked:
+            kept_for_safety.append((worktree, "locked"))
+            continue
         if worktree.detached and not args.include_detached:
             if worktree.age_days >= args.trim_artifacts_age_days:
                 trimmable.append(worktree)
                 kept_for_safety.append((worktree, "detached-trim-only"))
             else:
                 kept_for_safety.append((worktree, "detached"))
+            continue
+        reachability_reason = unsafe_reachability_reason(worktree)
+        if reachability_reason:
+            kept_for_safety.append((worktree, reachability_reason))
             continue
         if worktree.age_days >= args.min_age_days:
             removable.append(worktree)
@@ -236,8 +262,10 @@ def main() -> int:
 
     print_summary(
         repo_root=repo_root,
+        common_dir=inventory.common_dir,
         state_db=state_db,
         managed_worktrees=managed_worktrees,
+        report_only=inventory.report_only,
         recent_session_cwds=recent_session_cwds,
         kept_by_session=kept_by_session,
         kept_for_safety=kept_for_safety,
@@ -253,23 +281,18 @@ def main() -> int:
     if not args.apply:
         return 0
 
-    with progress_bar(total=len(trimmable), desc="trimming artifacts") as progress:
-        with ThreadPoolExecutor(max_workers=args.delete_workers) as executor:
-            futures = [
-                executor.submit(trim_worktree_artifacts, worktree.path, shared_node_modules_source)
-                for worktree in trimmable
-            ]
-            for future in as_completed(futures):
-                future.result()
-                progress.update(1)
-
-    with progress_bar(total=len(removable), desc="quarantining worktrees") as progress:
-        with ThreadPoolExecutor(max_workers=args.delete_workers) as executor:
-            futures = [executor.submit(quarantine_worktree_tree, worktree.path, quarantine_root) for worktree in removable]
-            for future in as_completed(futures):
-                future.result()
-                progress.update(1)
-    run(["git", "-C", repo_root, "worktree", "prune", "--expire", "now"])
+    apply_trims(
+        repo_root=repo_root,
+        codex_home=codex_home,
+        candidates=trimmable,
+        shared_node_modules_source=shared_node_modules_source,
+    )
+    apply_removals(
+        repo_root=repo_root,
+        codex_home=codex_home,
+        candidates=removable,
+        include_detached=args.include_detached,
+    )
     spawn_async_purge(
         codex_home=codex_home,
         quarantine_root=quarantine_root,
@@ -314,6 +337,7 @@ def parse_git_worktrees(porcelain: str) -> list[Worktree]:
                 "branch_ref": None,
                 "detached": False,
                 "age_days": compute_path_age_days(normalize_path(line.removeprefix("worktree "))),
+                "locked": False,
             }
             continue
         if current is None:
@@ -324,6 +348,8 @@ def parse_git_worktrees(porcelain: str) -> list[Worktree]:
             current["branch_ref"] = line.removeprefix("branch ")
         elif line == "detached":
             current["detached"] = True
+        elif line == "locked" or line.startswith("locked "):
+            current["locked"] = True
 
     if current:
         worktrees.append(to_worktree(current))
@@ -370,86 +396,97 @@ def slug_from_origin(origin: str) -> str:
     return slug or ""
 
 
-def discover_directory_worktrees(root_path: str) -> list[Worktree]:
-    worktrees: list[Worktree] = []
-    if not path_is_dir(root_path):
-        return worktrees
-    for entry in Path(root_path).iterdir():
-        if not entry.is_dir():
+def build_inventory(repo_root: str, codex_home: str) -> Inventory:
+    repo_root = normalize_path(repo_root)
+    common_dir = resolve_common_dir(repo_root)
+    registered = parse_git_worktrees(
+        run_text(["git", "-C", repo_root, "worktree", "list", "--porcelain"])
+    )
+    if not registered:
+        raise RuntimeError(f"no registered worktrees found for {repo_root}")
+
+    main_path = registered[0].path
+    registered_by_path = {worktree.path: worktree for worktree in registered}
+    report_only: list[ReportOnlyPath] = []
+    managed: list[Worktree] = []
+
+    for worktree in registered[1:]:
+        if not path_is_dir(worktree.path):
+            report_only.append(ReportOnlyPath(worktree.path, "stale-registration"))
             continue
-        worktree = inspect_directory_worktree(str(entry))
-        if worktree is not None:
-            worktrees.append(worktree)
-    return worktrees
+        candidate_common_dir = try_resolve_common_dir(worktree.path)
+        if candidate_common_dir != common_dir:
+            report_only.append(ReportOnlyPath(worktree.path, "registry-common-dir-mismatch"))
+            continue
+        managed.append(worktree)
+
+    for candidate_path in discover_candidate_directories(main_path, codex_home):
+        if candidate_path == main_path or candidate_path in registered_by_path:
+            continue
+        candidate_common_dir = try_resolve_common_dir(candidate_path)
+        if candidate_common_dir is None:
+            report_only.append(ReportOnlyPath(candidate_path, "non-git"))
+        elif candidate_common_dir != common_dir:
+            report_only.append(ReportOnlyPath(candidate_path, "foreign-common-dir"))
+        else:
+            report_only.append(ReportOnlyPath(candidate_path, "unregistered"))
+
+    return Inventory(
+        repo_root=repo_root,
+        common_dir=common_dir,
+        main_path=main_path,
+        worktrees=sorted(managed, key=lambda worktree: worktree.path),
+        report_only=dedupe_report_only(report_only),
+    )
 
 
-def discover_local_repo_worktrees(repo_root: str) -> list[Worktree]:
-    worktrees: list[Worktree] = []
-    for root_path in (
+def discover_candidate_directories(repo_root: str, codex_home: str) -> list[str]:
+    repo_slug = resolve_repo_slug(repo_root)
+    roots = [
+        os.path.join(codex_home, "worktrees", repo_slug),
         os.path.join(repo_root, ".claude", "worktrees"),
         os.path.join(repo_root, ".worktrees"),
-    ):
-        worktrees.extend(discover_directory_worktrees(root_path))
-    return worktrees
+    ]
+    candidates: list[str] = []
+    for root_path in roots:
+        root = Path(root_path)
+        if not root.is_dir():
+            continue
+        for entry in root.iterdir():
+            if entry.is_dir():
+                candidates.append(normalize_path(str(entry)))
+    return sorted(set(candidates))
 
 
-def inspect_directory_worktree(candidate_path: str) -> Optional[Worktree]:
-    normalized_path = normalize_path(candidate_path)
+def resolve_common_dir(repo_path: str) -> str:
     result = subprocess.run(
-        ["git", "-C", normalized_path, "rev-parse", "--is-inside-work-tree"],
+        ["git", "-C", repo_path, "rev-parse", "--path-format=absolute", "--git-common-dir"],
         stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
         text=True,
         check=False,
     )
-    if result.returncode != 0 or result.stdout.strip() != "true":
-        return Worktree(
-            path=normalized_path,
-            head="",
-            branch_ref=None,
-            detached=True,
-            age_days=compute_path_age_days(normalized_path),
-        )
+    if result.returncode == 0 and result.stdout.strip():
+        return normalize_path(result.stdout.strip())
 
-    head_result = subprocess.run(
-        ["git", "-C", normalized_path, "rev-parse", "HEAD"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        text=True,
-        check=False,
-    )
-    if head_result.returncode != 0:
+    common_dir = run_text(["git", "-C", repo_path, "rev-parse", "--git-common-dir"])
+    if os.path.isabs(common_dir):
+        return normalize_path(common_dir)
+    return normalize_path(os.path.join(repo_path, common_dir))
+
+
+def try_resolve_common_dir(repo_path: str) -> Optional[str]:
+    try:
+        return resolve_common_dir(repo_path)
+    except RuntimeError:
         return None
 
-    branch_result = subprocess.run(
-        ["git", "-C", normalized_path, "symbolic-ref", "--quiet", "--short", "HEAD"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        text=True,
-        check=False,
-    )
-    branch_ref = None
-    detached = True
-    if branch_result.returncode == 0:
-        branch_name = branch_result.stdout.strip()
-        if branch_name:
-            branch_ref = f"refs/heads/{branch_name}"
-            detached = False
 
-    return Worktree(
-        path=normalized_path,
-        head=head_result.stdout.strip(),
-        branch_ref=branch_ref,
-        detached=detached,
-        age_days=compute_path_age_days(normalized_path),
-    )
-
-
-def dedupe_worktrees(worktrees: list[Worktree]) -> list[Worktree]:
-    deduped: dict[str, Worktree] = {}
-    for worktree in worktrees:
-        deduped[worktree.path] = worktree
-    return list(deduped.values())
+def dedupe_report_only(paths: list[ReportOnlyPath]) -> list[ReportOnlyPath]:
+    deduped: dict[str, ReportOnlyPath] = {}
+    for item in paths:
+        deduped[item.path] = item
+    return [deduped[path] for path in sorted(deduped)]
 
 
 def to_worktree(raw: dict[str, object]) -> Worktree:
@@ -459,11 +496,15 @@ def to_worktree(raw: dict[str, object]) -> Worktree:
         branch_ref=str(raw["branch_ref"]) if raw["branch_ref"] else None,
         detached=bool(raw["detached"]),
         age_days=float(raw["age_days"]),
+        locked=bool(raw.get("locked", False)),
     )
 
 
 def compute_path_age_days(file_path: str) -> float:
-    stats = os.stat(file_path)
+    try:
+        stats = os.stat(file_path)
+    except FileNotFoundError:
+        return 0.0
     age_seconds = max(0.0, time.time() - stats.st_mtime)
     return age_seconds / 86400
 
@@ -530,23 +571,27 @@ def select_session_backed_worktrees(worktrees: list[Worktree], recent_session_cw
 
 
 def is_worktree_dirty(worktree_path: str) -> bool:
-    inside_repo_result = subprocess.run(
-        ["git", "-C", worktree_path, "rev-parse", "--is-inside-work-tree"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        text=True,
-        check=False,
+    status = run_text(
+        [
+            "git",
+            "-C",
+            worktree_path,
+            "status",
+            "--porcelain",
+            "--untracked-files=all",
+            "--ignore-submodules=none",
+        ]
     )
-    if inside_repo_result.returncode != 0 or inside_repo_result.stdout.strip() != "true":
-        return False
-    if has_changes(["git", "-C", worktree_path, "diff", "--quiet", "--ignore-submodules", "--"]):
-        return True
-    if has_changes(["git", "-C", worktree_path, "diff", "--cached", "--quiet", "--ignore-submodules", "--"]):
-        return True
-    return bool(run_text(["git", "-C", worktree_path, "ls-files", "--others", "--exclude-standard"]))
+    return bool(status)
 
 
-def collect_busy_worktree_paths(worktrees: list[Worktree]) -> set[str]:
+def collect_owned_worktree_paths(worktrees: list[Worktree]) -> set[str]:
+    return collect_lsof_worktree_paths(worktrees) | collect_tmux_worktree_paths(worktrees)
+
+
+def collect_lsof_worktree_paths(worktrees: list[Worktree]) -> set[str]:
+    if not shutil_which("lsof"):
+        raise RuntimeError("lsof is required to verify live worktree ownership")
     sorted_worktrees = sorted(worktrees, key=lambda worktree: len(worktree.path), reverse=True)
     result = subprocess.run(
         ["lsof", "-n", "-w", "-Ffn", "-a", "-d", "cwd"],
@@ -571,6 +616,128 @@ def collect_busy_worktree_paths(worktrees: list[Worktree]) -> set[str]:
     return busy_paths
 
 
+def collect_tmux_worktree_paths(worktrees: list[Worktree]) -> set[str]:
+    if not shutil_which("tmux"):
+        return set()
+    sorted_worktrees = sorted(worktrees, key=lambda worktree: len(worktree.path), reverse=True)
+    result = subprocess.run(
+        ["tmux", "list-panes", "-a", "-F", "#{pane_current_path}"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.strip().lower()
+        if "no server running" in stderr or "failed to connect to server" in stderr:
+            return set()
+        raise RuntimeError(result.stderr.strip() or "failed to inspect tmux worktree ownership")
+
+    busy_paths: set[str] = set()
+    for raw_path in result.stdout.splitlines():
+        if not raw_path.strip():
+            continue
+        cwd_path = normalize_path(raw_path.strip())
+        for worktree in sorted_worktrees:
+            if is_path_inside(worktree.path, cwd_path):
+                busy_paths.add(worktree.path)
+                break
+    return busy_paths
+
+
+def shutil_which(command: str) -> Optional[str]:
+    path = os.environ.get("PATH", os.defpath)
+    for directory in path.split(os.pathsep):
+        candidate = os.path.join(directory or ".", command)
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def unsafe_reachability_reason(worktree: Worktree) -> Optional[str]:
+    if worktree.detached:
+        if commit_reachable_from_other_ref(worktree, exclude_ref=None):
+            return None
+        return "detached-unreachable"
+
+    if not worktree.branch_ref:
+        return "unknown-branch"
+
+    branch_name = worktree.branch_ref.removeprefix("refs/heads/")
+    upstream_result = subprocess.run(
+        [
+            "git",
+            "-C",
+            worktree.path,
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{upstream}",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    if upstream_result.returncode == 0 and upstream_result.stdout.strip():
+        upstream = upstream_result.stdout.strip()
+        if is_ancestor(worktree.path, worktree.head, upstream):
+            return None
+        return "unmerged-upstream"
+
+    configured_remote = git_config(worktree.path, f"branch.{branch_name}.remote")
+    configured_merge = git_config(worktree.path, f"branch.{branch_name}.merge")
+    if configured_remote or configured_merge:
+        return "upstream-missing"
+
+    if commit_reachable_from_other_ref(worktree, exclude_ref=worktree.branch_ref):
+        return None
+    return "unreachable-no-upstream"
+
+
+def git_config(worktree_path: str, key: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", worktree_path, "config", "--get", key],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def is_ancestor(worktree_path: str, commit: str, ref: str) -> bool:
+    result = subprocess.run(
+        ["git", "-C", worktree_path, "merge-base", "--is-ancestor", commit, ref],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    raise RuntimeError(f"failed to compare {commit} with {ref} in {worktree_path}")
+
+
+def commit_reachable_from_other_ref(worktree: Worktree, exclude_ref: Optional[str]) -> bool:
+    refs = run_text(
+        [
+            "git",
+            "-C",
+            worktree.path,
+            "for-each-ref",
+            "--contains",
+            worktree.head,
+            "--format=%(refname)",
+            "refs/heads",
+            "refs/remotes",
+            "refs/tags",
+        ]
+    )
+    return any(ref and ref != exclude_ref for ref in refs.splitlines())
+
+
 def path_is_dir(raw_path: str) -> bool:
     return os.path.isdir(raw_path)
 
@@ -578,8 +745,10 @@ def path_is_dir(raw_path: str) -> bool:
 def print_summary(
     *,
     repo_root: str,
+    common_dir: str,
     state_db: Optional[str],
     managed_worktrees: list[Worktree],
+    report_only: list[ReportOnlyPath],
     recent_session_cwds: list[str],
     kept_by_session: list[Worktree],
     kept_for_safety: list[tuple[Worktree, str]],
@@ -592,8 +761,10 @@ def print_summary(
     shared_node_modules_source: str,
 ) -> None:
     print(f"repo root: {repo_root}")
+    print(f"git common dir: {common_dir}")
     print(f"codex state: {state_db or '(not found)'}")
-    print(f"managed worktrees: {len(managed_worktrees)}")
+    print(f"registered non-main worktrees: {len(managed_worktrees)}")
+    print(f"report-only paths: {len(report_only)}")
     print(f"recent sessions scanned: {len(recent_session_cwds)}")
     print(f"min age days: {min_age_days:g}")
     print(f"trim artifacts age days: {trim_artifacts_age_days:g}")
@@ -605,6 +776,11 @@ def print_summary(
     print(f"eligible for artifact trim: {len(trimmable)}")
     print(f"eligible for removal: {len(removable)}")
     print(f"mode: {'apply' if apply else 'dry-run'}")
+
+    if report_only:
+        print("\nReport-only paths:")
+        for item in report_only:
+            print(f"note  {item.path}  ({item.reason})")
 
     if kept_by_session:
         print("\nKept by recent sessions:")
@@ -635,25 +811,6 @@ def simplify_branch_label(worktree: Worktree) -> str:
     if worktree.detached:
         return "detached"
     return "unknown"
-
-
-def has_changes(command: list[str]) -> bool:
-    result = subprocess.run(
-        command,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.PIPE,
-        text=True,
-        check=False,
-    )
-    if result.returncode == 0:
-        return False
-    if result.returncode == 1:
-        return True
-    raise RuntimeError(result.stderr.strip() or f"{' '.join(command)} failed")
-
-
-def delete_worktree_tree(worktree_path: str) -> None:
-    delete_paths([worktree_path])
 
 
 def trim_worktree_artifacts(worktree_path: str, shared_node_modules_source: str) -> None:
@@ -700,14 +857,110 @@ def delete_paths(paths: list[str]) -> None:
     )
 
 
-def quarantine_worktree_tree(worktree_path: str, quarantine_root: str) -> str:
-    os.makedirs(quarantine_root, exist_ok=True)
-    quarantine_path = os.path.join(
-        quarantine_root,
-        f"{int(time.time() * 1000)}-{os.getpid()}-{os.path.basename(worktree_path)}",
+def apply_trims(
+    *,
+    repo_root: str,
+    codex_home: str,
+    candidates: list[Worktree],
+    shared_node_modules_source: str,
+) -> None:
+    with progress_bar(total=len(candidates), desc="trimming artifacts") as progress:
+        for candidate in candidates:
+            reason = revalidate_candidate(
+                repo_root=repo_root,
+                codex_home=codex_home,
+                expected=candidate,
+                require_reachable=False,
+                include_detached=True,
+            )
+            if reason:
+                print(f"skip  {candidate.path}  (changed: {reason})")
+            else:
+                trim_worktree_artifacts(candidate.path, shared_node_modules_source)
+            progress.update(1)
+
+
+def apply_removals(
+    *,
+    repo_root: str,
+    codex_home: str,
+    candidates: list[Worktree],
+    include_detached: bool,
+) -> None:
+    with progress_bar(total=len(candidates), desc="removing worktrees") as progress:
+        for candidate in candidates:
+            reason = revalidate_candidate(
+                repo_root=repo_root,
+                codex_home=codex_home,
+                expected=candidate,
+                require_reachable=True,
+                include_detached=include_detached,
+            )
+            if reason:
+                print(f"skip  {candidate.path}  (changed: {reason})")
+                progress.update(1)
+                continue
+
+            result = subprocess.run(
+                ["git", "-C", repo_root, "worktree", "remove", candidate.path],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            )
+            if result.returncode != 0:
+                print(
+                    f"skip  {candidate.path}  "
+                    f"(remove-failed: {result.stderr.strip() or result.returncode})"
+                )
+            else:
+                print(f"drop  {candidate.path}")
+            progress.update(1)
+
+
+def revalidate_candidate(
+    *,
+    repo_root: str,
+    codex_home: str,
+    expected: Worktree,
+    require_reachable: bool,
+    include_detached: bool,
+) -> Optional[str]:
+    inventory = build_inventory(repo_root, codex_home)
+    current = next(
+        (worktree for worktree in inventory.worktrees if worktree.path == expected.path),
+        None,
     )
-    shutil.move(worktree_path, quarantine_path)
-    return quarantine_path
+    if current is None:
+        return "no-longer-registered"
+    if current.head != expected.head or current.branch_ref != expected.branch_ref:
+        return "head-or-branch-changed"
+    if current.locked:
+        return "locked"
+    if is_worktree_dirty(current.path):
+        return "dirty"
+
+    owned_paths = collect_owned_worktree_paths(inventory.worktrees)
+    if current.path in owned_paths:
+        return "busy"
+
+    state_db = find_latest_state_db(codex_home)
+    if state_db:
+        session_cwds = read_recent_session_cwds(
+            state_db=state_db,
+            scan_limit=DEFAULT_SCAN_LIMIT,
+            keep_limit=DEFAULT_SESSION_LIMIT,
+            repo_root=repo_root,
+            worktrees=inventory.worktrees,
+        )
+        if current.path in select_session_backed_worktrees(inventory.worktrees, session_cwds):
+            return "recent-session"
+
+    if current.detached and not include_detached:
+        return "detached"
+    if require_reachable:
+        return unsafe_reachability_reason(current)
+    return None
 
 
 def spawn_async_purge(*, codex_home: str, quarantine_root: str, delete_workers: int) -> None:

--- a/bin/agent-worktree-ops/agent-worktree-clean
+++ b/bin/agent-worktree-ops/agent-worktree-clean
@@ -53,8 +53,8 @@ class Inventory:
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Remove clean, idle agent worktrees not referenced by the last N Codex sessions. "
-            "Dry-run by default."
+            "Audit registered worktrees and serially remove clean, idle candidates with "
+            "non-force git worktree remove. Dry-run by default."
         )
     )
     parser.add_argument("--apply", action="store_true", help="remove eligible worktrees")
@@ -89,7 +89,10 @@ def parse_args() -> argparse.Namespace:
         "--delete-workers",
         type=positive_int,
         default=DEFAULT_DELETE_WORKERS,
-        help=f"parallel workers for deletion when --apply is set (default: {DEFAULT_DELETE_WORKERS})",
+        help=(
+            "parallel workers for purging legacy quarantine entries "
+            f"(compatibility option; default: {DEFAULT_DELETE_WORKERS})"
+        ),
     )
     parser.add_argument(
         "--min-age-days",
@@ -109,7 +112,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--quarantine-root",
         default=DEFAULT_QUARANTINE_ROOT,
-        help="where removable worktrees are moved before async purge",
+        help="legacy quarantine directory to purge after apply (new removals are not quarantined)",
     )
     parser.add_argument(
         "--shared-node-modules-source",
@@ -286,12 +289,16 @@ def main() -> int:
         codex_home=codex_home,
         candidates=trimmable,
         shared_node_modules_source=shared_node_modules_source,
+        session_limit=args.limit,
+        scan_limit=args.scan_limit,
     )
     apply_removals(
         repo_root=repo_root,
         codex_home=codex_home,
         candidates=removable,
         include_detached=args.include_detached,
+        session_limit=args.limit,
+        scan_limit=args.scan_limit,
     )
     spawn_async_purge(
         codex_home=codex_home,
@@ -768,7 +775,8 @@ def print_summary(
     print(f"recent sessions scanned: {len(recent_session_cwds)}")
     print(f"min age days: {min_age_days:g}")
     print(f"trim artifacts age days: {trim_artifacts_age_days:g}")
-    print(f"quarantine root: {quarantine_root}")
+    print(f"legacy quarantine purge root: {quarantine_root}")
+    print("removal strategy: serial non-force git worktree remove")
     print(f"shared node_modules source: {shared_node_modules_source}")
     print(f"shared node_modules exists: {'yes' if path_is_dir(shared_node_modules_source) else 'no'}")
     print(f"kept by recent sessions: {len(kept_by_session)}")
@@ -863,6 +871,8 @@ def apply_trims(
     codex_home: str,
     candidates: list[Worktree],
     shared_node_modules_source: str,
+    session_limit: int,
+    scan_limit: int,
 ) -> None:
     with progress_bar(total=len(candidates), desc="trimming artifacts") as progress:
         for candidate in candidates:
@@ -872,6 +882,8 @@ def apply_trims(
                 expected=candidate,
                 require_reachable=False,
                 include_detached=True,
+                session_limit=session_limit,
+                scan_limit=scan_limit,
             )
             if reason:
                 print(f"skip  {candidate.path}  (changed: {reason})")
@@ -886,6 +898,8 @@ def apply_removals(
     codex_home: str,
     candidates: list[Worktree],
     include_detached: bool,
+    session_limit: int,
+    scan_limit: int,
 ) -> None:
     with progress_bar(total=len(candidates), desc="removing worktrees") as progress:
         for candidate in candidates:
@@ -895,6 +909,8 @@ def apply_removals(
                 expected=candidate,
                 require_reachable=True,
                 include_detached=include_detached,
+                session_limit=session_limit,
+                scan_limit=scan_limit,
             )
             if reason:
                 print(f"skip  {candidate.path}  (changed: {reason})")
@@ -925,6 +941,8 @@ def revalidate_candidate(
     expected: Worktree,
     require_reachable: bool,
     include_detached: bool,
+    session_limit: int,
+    scan_limit: int,
 ) -> Optional[str]:
     inventory = build_inventory(repo_root, codex_home)
     current = next(
@@ -948,8 +966,8 @@ def revalidate_candidate(
     if state_db:
         session_cwds = read_recent_session_cwds(
             state_db=state_db,
-            scan_limit=DEFAULT_SCAN_LIMIT,
-            keep_limit=DEFAULT_SESSION_LIMIT,
+            scan_limit=scan_limit,
+            keep_limit=session_limit,
             repo_root=repo_root,
             worktrees=inventory.worktrees,
         )

--- a/bin/agent-worktree-ops/agent-worktree-clean
+++ b/bin/agent-worktree-ops/agent-worktree-clean
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -43,15 +44,14 @@ class ReportOnlyPath:
 
 @dataclass(frozen=True)
 class Inventory:
-    repo_root: str
     common_dir: str
-    main_path: str
     worktrees: list[Worktree]
     report_only: list[ReportOnlyPath]
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
+        allow_abbrev=False,
         description=(
             "Audit registered worktrees and serially remove clean, idle candidates with "
             "non-force git worktree remove. Dry-run by default."
@@ -439,9 +439,7 @@ def build_inventory(repo_root: str, codex_home: str) -> Inventory:
             report_only.append(ReportOnlyPath(candidate_path, "unregistered"))
 
     return Inventory(
-        repo_root=repo_root,
         common_dir=common_dir,
-        main_path=main_path,
         worktrees=sorted(managed, key=lambda worktree: worktree.path),
         report_only=dedupe_report_only(report_only),
     )
@@ -597,7 +595,7 @@ def collect_owned_worktree_paths(worktrees: list[Worktree]) -> set[str]:
 
 
 def collect_lsof_worktree_paths(worktrees: list[Worktree]) -> set[str]:
-    if not shutil_which("lsof"):
+    if not shutil.which("lsof"):
         raise RuntimeError("lsof is required to verify live worktree ownership")
     sorted_worktrees = sorted(worktrees, key=lambda worktree: len(worktree.path), reverse=True)
     result = subprocess.run(
@@ -624,7 +622,7 @@ def collect_lsof_worktree_paths(worktrees: list[Worktree]) -> set[str]:
 
 
 def collect_tmux_worktree_paths(worktrees: list[Worktree]) -> set[str]:
-    if not shutil_which("tmux"):
+    if not shutil.which("tmux"):
         return set()
     sorted_worktrees = sorted(worktrees, key=lambda worktree: len(worktree.path), reverse=True)
     result = subprocess.run(
@@ -650,15 +648,6 @@ def collect_tmux_worktree_paths(worktrees: list[Worktree]) -> set[str]:
                 busy_paths.add(worktree.path)
                 break
     return busy_paths
-
-
-def shutil_which(command: str) -> Optional[str]:
-    path = os.environ.get("PATH", os.defpath)
-    for directory in path.split(os.pathsep):
-        candidate = os.path.join(directory or ".", command)
-        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
-            return candidate
-    return None
 
 
 def unsafe_reachability_reason(worktree: Worktree) -> Optional[str]:
@@ -1018,12 +1007,6 @@ def run_text(command: list[str]) -> str:
     if result.returncode != 0:
         raise RuntimeError(result.stderr.strip() or f"{' '.join(command)} failed")
     return result.stdout.strip()
-
-
-def run(command: list[str]) -> None:
-    result = subprocess.run(command, check=False)
-    if result.returncode != 0:
-        raise RuntimeError(f"{' '.join(command)} failed with exit code {result.returncode}")
 
 
 if __name__ == "__main__":

--- a/bin/agent-worktree-ops/agent-worktree-maintain
+++ b/bin/agent-worktree-ops/agent-worktree-maintain
@@ -201,6 +201,7 @@ fi
   echo "[$(date '+%F %T')] agent-worktree-maintain: start count=$worktree_count threshold=$threshold free_gib=$free_gib min_free_gib=$min_free_gib real_node_modules_gib=$real_node_modules_gib max_real_node_modules_gib=$max_real_node_modules_gib dist_gib=$dist_gib max_dist_gib=$max_dist_gib repo=$repo"
   "$DEFAULT_CLEANER" \
     --repo "$repo" \
+    --codex-home "$codex_home" \
     --limit "$session_limit" \
     --min-age-days "$min_age_days" \
     --trim-artifacts-age-days "$trim_artifacts_age_days" \

--- a/bin/agent-worktree-ops/agent-worktree-maintain
+++ b/bin/agent-worktree-ops/agent-worktree-maintain
@@ -28,50 +28,11 @@ max_real_node_modules_gib="$DEFAULT_MAX_REAL_NODE_MODULES_GIB"
 max_dist_gib="$DEFAULT_MAX_DIST_GIB"
 force=0
 
-repo_slug_from_origin() {
-  local origin="$1"
-  local cleaned slug
-
-  [[ -n "$origin" ]] || return 1
-
-  cleaned="${origin%.git}"
-  cleaned="${cleaned#ssh://}"
-  cleaned="${cleaned#https://}"
-  cleaned="${cleaned#http://}"
-  cleaned="${cleaned#*:*@}"
-  cleaned="${cleaned#git@}"
-  if [[ "${cleaned%%/*}" == *:* ]]; then
-    cleaned="${cleaned/:/\/}"
-  fi
-  cleaned="${cleaned#*/}"
-  slug=$(printf '%s' "$cleaned" | tr -s '/' '-' | tr -cd '[:alnum:]._-')
-  [[ -n "$slug" ]] || return 1
-  printf '%s\n' "$slug"
-}
-
-resolve_repo_slug() {
-  local origin=""
-  origin="$(git -C "$repo" config --get remote.origin.url 2>/dev/null || true)"
-  if [[ -n "$origin" ]]; then
-    repo_slug_from_origin "$origin" && return 0
-  fi
-  basename "$repo"
-}
-
 list_managed_worktrees() {
-  local repo_slug codex_repo_root root
-
-  repo_slug="$(resolve_repo_slug)"
-  codex_repo_root="$codex_home/worktrees/$repo_slug"
-
-  {
-    git -C "$repo" worktree list --porcelain | awk '/^worktree / {print substr($0, 10)}'
-    [[ -d "$codex_repo_root" ]] && find "$codex_repo_root" -mindepth 1 -maxdepth 1 -type d -print
-    for root in "$repo/.claude/worktrees" "$repo/.worktrees"; do
-      [[ -d "$root" ]] || continue
-      find "$root" -mindepth 1 -maxdepth 1 -type d -print
-    done
-  } | awk 'NF && !seen[$0]++'
+  "$DEFAULT_CLEANER" \
+    --repo "$repo" \
+    --codex-home "$codex_home" \
+    --list-registered
 }
 
 sum_real_node_modules_kib() {
@@ -156,7 +117,7 @@ Options:
   --min-age-days <n>       Minimum worktree age before cleanup.
   --trim-artifacts-age-days <n>
                            Minimum worktree age before trimming node_modules/dist.
-  --delete-workers <n>     Parallel delete workers for the cleaner.
+  --delete-workers <n>     Parallel workers for purging legacy quarantine entries.
   --threshold <n>          Minimum agent worktree count before apply mode runs.
   --min-free-gib <n>       Run cleanup when free disk falls below this GiB floor.
   --max-real-node-modules-gib <n>

--- a/bin/agent-worktree-ops/agent-worktree-purge
+++ b/bin/agent-worktree-ops/agent-worktree-purge
@@ -16,7 +16,10 @@ DEFAULT_QUARANTINE_ROOT = os.path.join(DEFAULT_CODEX_HOME, "quarantine", "worktr
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Purge quarantined agent worktree directories.")
+    parser = argparse.ArgumentParser(
+        allow_abbrev=False,
+        description="Purge quarantined agent worktree directories.",
+    )
     parser.add_argument(
         "--quarantine-root",
         default=DEFAULT_QUARANTINE_ROOT,

--- a/bin/agent-worktree-ops/install-agent-worktree-ops
+++ b/bin/agent-worktree-ops/install-agent-worktree-ops
@@ -84,6 +84,10 @@ launchctl bootout "$DOMAIN/$OLD_LABEL" >/dev/null 2>&1 || true
 rm -f "$OLD_PLIST_TARGET"
 rm -rf "$OLD_RUNTIME_DIR"
 launchctl bootout "$DOMAIN/$LABEL" >/dev/null 2>&1 || true
+if launchctl print "$DOMAIN/$LABEL" >/dev/null 2>&1; then
+  printf 'install-agent-worktree-ops: failed to unload %s/%s\n' "$DOMAIN" "$LABEL" >&2
+  exit 1
+fi
 
 if (( install_only == 1 )); then
   printf 'agent-worktree-ops installed without loading %s\n' "$LABEL"

--- a/bin/agent-worktree-ops/install-agent-worktree-ops
+++ b/bin/agent-worktree-ops/install-agent-worktree-ops
@@ -2,6 +2,29 @@
 
 set -euo pipefail
 
+install_only=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install-only)
+      install_only=1
+      shift
+      ;;
+    --help|-h)
+      cat <<'EOF'
+Usage: install-agent-worktree-ops [--install-only]
+
+Options:
+  --install-only  Install runtime files and plist without loading the LaunchAgent.
+EOF
+      exit 0
+      ;;
+    *)
+      printf 'install-agent-worktree-ops: unknown argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
 if [[ "$(uname -s)" != "Darwin" ]]; then
   printf 'agent-worktree-ops is macOS-only; skipping\n'
   exit 0
@@ -14,21 +37,59 @@ OLD_RUNTIME_DIR="$HOME/Library/Application Support/codex-worktree-maintain"
 PLIST_SOURCE="$DOTFILES_DIR/Library/LaunchAgents/com.vincentkoc.agent-worktree-ops.plist"
 PLIST_TARGET="$HOME/Library/LaunchAgents/com.vincentkoc.agent-worktree-ops.plist"
 OLD_PLIST_TARGET="$HOME/Library/LaunchAgents/com.vincentkoc.codex-worktree-maintain.plist"
+LABEL="com.vincentkoc.agent-worktree-ops"
+OLD_LABEL="com.vincentkoc.codex-worktree-maintain"
+DOMAIN="gui/$(id -u)"
+rendered_plist=""
 
 mkdir -p "$RUNTIME_DIR" "$HOME/Library/LaunchAgents"
-cp "$DOTFILES_DIR/bin/agent-worktree-ops/agent-worktree-clean" "$RUNTIME_DIR/agent-worktree-clean"
-cp "$DOTFILES_DIR/bin/agent-worktree-ops/agent-worktree-maintain" "$RUNTIME_DIR/agent-worktree-maintain"
-cp "$DOTFILES_DIR/bin/agent-worktree-ops/agent-worktree-purge" "$RUNTIME_DIR/agent-worktree-purge"
-chmod +x "$RUNTIME_DIR/agent-worktree-clean" "$RUNTIME_DIR/agent-worktree-maintain" "$RUNTIME_DIR/agent-worktree-purge"
 
-ln -sfn "$PLIST_SOURCE" "$PLIST_TARGET"
-launchctl bootout "gui/$(id -u)" "$OLD_PLIST_TARGET" >/dev/null 2>&1 || true
+install_atomic() {
+  local source="$1"
+  local target="$2"
+  local temporary
+
+  temporary="$(mktemp "$RUNTIME_DIR/.install.XXXXXX")"
+  cp "$source" "$temporary"
+  chmod 0755 "$temporary"
+  mv -f "$temporary" "$target"
+}
+
+xml_escape() {
+  sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+}
+
+cleanup_rendered_plist() {
+  [[ -z "$rendered_plist" ]] || rm -f "$rendered_plist"
+}
+trap cleanup_rendered_plist EXIT
+
+install_atomic "$DOTFILES_DIR/bin/agent-worktree-ops/agent-worktree-clean" "$RUNTIME_DIR/agent-worktree-clean"
+install_atomic "$DOTFILES_DIR/bin/agent-worktree-ops/agent-worktree-maintain" "$RUNTIME_DIR/agent-worktree-maintain"
+install_atomic "$DOTFILES_DIR/bin/agent-worktree-ops/agent-worktree-purge" "$RUNTIME_DIR/agent-worktree-purge"
+
+runtime_maintainer="$(
+  printf '%s' "$RUNTIME_DIR/agent-worktree-maintain" \
+    | xml_escape \
+    | sed -e 's/[&|]/\\&/g'
+)"
+rendered_plist="$(mktemp "$HOME/Library/LaunchAgents/.agent-worktree-ops.XXXXXX")"
+sed "s|__AGENT_WORKTREE_MAINTAIN__|$runtime_maintainer|" "$PLIST_SOURCE" >"$rendered_plist"
+plutil -lint "$rendered_plist" >/dev/null
+chmod 0644 "$rendered_plist"
+mv -f "$rendered_plist" "$PLIST_TARGET"
+rendered_plist=""
+
+launchctl bootout "$DOMAIN/$OLD_LABEL" >/dev/null 2>&1 || true
 rm -f "$OLD_PLIST_TARGET"
 rm -rf "$OLD_RUNTIME_DIR"
-launchctl bootout "gui/$(id -u)" "$PLIST_TARGET" >/dev/null 2>&1 || true
-if ! launchctl bootstrap "gui/$(id -u)" "$PLIST_TARGET" 2>/tmp/agent-worktree-ops-launchctl.err; then
-  printf 'warn: launchctl bootstrap skipped: %s\n' "$(cat /tmp/agent-worktree-ops-launchctl.err)" >&2
-  rm -f /tmp/agent-worktree-ops-launchctl.err
+
+if (( install_only == 1 )); then
+  printf 'agent-worktree-ops installed without loading %s\n' "$LABEL"
   exit 0
 fi
-rm -f /tmp/agent-worktree-ops-launchctl.err
+
+launchctl bootout "$DOMAIN/$LABEL" >/dev/null 2>&1 || true
+launchctl bootstrap "$DOMAIN" "$PLIST_TARGET"
+launchctl print "$DOMAIN/$LABEL" >/dev/null
+printf 'agent-worktree-ops loaded: %s/%s\n' "$DOMAIN" "$LABEL"

--- a/bin/agent-worktree-ops/install-agent-worktree-ops
+++ b/bin/agent-worktree-ops/install-agent-worktree-ops
@@ -83,13 +83,13 @@ rendered_plist=""
 launchctl bootout "$DOMAIN/$OLD_LABEL" >/dev/null 2>&1 || true
 rm -f "$OLD_PLIST_TARGET"
 rm -rf "$OLD_RUNTIME_DIR"
+launchctl bootout "$DOMAIN/$LABEL" >/dev/null 2>&1 || true
 
 if (( install_only == 1 )); then
   printf 'agent-worktree-ops installed without loading %s\n' "$LABEL"
   exit 0
 fi
 
-launchctl bootout "$DOMAIN/$LABEL" >/dev/null 2>&1 || true
 launchctl bootstrap "$DOMAIN" "$PLIST_TARGET"
 launchctl print "$DOMAIN/$LABEL" >/dev/null
 printf 'agent-worktree-ops loaded: %s/%s\n' "$DOMAIN" "$LABEL"

--- a/functions/gwt/README.md
+++ b/functions/gwt/README.md
@@ -20,7 +20,13 @@ Key responsibilities:
 - shared `node_modules` bootstrap for pnpm repos
 - pretty/default worktree listing with `--raw`, `--plain`, `--color`, and `--no-color`
 - unified worktree discovery across:
-  - `~/.codex/worktrees/<repo-slug>`
-  - `<repo>/.claude/worktrees`
-  - `<repo>/.worktrees`
+  - the current repository's registered Git worktrees
 - agent worktree cleanup front doors
+
+Cleanup behavior:
+
+- `gwt audit` is metadata-immutable and reports foreign or stale paths without acting on them.
+- `gwt clean` deliberately runs pressure maintenance immediately with `--force`.
+- `gwt rm` resolves targets to an absolute path registered to the current Git common dir.
+- `gwt rm` never prunes unrelated stale worktree registrations.
+- `gwt prune` is the only wrapper command that prunes worktree metadata.

--- a/functions/gwt/README.md
+++ b/functions/gwt/README.md
@@ -25,8 +25,9 @@ Key responsibilities:
 
 Cleanup behavior:
 
-- `gwt audit` is metadata-immutable and reports foreign or stale paths without acting on them.
+- `gwt audit` is metadata-immutable, rejects `--apply`, and reports foreign or stale paths.
 - `gwt clean` deliberately runs pressure maintenance immediately with `--force`.
+- Both cleanup wrappers reject repository/Codex-home scope overrides.
 - `gwt rm` resolves targets to an absolute path registered to the current Git common dir.
 - `gwt rm` never prunes unrelated stale worktree registrations.
 - `gwt prune` is the only wrapper command that prunes worktree metadata.

--- a/functions/gwt/gwt.zsh
+++ b/functions/gwt/gwt.zsh
@@ -120,7 +120,6 @@ _gwt_cleanup_failed_worktree() {
     fi
 
     git worktree remove --force "$worktree_path" >/dev/null 2>&1 || rm -rf "$worktree_path"
-    git worktree prune >/dev/null 2>&1 || true
 }
 
 _gwt_sparse_profile_file() {
@@ -413,8 +412,7 @@ _gwt_codex_repo_worktree_root() {
 
 _gwt_discover_worktree_paths() {
     local repo_root="${1:-}"
-    local codex_repo_root local_root worktree_path
-    local discovered
+    local worktree_path main_worktree
 
     if [[ -z "$repo_root" ]]; then
         repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
@@ -422,27 +420,48 @@ _gwt_discover_worktree_paths() {
         repo_root=$(git -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
     fi
 
-    discovered=$({
-        git -C "$repo_root" worktree list --porcelain 2>/dev/null | awk '/^worktree / {print substr($0, 10)}'
-
-        codex_repo_root=$(_gwt_codex_repo_worktree_root "$repo_root" 2>/dev/null || true)
-        if [[ -n "$codex_repo_root" && -d "$codex_repo_root" ]]; then
-            find "$codex_repo_root" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null
-        fi
-
-        while IFS= read -r local_root; do
-            [[ -d "$local_root" ]] || continue
-            find "$local_root" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null
-        done < <(_gwt_repo_local_worktree_roots "$repo_root")
-    } | awk 'NF && !seen[$0]++') || return 1
-
-    while IFS= read -r worktree_path; do
+    main_worktree=$(git -C "$repo_root" worktree list --porcelain 2>/dev/null \
+        | awk '/^worktree / {print substr($0, 10); exit}') || return 1
+    git -C "$repo_root" worktree list --porcelain 2>/dev/null \
+        | awk '/^worktree / {print substr($0, 10)}' \
+        | while IFS= read -r worktree_path; do
         [[ -n "$worktree_path" && -d "$worktree_path" ]] || continue
-        [[ "$worktree_path" == "$repo_root" ]] && continue
+        [[ "$worktree_path" == "$main_worktree" ]] && continue
         printf '%s\n' "$worktree_path"
-    done <<< "$discovered"
+    done
 
     return 0
+}
+
+_gwt_common_dir() {
+    local repo_path="$1"
+    local common_dir
+
+    common_dir=$(git -C "$repo_path" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+    [[ -n "$common_dir" ]] || return 1
+    (cd "$common_dir" 2>/dev/null && pwd -P)
+}
+
+_gwt_registered_worktree_path() {
+    local repo_root="$1"
+    local target_path="$2"
+    local repo_common target_common registered_path
+
+    target_path=$(cd "$target_path" 2>/dev/null && pwd -P) || return 1
+    repo_common=$(_gwt_common_dir "$repo_root") || return 1
+    target_common=$(_gwt_common_dir "$target_path") || return 1
+    [[ "$repo_common" == "$target_common" ]] || return 1
+
+    while IFS= read -r registered_path; do
+        [[ -d "$registered_path" ]] || continue
+        registered_path=$(cd "$registered_path" 2>/dev/null && pwd -P) || continue
+        if [[ "$registered_path" == "$target_path" ]]; then
+            printf '%s\n' "$target_path"
+            return 0
+        fi
+    done < <(git -C "$repo_root" worktree list --porcelain 2>/dev/null | awk '/^worktree / {print substr($0, 10)}')
+
+    return 1
 }
 
 _gwt_gitdir_for_path() {
@@ -928,7 +947,7 @@ Commands:
   gwt new <branch> [start-point] [--profile <name>|--full]
   gwt ls [--raw|--plain|--color|--no-color]
   gwt audit [agent-worktree-clean args...]
-  gwt clean [agent-worktree-maintain args...]
+  gwt clean [agent-worktree-maintain args...]  Run maintenance immediately (--force)
   gwt cd [branch|name|path]         Jump into a worktree (fzf picker when empty)
   gwt rm <branch|name|path> [--force] Remove a worktree safely
   gwt prune                         Prune stale worktree metadata
@@ -1091,6 +1110,7 @@ EOF
                 echo "gwt: agent-worktree-maintain not found" >&2
                 return 1
             }
+            echo "gwt: running immediate forced maintenance for $repo_root"
             "$maintainer_path" --repo "$repo_root" --force "$@" || return 1
             ;;
         new|add)
@@ -1141,9 +1161,23 @@ EOF
             worktree_path="$worktree_parent/$branch_slug"
             mkdir -p "$worktree_parent" || return 1
 
-            if [[ -d "$worktree_path" ]]; then
-                echo "gwt: worktree already exists at $worktree_path"
-                cd "$worktree_path" || return 1
+            if [[ -e "$worktree_path" || -L "$worktree_path" ]]; then
+                local existing_path existing_branch
+                if [[ ! -d "$worktree_path" ]]; then
+                    echo "gwt: existing worktree path is not a directory: $worktree_path" >&2
+                    return 1
+                fi
+                existing_path=$(_gwt_registered_worktree_path "$repo_root" "$worktree_path" 2>/dev/null) || {
+                    echo "gwt: refusing existing path not registered to this repository: $worktree_path" >&2
+                    return 1
+                }
+                existing_branch=$(_gwt_worktree_branch_label "$existing_path")
+                if [[ "$existing_branch" != "$branch" ]]; then
+                    echo "gwt: existing worktree branch '$existing_branch' does not match '$branch'" >&2
+                    return 1
+                fi
+                echo "gwt: worktree already exists at $existing_path"
+                cd "$existing_path" || return 1
                 _gwt_tmux_sync_context
                 return 0
             fi
@@ -1227,7 +1261,7 @@ EOF
         rm|remove)
             local target=""
             local force_remove=false
-            local arg target_path main_worktree
+            local arg target_path main_worktree repo_root
 
             for arg in "$@"; do
                 case "$arg" in
@@ -1246,7 +1280,13 @@ EOF
                 return 1
             fi
 
-            main_worktree=$(git worktree list | head -n 1 | awk '{print $1}')
+            repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+            target_path=$(_gwt_registered_worktree_path "$repo_root" "$target_path" 2>/dev/null) || {
+                echo "gwt: refusing path not registered to this repository: $target_path" >&2
+                return 1
+            }
+            main_worktree=$(git worktree list --porcelain | awk '/^worktree / {print substr($0, 10); exit}')
+            main_worktree=$(cd "$main_worktree" 2>/dev/null && pwd -P) || return 1
             if [[ "$target_path" == "$main_worktree" ]]; then
                 echo "gwt: refusing to remove the main worktree ($target_path)"
                 return 1
@@ -1268,7 +1308,6 @@ EOF
                 git worktree remove "$target_path" || return 1
             fi
 
-            git worktree prune
             _gwt_tmux_sync_context
             ;;
         prune)

--- a/functions/gwt/gwt.zsh
+++ b/functions/gwt/gwt.zsh
@@ -396,12 +396,6 @@ _gwt_sparse_register_shell_hook() {
     _gwt_sparse_sync_shell_env
 }
 
-_gwt_repo_local_worktree_roots() {
-    local repo_root="$1"
-    printf '%s\n' "$repo_root/.claude/worktrees"
-    printf '%s\n' "$repo_root/.worktrees"
-}
-
 _gwt_codex_repo_worktree_root() {
     local repo_root="$1"
     local repo_slug root
@@ -504,25 +498,6 @@ _gwt_worktree_branch_label() {
     fi
 
     printf '%s\n' "unmanaged"
-}
-
-_gwt_worktree_source_label() {
-    local repo_root="$1"
-    local worktree_path="$2"
-    local codex_repo_root
-
-    codex_repo_root=$(_gwt_codex_repo_worktree_root "$repo_root" 2>/dev/null || true)
-    if [[ "$worktree_path" == "$repo_root" ]]; then
-        printf '%s\n' "main"
-    elif [[ -n "$codex_repo_root" && "$worktree_path" == "$codex_repo_root/"* ]]; then
-        printf '%s\n' "codex"
-    elif [[ "$worktree_path" == "$repo_root/.claude/worktrees/"* ]]; then
-        printf '%s\n' "claude"
-    elif [[ "$worktree_path" == "$repo_root/.worktrees/"* ]]; then
-        printf '%s\n' "local"
-    else
-        printf '%s\n' "git"
-    fi
 }
 
 _gwt_tool_path() {

--- a/functions/gwt/gwt.zsh
+++ b/functions/gwt/gwt.zsh
@@ -542,6 +542,27 @@ _gwt_tool_path() {
     return 1
 }
 
+_gwt_validate_cleanup_args() {
+    local command_name="$1"
+    shift
+    local arg
+
+    for arg in "$@"; do
+        case "$arg" in
+            --repo|--repo=*|--codex-home|--codex-home=*)
+                echo "gwt: $command_name controls repository scope; '$arg' is not allowed" >&2
+                return 1
+                ;;
+            --apply|--apply=*|-a)
+                if [[ "$command_name" == "audit" ]]; then
+                    echo "gwt: audit is immutable; use 'gwt clean' for apply mode" >&2
+                    return 1
+                fi
+                ;;
+        esac
+    done
+}
+
 _gwt_should_use_color() {
     local mode="${1:-auto}"
 
@@ -1082,6 +1103,7 @@ EOF
         audit)
             local repo_root cleaner_path audit_table worktree_count
             repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+            _gwt_validate_cleanup_args audit "$@" || return 1
             cleaner_path=$(_gwt_tool_path agent-worktree-clean) || {
                 echo "gwt: agent-worktree-clean not found" >&2
                 return 1
@@ -1106,6 +1128,7 @@ EOF
         clean)
             local repo_root maintainer_path
             repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+            _gwt_validate_cleanup_args clean "$@" || return 1
             maintainer_path=$(_gwt_tool_path agent-worktree-maintain) || {
                 echo "gwt: agent-worktree-maintain not found" >&2
                 return 1
@@ -1261,7 +1284,7 @@ EOF
         rm|remove)
             local target=""
             local force_remove=false
-            local arg target_path main_worktree repo_root
+            local arg target_path main_worktree repo_root current_path
 
             for arg in "$@"; do
                 case "$arg" in
@@ -1292,7 +1315,8 @@ EOF
                 return 1
             fi
 
-            if [[ "$(pwd)/" == "$target_path/"* ]]; then
+            current_path=$(pwd -P) || return 1
+            if [[ "$current_path/" == "$target_path/"* ]]; then
                 echo "gwt: cannot remove the worktree you are currently in"
                 return 1
             fi

--- a/tests/agent-worktree-maintain-test.sh
+++ b/tests/agent-worktree-maintain-test.sh
@@ -33,6 +33,7 @@ CODEX_HOME="$codex_home" \
 
 grep -q 'start count=1 ' "$codex_home/log/agent-worktree-maintain.log"
 grep -q -- "--repo $repo" "$temporary/cleaner.args"
+grep -q -- "--codex-home $codex_home" "$temporary/cleaner.args"
 grep -q -- '--apply' "$temporary/cleaner.args"
 
 printf 'agent worktree maintainer tests passed\n'

--- a/tests/agent-worktree-maintain-test.sh
+++ b/tests/agent-worktree-maintain-test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+temporary="$(mktemp -d)"
+trap 'rm -rf "$temporary"' EXIT
+
+runtime="$temporary/runtime"
+repo="$temporary/repo"
+codex_home="$temporary/codex"
+registered="$temporary/registered"
+mkdir -p "$runtime" "$repo" "$registered"
+cp "$root/bin/agent-worktree-ops/agent-worktree-maintain" "$runtime/agent-worktree-maintain"
+
+cat >"$runtime/agent-worktree-clean" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ " $* " == *" --list-registered "* ]]; then
+  printf '%s\n' "$TEST_REGISTERED"
+  exit 0
+fi
+printf '%s\n' "$*" >"$TEST_CLEANER_ARGS"
+EOF
+chmod +x "$runtime/agent-worktree-clean" "$runtime/agent-worktree-maintain"
+
+TEST_REGISTERED="$registered" \
+TEST_CLEANER_ARGS="$temporary/cleaner.args" \
+CODEX_HOME="$codex_home" \
+"$runtime/agent-worktree-maintain" \
+  --repo "$repo" \
+  --codex-home "$codex_home" \
+  --force
+
+grep -q 'start count=1 ' "$codex_home/log/agent-worktree-maintain.log"
+grep -q -- "--repo $repo" "$temporary/cleaner.args"
+grep -q -- '--apply' "$temporary/cleaner.args"
+
+printf 'agent worktree maintainer tests passed\n'

--- a/tests/agent-worktree-ops-test.py
+++ b/tests/agent-worktree-ops-test.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 
 import importlib.util
+import io
 import os
 import shutil
 import subprocess
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 from types import SimpleNamespace
@@ -231,7 +233,7 @@ class WorktreeCleanerTests(unittest.TestCase):
     def test_live_ownership_probe_failures_are_fatal(self) -> None:
         worktree = CLEANER.Worktree("/tmp/example", "abc", "refs/heads/test", False, 10)
         failed = SimpleNamespace(returncode=2, stdout="", stderr="permission denied")
-        with mock.patch.object(CLEANER, "shutil_which", return_value="/usr/bin/tool"):
+        with mock.patch.object(CLEANER.shutil, "which", return_value="/usr/bin/tool"):
             with mock.patch.object(CLEANER.subprocess, "run", return_value=failed):
                 with self.assertRaisesRegex(RuntimeError, "lsof"):
                     CLEANER.collect_lsof_worktree_paths([worktree])
@@ -281,6 +283,19 @@ class WorktreeCleanerTests(unittest.TestCase):
         self.assertIsNone(reason)
         self.assertEqual(read_sessions.call_args.kwargs["keep_limit"], 7)
         self.assertEqual(read_sessions.call_args.kwargs["scan_limit"], 13)
+
+    def test_argparse_rejects_abbreviated_apply_and_repo_flags(self) -> None:
+        for abbreviated in ("--app", "--rep"):
+            with self.subTest(abbreviated=abbreviated):
+                with mock.patch.object(
+                    CLEANER.sys,
+                    "argv",
+                    ["agent-worktree-clean", abbreviated, "/tmp/other"],
+                ):
+                    with redirect_stderr(io.StringIO()):
+                        with self.assertRaises(SystemExit) as raised:
+                            CLEANER.parse_args()
+                self.assertNotEqual(raised.exception.code, 0)
 
 
 if __name__ == "__main__":

--- a/tests/agent-worktree-ops-test.py
+++ b/tests/agent-worktree-ops-test.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLEANER_PATH = ROOT / "bin" / "agent-worktree-ops" / "agent-worktree-clean"
+SPEC = importlib.util.spec_from_loader(
+    "agent_worktree_clean",
+    SourceFileLoader("agent_worktree_clean", str(CLEANER_PATH)),
+)
+assert SPEC and SPEC.loader
+CLEANER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CLEANER
+SPEC.loader.exec_module(CLEANER)
+
+
+def git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=check,
+    )
+
+
+def init_repo(path: Path, *, origin: str = "git@example.test:openclaw/openclaw.git") -> None:
+    path.mkdir(parents=True)
+    subprocess.run(["git", "init", "-b", "main", str(path)], check=True, stdout=subprocess.DEVNULL)
+    git(path, "config", "user.name", "Worktree Test")
+    git(path, "config", "user.email", "worktree@example.test")
+    git(path, "config", "remote.origin.url", origin)
+    (path / "README.md").write_text("fixture\n", encoding="utf-8")
+    git(path, "add", "README.md")
+    git(path, "commit", "-m", "fixture")
+
+
+def add_worktree(repo: Path, path: Path, branch: str, start: str = "main") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    git(repo, "worktree", "add", "-b", branch, str(path), start)
+
+
+class WorktreeCleanerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.base = Path(self.temporary.name)
+        self.repo = self.base / "repo"
+        self.codex_home = self.base / "codex"
+        init_repo(self.repo)
+        self.slug_root = self.codex_home / "worktrees" / "openclaw-openclaw"
+        self.slug_root.mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_inventory_is_registry_and_common_dir_authoritative(self) -> None:
+        registered = self.slug_root / "registered"
+        add_worktree(self.repo, registered, "registered")
+
+        stale_path = self.slug_root / "stale-registration"
+        add_worktree(self.repo, stale_path, "stale-registration")
+        shutil.rmtree(stale_path)
+
+        moved_source = self.slug_root / "moved-source"
+        unregistered = self.slug_root / "unregistered"
+        add_worktree(self.repo, moved_source, "moved-source")
+        moved_source.rename(unregistered)
+
+        foreign = self.slug_root / "foreign"
+        init_repo(foreign)
+        non_git = self.slug_root / "notes"
+        non_git.mkdir()
+
+        inventory = CLEANER.build_inventory(str(self.repo), str(self.codex_home))
+
+        self.assertEqual(
+            [worktree.path for worktree in inventory.worktrees],
+            [CLEANER.normalize_path(str(registered))],
+        )
+        reasons = {item.path: item.reason for item in inventory.report_only}
+        self.assertEqual(reasons[CLEANER.normalize_path(str(stale_path))], "stale-registration")
+        self.assertEqual(reasons[CLEANER.normalize_path(str(moved_source))], "stale-registration")
+        self.assertEqual(reasons[CLEANER.normalize_path(str(unregistered))], "unregistered")
+        self.assertEqual(reasons[CLEANER.normalize_path(str(foreign))], "foreign-common-dir")
+        self.assertEqual(reasons[CLEANER.normalize_path(str(non_git))], "non-git")
+
+    def test_audit_does_not_mutate_metadata_and_apply_preserves_unrelated_stale_registration(self) -> None:
+        removable = self.slug_root / "removable"
+        stale = self.slug_root / "stale"
+        add_worktree(self.repo, removable, "removable")
+        add_worktree(self.repo, stale, "stale")
+        shutil.rmtree(stale)
+
+        fake_bin = self.base / "bin"
+        fake_bin.mkdir()
+        (fake_bin / "lsof").write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+        (fake_bin / "tmux").write_text(
+            "#!/bin/sh\necho 'no server running' >&2\nexit 1\n",
+            encoding="utf-8",
+        )
+        os.chmod(fake_bin / "lsof", 0o755)
+        os.chmod(fake_bin / "tmux", 0o755)
+        environment = os.environ.copy()
+        environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
+
+        before = git(self.repo, "worktree", "list", "--porcelain").stdout
+        audit = subprocess.run(
+            [
+                str(CLEANER_PATH),
+                "--repo",
+                str(self.repo),
+                "--codex-home",
+                str(self.codex_home),
+                "--min-age-days",
+                "0",
+                "--trim-artifacts-age-days",
+                "999",
+            ],
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+        self.assertIn("mode: dry-run", audit.stdout)
+        self.assertEqual(before, git(self.repo, "worktree", "list", "--porcelain").stdout)
+
+        subprocess.run(
+            [
+                str(CLEANER_PATH),
+                "--repo",
+                str(self.repo),
+                "--codex-home",
+                str(self.codex_home),
+                "--min-age-days",
+                "0",
+                "--trim-artifacts-age-days",
+                "999",
+                "--apply",
+            ],
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+        after = git(self.repo, "worktree", "list", "--porcelain").stdout
+        self.assertFalse(removable.exists())
+        self.assertIn(f"worktree {CLEANER.normalize_path(str(stale))}", after)
+
+    def test_reachability_matrix(self) -> None:
+        safe_upstream = self.slug_root / "safe-upstream"
+        ahead_upstream = self.slug_root / "ahead-upstream"
+        safe_no_upstream = self.slug_root / "safe-no-upstream"
+        ahead_no_upstream = self.slug_root / "ahead-no-upstream"
+        detached_reachable = self.slug_root / "detached-reachable"
+        detached_unreachable = self.slug_root / "detached-unreachable"
+
+        add_worktree(self.repo, safe_upstream, "safe-upstream")
+        git(safe_upstream, "config", "branch.safe-upstream.remote", ".")
+        git(safe_upstream, "config", "branch.safe-upstream.merge", "refs/heads/main")
+
+        add_worktree(self.repo, ahead_upstream, "ahead-upstream")
+        git(ahead_upstream, "config", "branch.ahead-upstream.remote", ".")
+        git(ahead_upstream, "config", "branch.ahead-upstream.merge", "refs/heads/main")
+        (ahead_upstream / "ahead.txt").write_text("ahead\n", encoding="utf-8")
+        git(ahead_upstream, "add", "ahead.txt")
+        git(ahead_upstream, "commit", "-m", "ahead")
+
+        add_worktree(self.repo, safe_no_upstream, "safe-no-upstream")
+        add_worktree(self.repo, ahead_no_upstream, "ahead-no-upstream")
+        (ahead_no_upstream / "unique.txt").write_text("unique\n", encoding="utf-8")
+        git(ahead_no_upstream, "add", "unique.txt")
+        git(ahead_no_upstream, "commit", "-m", "unique")
+
+        git(self.repo, "worktree", "add", "--detach", str(detached_reachable), "main")
+        git(self.repo, "worktree", "add", "--detach", str(detached_unreachable), "main")
+        git(detached_unreachable, "config", "user.name", "Worktree Test")
+        git(detached_unreachable, "config", "user.email", "worktree@example.test")
+        (detached_unreachable / "detached.txt").write_text("detached\n", encoding="utf-8")
+        git(detached_unreachable, "add", "detached.txt")
+        git(detached_unreachable, "commit", "-m", "detached")
+
+        inventory = CLEANER.build_inventory(str(self.repo), str(self.codex_home))
+        worktrees = {Path(item.path).name: item for item in inventory.worktrees}
+        self.assertIsNone(CLEANER.unsafe_reachability_reason(worktrees["safe-upstream"]))
+        self.assertEqual(
+            CLEANER.unsafe_reachability_reason(worktrees["ahead-upstream"]),
+            "unmerged-upstream",
+        )
+        self.assertIsNone(CLEANER.unsafe_reachability_reason(worktrees["safe-no-upstream"]))
+        self.assertEqual(
+            CLEANER.unsafe_reachability_reason(worktrees["ahead-no-upstream"]),
+            "unreachable-no-upstream",
+        )
+        self.assertIsNone(CLEANER.unsafe_reachability_reason(worktrees["detached-reachable"]))
+        self.assertEqual(
+            CLEANER.unsafe_reachability_reason(worktrees["detached-unreachable"]),
+            "detached-unreachable",
+        )
+
+    def test_dirty_submodule_is_dirty(self) -> None:
+        child = self.base / "child"
+        parent = self.base / "parent"
+        init_repo(child, origin="git@example.test:fixtures/child.git")
+        init_repo(parent, origin="git@example.test:fixtures/parent.git")
+        git(
+            parent,
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            str(child),
+            "vendor/child",
+        )
+        git(parent, "commit", "-am", "add submodule")
+        (parent / "vendor" / "child" / "README.md").write_text("dirty\n", encoding="utf-8")
+        self.assertTrue(CLEANER.is_worktree_dirty(str(parent)))
+
+    def test_live_ownership_probe_failures_are_fatal(self) -> None:
+        worktree = CLEANER.Worktree("/tmp/example", "abc", "refs/heads/test", False, 10)
+        failed = SimpleNamespace(returncode=2, stdout="", stderr="permission denied")
+        with mock.patch.object(CLEANER, "shutil_which", return_value="/usr/bin/tool"):
+            with mock.patch.object(CLEANER.subprocess, "run", return_value=failed):
+                with self.assertRaisesRegex(RuntimeError, "lsof"):
+                    CLEANER.collect_lsof_worktree_paths([worktree])
+                with self.assertRaisesRegex(RuntimeError, "permission denied"):
+                    CLEANER.collect_tmux_worktree_paths([worktree])
+
+    def test_apply_revalidation_detects_new_dirty_state(self) -> None:
+        target = self.slug_root / "race"
+        add_worktree(self.repo, target, "race")
+        expected = CLEANER.build_inventory(str(self.repo), str(self.codex_home)).worktrees[0]
+        (target / "appeared-after-audit.txt").write_text("race\n", encoding="utf-8")
+
+        with mock.patch.object(CLEANER, "collect_owned_worktree_paths", return_value=set()):
+            reason = CLEANER.revalidate_candidate(
+                repo_root=str(self.repo),
+                codex_home=str(self.codex_home),
+                expected=expected,
+                require_reachable=True,
+                include_detached=False,
+            )
+        self.assertEqual(reason, "dirty")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agent-worktree-ops-test.py
+++ b/tests/agent-worktree-ops-test.py
@@ -251,8 +251,36 @@ class WorktreeCleanerTests(unittest.TestCase):
                 expected=expected,
                 require_reachable=True,
                 include_detached=False,
+                session_limit=30,
+                scan_limit=200,
             )
         self.assertEqual(reason, "dirty")
+
+    def test_apply_revalidation_preserves_session_limits(self) -> None:
+        target = self.slug_root / "limits"
+        add_worktree(self.repo, target, "limits")
+        expected = CLEANER.build_inventory(str(self.repo), str(self.codex_home)).worktrees[0]
+
+        with mock.patch.object(CLEANER, "collect_owned_worktree_paths", return_value=set()):
+            with mock.patch.object(CLEANER, "find_latest_state_db", return_value="/tmp/state.sqlite"):
+                with mock.patch.object(
+                    CLEANER,
+                    "read_recent_session_cwds",
+                    return_value=[],
+                ) as read_sessions:
+                    reason = CLEANER.revalidate_candidate(
+                        repo_root=str(self.repo),
+                        codex_home=str(self.codex_home),
+                        expected=expected,
+                        require_reachable=False,
+                        include_detached=False,
+                        session_limit=7,
+                        scan_limit=13,
+                    )
+
+        self.assertIsNone(reason)
+        self.assertEqual(read_sessions.call_args.kwargs["keep_limit"], 7)
+        self.assertEqual(read_sessions.call_args.kwargs["scan_limit"], 13)
 
 
 if __name__ == "__main__":

--- a/tests/gwt-cleanup-test.zsh
+++ b/tests/gwt-cleanup-test.zsh
@@ -35,6 +35,43 @@ HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
 [[ ! -d "$remove_path" ]]
 git -C "$repo" worktree list --porcelain | grep -Fq "worktree ${stale_path:A}"
 
+if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
+  source "$1"
+  cd "$2"
+  gwt audit --apply
+' zsh "$root/functions/gwt/gwt.zsh" "$repo" >"$temporary/audit-apply.out" 2>&1; then
+  print -u2 'expected gwt audit --apply to fail'
+  exit 1
+fi
+grep -Fq "audit is immutable" "$temporary/audit-apply.out"
+
+for command_name in audit clean; do
+  if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
+    source "$1"
+    cd "$2"
+    gwt "$3" --repo "$4"
+  ' zsh "$root/functions/gwt/gwt.zsh" "$repo" "$command_name" "$temporary/other"; then
+    print -u2 "expected gwt $command_name --repo to fail"
+    exit 1
+  fi
+done >"$temporary/scope.out" 2>&1
+grep -Fq 'controls repository scope' "$temporary/scope.out"
+
+current_path="$temporary/current"
+current_link="$temporary/current-link"
+git -C "$repo" worktree add -b current "$current_path" main >/dev/null
+ln -s "$current_path" "$current_link"
+if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
+  source "$1"
+  cd "$2"
+  gwt rm current
+' zsh "$root/functions/gwt/gwt.zsh" "$current_link" >"$temporary/current.out" 2>&1; then
+  print -u2 'expected removal from a symlinked current worktree to fail'
+  exit 1
+fi
+grep -Fq 'cannot remove the worktree you are currently in' "$temporary/current.out"
+[[ -d "$current_path" ]]
+
 git init -b main "$foreign" >/dev/null
 git -C "$foreign" config user.name "Worktree Test"
 git -C "$foreign" config user.email "worktree@example.test"

--- a/tests/gwt-cleanup-test.zsh
+++ b/tests/gwt-cleanup-test.zsh
@@ -11,6 +11,8 @@ foreign="$temporary/foreign"
 worktrees_root="$home/worktrees"
 runtime="$home/Library/Application Support/agent-worktree-ops"
 mkdir -p "$home" "$runtime"
+cp "$root/bin/agent-worktree-ops/agent-worktree-clean" "$runtime/agent-worktree-clean"
+chmod +x "$runtime/agent-worktree-clean"
 
 git init -b main "$repo" >/dev/null
 git -C "$repo" config user.name "Worktree Test"
@@ -44,6 +46,28 @@ if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
   exit 1
 fi
 grep -Fq "audit is immutable" "$temporary/audit-apply.out"
+
+metadata_before="$(git -C "$repo" worktree list --porcelain | shasum -a 256)"
+if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
+  source "$1"
+  cd "$2"
+  gwt audit --app
+' zsh "$root/functions/gwt/gwt.zsh" "$repo" >"$temporary/audit-app.out" 2>&1; then
+  print -u2 'expected abbreviated --app to fail'
+  exit 1
+fi
+if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
+  source "$1"
+  cd "$2"
+  gwt audit --rep "$3"
+' zsh "$root/functions/gwt/gwt.zsh" "$repo" "$temporary/other" >"$temporary/audit-rep.out" 2>&1; then
+  print -u2 'expected abbreviated --rep to fail'
+  exit 1
+fi
+metadata_after="$(git -C "$repo" worktree list --porcelain | shasum -a 256)"
+[[ "$metadata_before" == "$metadata_after" ]]
+grep -Fq 'unrecognized arguments: --app' "$temporary/audit-app.out"
+grep -Fq 'unrecognized arguments: --rep' "$temporary/audit-rep.out"
 
 for command_name in audit clean; do
   if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '

--- a/tests/gwt-cleanup-test.zsh
+++ b/tests/gwt-cleanup-test.zsh
@@ -1,0 +1,87 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+
+root="${0:A:h:h}"
+temporary="$(mktemp -d)"
+trap 'rm -rf "$temporary"' EXIT
+
+home="$temporary/home"
+repo="$temporary/repo"
+foreign="$temporary/foreign"
+worktrees_root="$home/worktrees"
+runtime="$home/Library/Application Support/agent-worktree-ops"
+mkdir -p "$home" "$runtime"
+
+git init -b main "$repo" >/dev/null
+git -C "$repo" config user.name "Worktree Test"
+git -C "$repo" config user.email "worktree@example.test"
+git -C "$repo" config remote.origin.url "git@example.test:owner/repo.git"
+print fixture >"$repo/README.md"
+git -C "$repo" add README.md
+git -C "$repo" commit -m fixture >/dev/null
+
+remove_path="$temporary/remove-me"
+stale_path="$temporary/stale"
+git -C "$repo" worktree add -b remove-me "$remove_path" main >/dev/null
+git -C "$repo" worktree add -b stale "$stale_path" main >/dev/null
+rm -rf "$stale_path"
+
+HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
+  source "$1"
+  cd "$2"
+  gwt rm remove-me
+' zsh "$root/functions/gwt/gwt.zsh" "$repo"
+
+[[ ! -d "$remove_path" ]]
+git -C "$repo" worktree list --porcelain | grep -Fq "worktree ${stale_path:A}"
+
+git init -b main "$foreign" >/dev/null
+git -C "$foreign" config user.name "Worktree Test"
+git -C "$foreign" config user.email "worktree@example.test"
+print foreign >"$foreign/README.md"
+git -C "$foreign" add README.md
+git -C "$foreign" commit -m foreign >/dev/null
+
+if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
+  source "$1"
+  cd "$2"
+  gwt rm "$3"
+' zsh "$root/functions/gwt/gwt.zsh" "$repo" "$foreign" >"$temporary/rm.out" 2>&1; then
+  print -u2 'expected foreign absolute path removal to fail'
+  exit 1
+fi
+grep -Fq 'refusing path not registered to this repository' "$temporary/rm.out"
+
+existing_path="$worktrees_root/owner-repo/existing-branch"
+mkdir -p "${existing_path:h}"
+git clone -q "$foreign" "$existing_path"
+if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
+  source "$1"
+  cd "$2"
+  gwt new existing/branch main
+' zsh "$root/functions/gwt/gwt.zsh" "$repo" >"$temporary/new.out" 2>&1; then
+  print -u2 'expected foreign existing path reuse to fail'
+  exit 1
+fi
+grep -Fq 'refusing existing path not registered to this repository' "$temporary/new.out"
+
+cat >"$runtime/agent-worktree-maintain" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >"$TEST_MAINTAIN_ARGS"
+EOF
+chmod +x "$runtime/agent-worktree-maintain"
+
+HOME="$home" \
+DOTFILES_WORKTREES_ROOT="$worktrees_root" \
+TEST_MAINTAIN_ARGS="$temporary/maintain.args" \
+zsh -f -c '
+  source "$1"
+  cd "$2"
+  gwt clean --min-age-days 7
+' zsh "$root/functions/gwt/gwt.zsh" "$repo" >"$temporary/clean.out"
+
+grep -Fq 'running immediate forced maintenance' "$temporary/clean.out"
+grep -Fq -- '--force --min-age-days 7' "$temporary/maintain.args"
+grep -Fq -- "--repo ${repo:A}" "$temporary/maintain.args"
+
+print 'gwt cleanup tests passed'

--- a/tests/install-agent-worktree-ops-test.sh
+++ b/tests/install-agent-worktree-ops-test.sh
@@ -8,17 +8,38 @@ trap 'rm -rf "$temporary"' EXIT
 home="$temporary/home with spaces"
 fake_bin="$temporary/bin"
 launchctl_log="$temporary/launchctl.log"
+launchctl_state="$temporary/launchctl.loaded"
 mkdir -p "$home" "$fake_bin"
 
 cat >"$fake_bin/launchctl" <<'EOF'
 #!/usr/bin/env bash
+set -euo pipefail
 printf '%s\n' "$*" >>"$TEST_LAUNCHCTL_LOG"
+label="gui/$(id -u)/com.vincentkoc.agent-worktree-ops"
+case "$1" in
+  bootout)
+    if [[ "${2:-}" == "$label" ]]; then
+      if [[ "${TEST_FAIL_BOOTOUT:-0}" == "1" ]]; then
+        exit 1
+      fi
+      rm -f "$TEST_LAUNCHCTL_STATE"
+    fi
+    ;;
+  print)
+    [[ "${2:-}" == "$label" && -f "$TEST_LAUNCHCTL_STATE" ]]
+    ;;
+  bootstrap)
+    touch "$TEST_LAUNCHCTL_STATE"
+    ;;
+esac
 EOF
 chmod +x "$fake_bin/launchctl"
+touch "$launchctl_state"
 
 HOME="$home" \
 PATH="$fake_bin:$PATH" \
 TEST_LAUNCHCTL_LOG="$launchctl_log" \
+TEST_LAUNCHCTL_STATE="$launchctl_state" \
 "$root/bin/agent-worktree-ops/install-agent-worktree-ops" --install-only
 
 plist="$home/Library/LaunchAgents/com.vincentkoc.agent-worktree-ops.plist"
@@ -29,10 +50,26 @@ grep -Fq "$runtime/agent-worktree-maintain" "$plist"
 [[ -x "$runtime/agent-worktree-clean" ]]
 [[ -x "$runtime/agent-worktree-maintain" ]]
 [[ -x "$runtime/agent-worktree-purge" ]]
+[[ ! -e "$launchctl_state" ]]
 grep -Fq "bootout gui/$(id -u)/com.vincentkoc.agent-worktree-ops" "$launchctl_log"
-if grep -Eq '^(bootstrap|print) ' "$launchctl_log"; then
+grep -Fq "print gui/$(id -u)/com.vincentkoc.agent-worktree-ops" "$launchctl_log"
+if grep -Eq '^bootstrap ' "$launchctl_log"; then
   printf 'install-only must not reload the LaunchAgent\n' >&2
   exit 1
 fi
+
+touch "$launchctl_state"
+if HOME="$home" \
+  PATH="$fake_bin:$PATH" \
+  TEST_LAUNCHCTL_LOG="$launchctl_log" \
+  TEST_LAUNCHCTL_STATE="$launchctl_state" \
+  TEST_FAIL_BOOTOUT=1 \
+  "$root/bin/agent-worktree-ops/install-agent-worktree-ops" --install-only \
+  >"$temporary/failed.out" 2>&1; then
+  printf 'install-only must fail when the LaunchAgent remains loaded\n' >&2
+  exit 1
+fi
+[[ -e "$launchctl_state" ]]
+grep -Fq 'failed to unload' "$temporary/failed.out"
 
 printf 'agent worktree installer tests passed\n'

--- a/tests/install-agent-worktree-ops-test.sh
+++ b/tests/install-agent-worktree-ops-test.sh
@@ -6,9 +6,20 @@ temporary="$(mktemp -d)"
 trap 'rm -rf "$temporary"' EXIT
 
 home="$temporary/home with spaces"
-mkdir -p "$home"
+fake_bin="$temporary/bin"
+launchctl_log="$temporary/launchctl.log"
+mkdir -p "$home" "$fake_bin"
 
-HOME="$home" "$root/bin/agent-worktree-ops/install-agent-worktree-ops" --install-only
+cat >"$fake_bin/launchctl" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$TEST_LAUNCHCTL_LOG"
+EOF
+chmod +x "$fake_bin/launchctl"
+
+HOME="$home" \
+PATH="$fake_bin:$PATH" \
+TEST_LAUNCHCTL_LOG="$launchctl_log" \
+"$root/bin/agent-worktree-ops/install-agent-worktree-ops" --install-only
 
 plist="$home/Library/LaunchAgents/com.vincentkoc.agent-worktree-ops.plist"
 runtime="$home/Library/Application Support/agent-worktree-ops"
@@ -18,5 +29,10 @@ grep -Fq "$runtime/agent-worktree-maintain" "$plist"
 [[ -x "$runtime/agent-worktree-clean" ]]
 [[ -x "$runtime/agent-worktree-maintain" ]]
 [[ -x "$runtime/agent-worktree-purge" ]]
+grep -Fq "bootout gui/$(id -u)/com.vincentkoc.agent-worktree-ops" "$launchctl_log"
+if grep -Eq '^(bootstrap|print) ' "$launchctl_log"; then
+  printf 'install-only must not reload the LaunchAgent\n' >&2
+  exit 1
+fi
 
 printf 'agent worktree installer tests passed\n'

--- a/tests/install-agent-worktree-ops-test.sh
+++ b/tests/install-agent-worktree-ops-test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+temporary="$(mktemp -d)"
+trap 'rm -rf "$temporary"' EXIT
+
+home="$temporary/home with spaces"
+mkdir -p "$home"
+
+HOME="$home" "$root/bin/agent-worktree-ops/install-agent-worktree-ops" --install-only
+
+plist="$home/Library/LaunchAgents/com.vincentkoc.agent-worktree-ops.plist"
+runtime="$home/Library/Application Support/agent-worktree-ops"
+[[ -f "$plist" && ! -L "$plist" ]]
+plutil -lint "$plist" >/dev/null
+grep -Fq "$runtime/agent-worktree-maintain" "$plist"
+[[ -x "$runtime/agent-worktree-clean" ]]
+[[ -x "$runtime/agent-worktree-maintain" ]]
+[[ -x "$runtime/agent-worktree-purge" ]]
+
+printf 'agent worktree installer tests passed\n'


### PR DESCRIPTION
## Summary

- scope cleanup to registered, non-main worktrees owned by the selected Git common dir
- keep audit metadata-immutable and revalidate dirtiness, reachability, sessions, tmux panes, and process ownership before serial non-force removal
- harden gwt scope/current-worktree guards and install a portable LaunchAgent runtime with exact unload verification

## Verification

- `python3 tests/agent-worktree-ops-test.py`
- `tests/agent-worktree-maintain-test.sh`
- `tests/gwt-cleanup-test.zsh`
- `tests/install-agent-worktree-ops-test.sh`
- `tests/deepclean-test.sh` and `tests/deepclean-test.zsh`
- ShellCheck, Python/Bash/Zsh syntax checks, `plutil -lint`, and `git diff --check`
- live dry-run audit preserved the exact Git worktree metadata hash

