### PR TITLE
fix(shell): keep gwt on local dotfiles authority

### DIFF
--- a/.functions
+++ b/.functions
@@ -167,12 +167,53 @@ repo() {
 }
 
 # Modular shell bundles.
-_dotfiles_functions_root="${DOTFILES_FUNCTIONS_ROOT:-$HOME/functions}"
-if [[ ! -d "$_dotfiles_functions_root" ]]; then
-    _dotfiles_functions_root="${DOTFILES_DIR:-$HOME/Library/Mobile Documents/com~apple~CloudDocs/dotfiles}/functions"
+_dotfiles_functions_physical_dir() {
+    [[ -d "$1" ]] || return 1
+    (builtin cd -P -- "$1" 2>/dev/null && pwd -P)
+}
+
+_dotfiles_functions_is_clouddocs() {
+    case "$1" in
+        *"/Library/Mobile Documents/com~apple~CloudDocs"|*"/Library/Mobile Documents/com~apple~CloudDocs/"*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+_dotfiles_functions_root=""
+_dotfiles_functions_default="$HOME/functions"
+_dotfiles_functions_explicit="${DOTFILES_FUNCTIONS_ROOT:-}"
+
+if [[ -n "$_dotfiles_functions_explicit" && "$_dotfiles_functions_explicit" != "$_dotfiles_functions_default" ]]; then
+    _dotfiles_functions_candidate=$(_dotfiles_functions_physical_dir "$_dotfiles_functions_explicit" 2>/dev/null || true)
+    if [[ -n "$_dotfiles_functions_candidate" ]] && ! _dotfiles_functions_is_clouddocs "$_dotfiles_functions_candidate"; then
+        _dotfiles_functions_root="$_dotfiles_functions_candidate"
+    fi
+fi
+
+if [[ -z "$_dotfiles_functions_root" ]]; then
+    for _dotfiles_functions_candidate in \
+        "$HOME/GIT/_Perso/dotfiles/functions" \
+        "$HOME/.dotfiles/functions"; do
+        _dotfiles_functions_candidate=$(_dotfiles_functions_physical_dir "$_dotfiles_functions_candidate" 2>/dev/null || true)
+        if [[ -n "$_dotfiles_functions_candidate" ]] && ! _dotfiles_functions_is_clouddocs "$_dotfiles_functions_candidate"; then
+            _dotfiles_functions_root="$_dotfiles_functions_candidate"
+            break
+        fi
+    done
+fi
+
+if [[ -z "$_dotfiles_functions_root" ]]; then
+    _dotfiles_functions_candidate=$(_dotfiles_functions_physical_dir "$_dotfiles_functions_default" 2>/dev/null || true)
+    if [[ -n "$_dotfiles_functions_candidate" ]] && ! _dotfiles_functions_is_clouddocs "$_dotfiles_functions_candidate"; then
+        _dotfiles_functions_root="$_dotfiles_functions_candidate"
+    fi
 fi
 typeset -a _dotfiles_functions_modules
-if [[ -n "${ZSH_VERSION:-}" ]]; then
+if [[ -z "$_dotfiles_functions_root" ]]; then
+    _dotfiles_functions_modules=()
+elif [[ -n "${ZSH_VERSION:-}" ]]; then
     _dotfiles_functions_modules=("$_dotfiles_functions_root"/**/*.zsh(N))
     _dotfiles_functions_modules=(${(o)_dotfiles_functions_modules})
 else
@@ -182,7 +223,9 @@ for _dotfiles_functions_module in "${_dotfiles_functions_modules[@]}"; do
     [[ -r "$_dotfiles_functions_module" ]] || continue
     source "$_dotfiles_functions_module"
 done
-unset _dotfiles_functions_root _dotfiles_functions_module _dotfiles_functions_modules
+unset _dotfiles_functions_root _dotfiles_functions_default _dotfiles_functions_explicit
+unset _dotfiles_functions_candidate _dotfiles_functions_module _dotfiles_functions_modules
+unset -f _dotfiles_functions_physical_dir _dotfiles_functions_is_clouddocs 2>/dev/null || true
 
 # Extract most known archives with one command
 extract () {

--- a/functions/README.md
+++ b/functions/README.md
@@ -15,4 +15,10 @@ Add new shell features here as focused folders instead of growing `.functions` i
 Install/runtime notes:
 
 - installer symlinks this directory to `~/functions`
-- `.functions` prefers `DOTFILES_FUNCTIONS_ROOT`, then falls back to the dotfiles repo copy
+- a custom `DOTFILES_FUNCTIONS_ROOT` wins when its physical path is local
+- otherwise `.functions` prefers `~/GIT/_Perso/dotfiles/functions`, then
+  `~/.dotfiles/functions`, before a local physical `~/functions`
+- the generated `DOTFILES_FUNCTIONS_ROOT=~/functions` default does not override
+  either canonical checkout
+- if none of those roots exists, modular functions stay unloaded
+- CloudDocs paths and symlinks resolving into CloudDocs are never module roots

--- a/functions/gwt/README.md
+++ b/functions/gwt/README.md
@@ -28,6 +28,12 @@ Cleanup behavior:
 - `gwt audit` is metadata-immutable, rejects `--apply`, and reports foreign or stale paths.
 - `gwt clean` deliberately runs pressure maintenance immediately with `--force`.
 - Both cleanup wrappers reject repository/Codex-home scope overrides.
+- The module locator chooses the local functions tree; `gwt` then resolves its
+  physical source checkout and uses the adjacent cleanup helpers.
+- If the source checkout is in CloudDocs or has no helper, cleanup falls back
+  only to the installed Application Support runtime.
+- Hardcoded Git paths, `~/.dotfiles`, CloudDocs, and `~/bin` are never direct
+  cleanup-helper fallbacks.
 - `gwt rm` resolves targets to an absolute path registered to the current Git common dir.
 - `gwt rm` never prunes unrelated stale worktree registrations.
 - `gwt prune` is the only wrapper command that prunes worktree metadata.

--- a/functions/gwt/gwt.zsh
+++ b/functions/gwt/gwt.zsh
@@ -1,6 +1,49 @@
 [[ -n "${DOTFILES_GWT_LOADED:-}" ]] && return 0
 typeset -g DOTFILES_GWT_LOADED=1
 
+_gwt_physical_source_path() {
+    local source_path="$1"
+    local source_target=""
+    local source_dir=""
+
+    if [[ "$source_path" != /* ]]; then
+        source_path="$PWD/$source_path"
+    fi
+
+    while [[ -L "$source_path" ]]; do
+        source_target=$(readlink "$source_path") || return 1
+        if [[ "$source_target" == /* ]]; then
+            source_path="$source_target"
+        else
+            source_path="$(dirname "$source_path")/$source_target"
+        fi
+    done
+
+    source_dir=$(builtin cd -P -- "$(dirname "$source_path")" 2>/dev/null && pwd -P) || return 1
+    printf '%s/%s\n' "$source_dir" "$(basename "$source_path")"
+}
+
+if [[ -n "${ZSH_VERSION:-}" ]]; then
+    _gwt_loaded_source="${(%):-%x}"
+else
+    _gwt_loaded_source="${BASH_SOURCE[0]:-$0}"
+fi
+DOTFILES_GWT_SOURCE_PATH=$(_gwt_physical_source_path "$_gwt_loaded_source") || return 1
+DOTFILES_GWT_CHECKOUT_ROOT=$(
+    builtin cd -P -- "$(dirname "$DOTFILES_GWT_SOURCE_PATH")/../.." 2>/dev/null && pwd -P
+) || return 1
+unset _gwt_loaded_source
+unset -f _gwt_physical_source_path 2>/dev/null || true
+
+_gwt_path_is_clouddocs() {
+    case "$1" in
+        *"/Library/Mobile Documents/com~apple~CloudDocs"|*"/Library/Mobile Documents/com~apple~CloudDocs/"*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
 _gwt_slug_from_origin() {
     local origin="$1"
     local cleaned slug
@@ -504,15 +547,17 @@ _gwt_tool_path() {
     local tool_name="$1"
     local candidate
 
-    for candidate in \
-        "$HOME/Library/Application Support/agent-worktree-ops/$tool_name" \
-        "$HOME/Library/Mobile Documents/com~apple~CloudDocs/dotfiles/bin/agent-worktree-ops/$tool_name" \
-        "$HOME/bin/$tool_name"; do
-        if [[ -x "$candidate" ]]; then
-            printf '%s\n' "$candidate"
-            return 0
-        fi
-    done
+    candidate="$DOTFILES_GWT_CHECKOUT_ROOT/bin/agent-worktree-ops/$tool_name"
+    if ! _gwt_path_is_clouddocs "$DOTFILES_GWT_CHECKOUT_ROOT" && [[ -x "$candidate" ]]; then
+        printf '%s\n' "$candidate"
+        return 0
+    fi
+
+    candidate="$HOME/Library/Application Support/agent-worktree-ops/$tool_name"
+    if [[ -x "$candidate" ]]; then
+        printf '%s\n' "$candidate"
+        return 0
+    fi
 
     return 1
 }

--- a/tests/functions-authority-test.zsh
+++ b/tests/functions-authority-test.zsh
@@ -1,0 +1,106 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+
+root="${0:A:h:h}"
+temporary="$(mktemp -d)"
+trap 'rm -rf "$temporary"' EXIT
+
+write_module() {
+  local module_root="$1"
+  local marker="$2"
+  mkdir -p "$module_root/gwt"
+  cat >"$module_root/gwt/gwt.zsh" <<EOF
+typeset -g TEST_FUNCTIONS_AUTHORITY='$marker'
+gwt() {
+  print -r -- '$marker'
+}
+EOF
+}
+
+write_cloud_decoy() {
+  local module_root="$1"
+  mkdir -p "$module_root/decoy"
+  cat >"$module_root/decoy/cloud.zsh" <<'EOF'
+typeset -g TEST_CLOUDDOCS_LOADED=1
+print -r -- touched >"$TEST_CLOUDDOCS_TOUCH"
+EOF
+}
+
+assert_authority() {
+  local home="$1"
+  local functions_root="$2"
+  local expected="$3"
+  local touch_path="$4"
+
+  HOME="$home" \
+  DOTFILES_FUNCTIONS_ROOT="$functions_root" \
+  TEST_CLOUDDOCS_TOUCH="$touch_path" \
+  zsh -f -c '
+    source "$1"
+    [[ "$TEST_FUNCTIONS_AUTHORITY" == "$2" ]]
+    [[ "$(gwt)" == "$2" ]]
+    [[ -z "${TEST_CLOUDDOCS_LOADED:-}" ]]
+  ' zsh "$root/.functions" "$expected"
+  [[ ! -e "$touch_path" ]]
+}
+
+generated_home="$temporary/generated-home"
+generated_cloud="$generated_home/Library/Mobile Documents/com~apple~CloudDocs/dotfiles/functions"
+mkdir -p "$generated_home"
+write_module "$generated_home/GIT/_Perso/dotfiles/functions" git
+write_cloud_decoy "$generated_cloud"
+ln -s "$generated_cloud" "$generated_home/functions"
+assert_authority "$generated_home" "" git "$temporary/generated-empty.touch"
+assert_authority "$generated_home" "$generated_home/functions" git "$temporary/generated-lexical.touch"
+
+wsl_home="$temporary/wsl-home"
+mkdir -p "$wsl_home"
+write_module "$wsl_home/.dotfiles/functions" wsl
+assert_authority "$wsl_home" "" wsl "$temporary/wsl.touch"
+
+both_home="$temporary/both-home"
+mkdir -p "$both_home"
+write_module "$both_home/GIT/_Perso/dotfiles/functions" git
+write_module "$both_home/.dotfiles/functions" wsl
+assert_authority "$both_home" "" git "$temporary/both.touch"
+
+explicit_home="$temporary/explicit-home"
+explicit_root="$temporary/explicit-functions"
+mkdir -p "$explicit_home"
+write_module "$explicit_root" explicit
+write_module "$explicit_home/GIT/_Perso/dotfiles/functions" git
+assert_authority "$explicit_home" "$explicit_root" explicit "$temporary/explicit.touch"
+
+cloud_explicit_home="$temporary/cloud-explicit-home"
+cloud_explicit_root="$cloud_explicit_home/Library/Mobile Documents/com~apple~CloudDocs/custom/functions"
+mkdir -p "$cloud_explicit_home"
+write_cloud_decoy "$cloud_explicit_root"
+write_module "$cloud_explicit_home/GIT/_Perso/dotfiles/functions" git
+assert_authority "$cloud_explicit_home" "$cloud_explicit_root" git "$temporary/cloud-explicit.touch"
+
+local_home="$temporary/local-home"
+local_functions="$temporary/local-functions"
+mkdir -p "$local_home"
+write_module "$local_functions" home
+ln -s "$local_functions" "$local_home/functions"
+assert_authority "$local_home" "" home "$temporary/local.touch"
+
+closed_home="$temporary/closed-home"
+closed_cloud="$closed_home/Library/Mobile Documents/com~apple~CloudDocs/dotfiles/functions"
+mkdir -p "$closed_home"
+write_cloud_decoy "$closed_cloud"
+ln -s "$closed_cloud" "$closed_home/functions"
+
+HOME="$closed_home" \
+DOTFILES_FUNCTIONS_ROOT="$closed_home/functions" \
+DOTFILES_DIR="${closed_cloud:h}" \
+TEST_CLOUDDOCS_TOUCH="$temporary/closed.touch" \
+zsh -f -c '
+  source "$1"
+  [[ -z "${TEST_FUNCTIONS_AUTHORITY:-}" ]]
+  [[ -z "${TEST_CLOUDDOCS_LOADED:-}" ]]
+  ! whence -w gwt >/dev/null 2>&1
+' zsh "$root/.functions"
+[[ ! -e "$temporary/closed.touch" ]]
+
+print 'functions authority tests passed'

--- a/tests/gwt-cleanup-test.zsh
+++ b/tests/gwt-cleanup-test.zsh
@@ -10,7 +10,10 @@ repo="$temporary/repo"
 foreign="$temporary/foreign"
 worktrees_root="$home/worktrees"
 runtime="$home/Library/Application Support/agent-worktree-ops"
-mkdir -p "$home" "$runtime"
+gwt_fixture_root="$temporary/gwt-fixture"
+gwt_source="$gwt_fixture_root/functions/gwt/gwt.zsh"
+mkdir -p "$home" "$runtime" "${gwt_source:h}"
+cp "$root/functions/gwt/gwt.zsh" "$gwt_source"
 cp "$root/bin/agent-worktree-ops/agent-worktree-clean" "$runtime/agent-worktree-clean"
 chmod +x "$runtime/agent-worktree-clean"
 
@@ -32,7 +35,7 @@ HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
   source "$1"
   cd "$2"
   gwt rm remove-me
-' zsh "$root/functions/gwt/gwt.zsh" "$repo"
+ ' zsh "$gwt_source" "$repo"
 
 [[ ! -d "$remove_path" ]]
 git -C "$repo" worktree list --porcelain | grep -Fq "worktree ${stale_path:A}"
@@ -41,7 +44,7 @@ if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
   source "$1"
   cd "$2"
   gwt audit --apply
-' zsh "$root/functions/gwt/gwt.zsh" "$repo" >"$temporary/audit-apply.out" 2>&1; then
+ ' zsh "$gwt_source" "$repo" >"$temporary/audit-apply.out" 2>&1; then
   print -u2 'expected gwt audit --apply to fail'
   exit 1
 fi
@@ -52,7 +55,7 @@ if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
   source "$1"
   cd "$2"
   gwt audit --app
-' zsh "$root/functions/gwt/gwt.zsh" "$repo" >"$temporary/audit-app.out" 2>&1; then
+ ' zsh "$gwt_source" "$repo" >"$temporary/audit-app.out" 2>&1; then
   print -u2 'expected abbreviated --app to fail'
   exit 1
 fi
@@ -60,7 +63,7 @@ if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
   source "$1"
   cd "$2"
   gwt audit --rep "$3"
-' zsh "$root/functions/gwt/gwt.zsh" "$repo" "$temporary/other" >"$temporary/audit-rep.out" 2>&1; then
+ ' zsh "$gwt_source" "$repo" "$temporary/other" >"$temporary/audit-rep.out" 2>&1; then
   print -u2 'expected abbreviated --rep to fail'
   exit 1
 fi
@@ -74,7 +77,7 @@ for command_name in audit clean; do
     source "$1"
     cd "$2"
     gwt "$3" --repo "$4"
-  ' zsh "$root/functions/gwt/gwt.zsh" "$repo" "$command_name" "$temporary/other"; then
+  ' zsh "$gwt_source" "$repo" "$command_name" "$temporary/other"; then
     print -u2 "expected gwt $command_name --repo to fail"
     exit 1
   fi
@@ -89,7 +92,7 @@ if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
   source "$1"
   cd "$2"
   gwt rm current
-' zsh "$root/functions/gwt/gwt.zsh" "$current_link" >"$temporary/current.out" 2>&1; then
+ ' zsh "$gwt_source" "$current_link" >"$temporary/current.out" 2>&1; then
   print -u2 'expected removal from a symlinked current worktree to fail'
   exit 1
 fi
@@ -107,7 +110,7 @@ if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
   source "$1"
   cd "$2"
   gwt rm "$3"
-' zsh "$root/functions/gwt/gwt.zsh" "$repo" "$foreign" >"$temporary/rm.out" 2>&1; then
+ ' zsh "$gwt_source" "$repo" "$foreign" >"$temporary/rm.out" 2>&1; then
   print -u2 'expected foreign absolute path removal to fail'
   exit 1
 fi
@@ -120,7 +123,7 @@ if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
   source "$1"
   cd "$2"
   gwt new existing/branch main
-' zsh "$root/functions/gwt/gwt.zsh" "$repo" >"$temporary/new.out" 2>&1; then
+ ' zsh "$gwt_source" "$repo" >"$temporary/new.out" 2>&1; then
   print -u2 'expected foreign existing path reuse to fail'
   exit 1
 fi
@@ -139,10 +142,117 @@ zsh -f -c '
   source "$1"
   cd "$2"
   gwt clean --min-age-days 7
-' zsh "$root/functions/gwt/gwt.zsh" "$repo" >"$temporary/clean.out"
+ ' zsh "$gwt_source" "$repo" >"$temporary/clean.out"
 
 grep -Fq 'running immediate forced maintenance' "$temporary/clean.out"
 grep -Fq -- '--force --min-age-days 7' "$temporary/maintain.args"
 grep -Fq -- "--repo ${repo:A}" "$temporary/maintain.args"
+
+authority_tool="authority-probe"
+
+write_probe() {
+  local probe_path="$1"
+  local marker="$2"
+  mkdir -p "${probe_path:h}"
+  cat >"$probe_path" <<EOF
+#!/usr/bin/env bash
+printf '$marker\\n'
+EOF
+  chmod +x "$probe_path"
+}
+
+symlink_home="$temporary/symlink-home"
+symlink_checkout="$temporary/symlink-checkout"
+symlink_source="$symlink_checkout/functions/gwt/gwt.zsh"
+symlink_helper="$symlink_checkout/bin/agent-worktree-ops/$authority_tool"
+mkdir -p "$symlink_home" "${symlink_source:h}"
+cp "$root/functions/gwt/gwt.zsh" "$symlink_source"
+write_probe "$symlink_helper" checkout
+ln -s "$symlink_checkout/functions" "$symlink_home/functions"
+resolved="$(
+  HOME="$symlink_home" zsh -f -c '
+    source "$1"
+    [[ "$DOTFILES_GWT_SOURCE_PATH" == "$2" ]]
+    [[ "$DOTFILES_GWT_CHECKOUT_ROOT" == "$3" ]]
+    _gwt_tool_path "$4"
+  ' zsh "$symlink_home/functions/gwt/gwt.zsh" "${symlink_source:A}" "${symlink_checkout:A}" "$authority_tool"
+)"
+[[ "$resolved" == "${symlink_helper:A}" ]]
+[[ "$("$resolved")" == checkout ]]
+
+wsl_home="$temporary/wsl-home"
+wsl_source="$wsl_home/.dotfiles/functions/gwt/gwt.zsh"
+wsl_helper="$wsl_home/.dotfiles/bin/agent-worktree-ops/$authority_tool"
+mkdir -p "${wsl_source:h}"
+cp "$root/functions/gwt/gwt.zsh" "$wsl_source"
+write_probe "$wsl_helper" wsl
+resolved="$(
+  HOME="$wsl_home" zsh -f -c '
+    source "$1"
+    _gwt_tool_path "$2"
+  ' zsh "$wsl_source" "$authority_tool"
+)"
+[[ "$resolved" == "${wsl_helper:A}" ]]
+[[ "$("$resolved")" == wsl ]]
+
+cloud_home="$temporary/cloud-home"
+cloud_checkout="$cloud_home/Library/Mobile Documents/com~apple~CloudDocs/dotfiles"
+cloud_source="$cloud_checkout/functions/gwt/gwt.zsh"
+cloud_helper="$cloud_checkout/bin/agent-worktree-ops/$authority_tool"
+cloud_runtime="$cloud_home/Library/Application Support/agent-worktree-ops/$authority_tool"
+mkdir -p "${cloud_source:h}"
+cp "$root/functions/gwt/gwt.zsh" "$cloud_source"
+write_probe "$cloud_helper" cloud
+write_probe "$cloud_runtime" runtime
+resolved="$(
+  HOME="$cloud_home" zsh -f -c '
+    source "$1"
+    _gwt_tool_path "$2"
+  ' zsh "$cloud_source" "$authority_tool"
+)"
+[[ "$resolved" == "$cloud_runtime" ]]
+[[ "$("$resolved")" == runtime ]]
+
+runtime_home="$temporary/runtime-home"
+runtime_checkout="$temporary/runtime-checkout"
+runtime_source="$runtime_checkout/functions/gwt/gwt.zsh"
+runtime_helper="$runtime_home/Library/Application Support/agent-worktree-ops/$authority_tool"
+mkdir -p "${runtime_source:h}"
+cp "$root/functions/gwt/gwt.zsh" "$runtime_source"
+write_probe "$runtime_helper" runtime
+resolved="$(
+  HOME="$runtime_home" zsh -f -c '
+    source "$1"
+    _gwt_tool_path "$2"
+  ' zsh "$runtime_source" "$authority_tool"
+)"
+[[ "$resolved" == "$runtime_helper" ]]
+
+closed_home="$temporary/closed-home"
+closed_checkout="$temporary/closed-checkout"
+closed_source="$closed_checkout/functions/gwt/gwt.zsh"
+mkdir -p "${closed_source:h}"
+cp "$root/functions/gwt/gwt.zsh" "$closed_source"
+if resolved="$(
+  HOME="$closed_home" zsh -f -c '
+    source "$1"
+    _gwt_tool_path "$2"
+  ' zsh "$closed_source" "$authority_tool"
+)"; then
+  print -u2 'expected tool resolution to fail without adjacent or installed helpers'
+  exit 1
+fi
+[[ -z "$resolved" ]]
+
+for stale_fallback in \
+  '$HOME/GIT/_Perso/dotfiles/bin/agent-worktree-ops' \
+  '$HOME/.dotfiles/bin/agent-worktree-ops' \
+  'CloudDocs/dotfiles/bin/agent-worktree-ops' \
+  '$HOME/bin/$tool_name'; do
+  if grep -Fq "$stale_fallback" "$root/functions/gwt/gwt.zsh"; then
+    print -u2 "stale helper fallback remains: $stale_fallback"
+    exit 1
+  fi
+done
 
 print 'gwt cleanup tests passed'


### PR DESCRIPTION
## Summary

- prefer physical local function roots and reject CloudDocs paths or symlinks
- resolve `gwt` cleanup helpers beside the loaded checkout, with the installed runtime as the only fallback
- cover macOS, WSL, legacy symlink, runtime fallback, and fail-closed authority cases

## Verification

- `python3 tests/agent-worktree-ops-test.py`
- `tests/agent-worktree-maintain-test.sh`
- `tests/gwt-cleanup-test.zsh`
- `tests/functions-authority-test.zsh`
- `tests/install-agent-worktree-ops-test.sh`
- `tests/deepclean-test.sh` and `tests/deepclean-test.zsh`
- ShellCheck, Python/Bash/Zsh syntax checks, `plutil -lint`, and `git diff --check`
- fresh `zsh -df` proof resolved the physical checkout and adjacent cleanup helper
- maintenance scheduler remained unloaded; no bootstrap, install, or apply action ran
