### PR TITLE
fix(gwt): keep audits free of optional Git locks

### DIFF
--- a/bin/agent-worktree-ops/agent-worktree-clean
+++ b/bin/agent-worktree-ops/agent-worktree-clean
@@ -26,17 +26,18 @@ DEFAULT_CODEX_HOME = os.environ.get("CODEX_HOME", str(Path.home() / ".codex"))
 DEFAULT_QUARANTINE_ROOT = os.path.join(DEFAULT_CODEX_HOME, "quarantine", "worktrees")
 
 
-def readonly_git_env() -> dict[str, str]:
+def audit_git_env() -> dict[str, str]:
     environment = os.environ.copy()
     environment["GIT_OPTIONAL_LOCKS"] = "0"
+    environment["GIT_NO_LAZY_FETCH"] = "1"
     return environment
 
 
-def run_git_readonly(
+def run_git_audit(
     command: list[str],
     **kwargs,
 ) -> subprocess.CompletedProcess[str]:
-    return subprocess.run(command, env=readonly_git_env(), **kwargs)
+    return subprocess.run(command, env=audit_git_env(), **kwargs)
 
 
 @dataclass(frozen=True)
@@ -378,7 +379,7 @@ def parse_git_worktrees(porcelain: str) -> list[Worktree]:
 
 
 def resolve_repo_slug(repo_root: str) -> str:
-    origin_result = run_git_readonly(
+    origin_result = run_git_audit(
         ["git", "-C", repo_root, "config", "--get", "remote.origin.url"],
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
@@ -477,7 +478,7 @@ def discover_candidate_directories(repo_root: str, codex_home: str) -> list[str]
 
 
 def resolve_common_dir(repo_path: str) -> str:
-    result = run_git_readonly(
+    result = run_git_audit(
         ["git", "-C", repo_path, "rev-parse", "--path-format=absolute", "--git-common-dir"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -673,7 +674,7 @@ def unsafe_reachability_reason(worktree: Worktree) -> Optional[str]:
         return "unknown-branch"
 
     branch_name = worktree.branch_ref.removeprefix("refs/heads/")
-    upstream_result = run_git_readonly(
+    upstream_result = run_git_audit(
         [
             "git",
             "-C",
@@ -705,7 +706,7 @@ def unsafe_reachability_reason(worktree: Worktree) -> Optional[str]:
 
 
 def git_config(worktree_path: str, key: str) -> str:
-    result = run_git_readonly(
+    result = run_git_audit(
         ["git", "-C", worktree_path, "config", "--get", key],
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
@@ -716,7 +717,7 @@ def git_config(worktree_path: str, key: str) -> str:
 
 
 def is_ancestor(worktree_path: str, commit: str, ref: str) -> bool:
-    result = run_git_readonly(
+    result = run_git_audit(
         ["git", "-C", worktree_path, "merge-base", "--is-ancestor", commit, ref],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
@@ -1010,7 +1011,7 @@ def spawn_async_purge(*, codex_home: str, quarantine_root: str, delete_workers: 
 
 
 def run_text(command: list[str]) -> str:
-    runner = run_git_readonly if command and command[0] == "git" else subprocess.run
+    runner = run_git_audit if command and command[0] == "git" else subprocess.run
     result = runner(
         command,
         stdout=subprocess.PIPE,

--- a/bin/agent-worktree-ops/agent-worktree-clean
+++ b/bin/agent-worktree-ops/agent-worktree-clean
@@ -26,6 +26,19 @@ DEFAULT_CODEX_HOME = os.environ.get("CODEX_HOME", str(Path.home() / ".codex"))
 DEFAULT_QUARANTINE_ROOT = os.path.join(DEFAULT_CODEX_HOME, "quarantine", "worktrees")
 
 
+def readonly_git_env() -> dict[str, str]:
+    environment = os.environ.copy()
+    environment["GIT_OPTIONAL_LOCKS"] = "0"
+    return environment
+
+
+def run_git_readonly(
+    command: list[str],
+    **kwargs,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, env=readonly_git_env(), **kwargs)
+
+
 @dataclass(frozen=True)
 class Worktree:
     path: str
@@ -365,7 +378,7 @@ def parse_git_worktrees(porcelain: str) -> list[Worktree]:
 
 
 def resolve_repo_slug(repo_root: str) -> str:
-    origin_result = subprocess.run(
+    origin_result = run_git_readonly(
         ["git", "-C", repo_root, "config", "--get", "remote.origin.url"],
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
@@ -464,7 +477,7 @@ def discover_candidate_directories(repo_root: str, codex_home: str) -> list[str]
 
 
 def resolve_common_dir(repo_path: str) -> str:
-    result = subprocess.run(
+    result = run_git_readonly(
         ["git", "-C", repo_path, "rev-parse", "--path-format=absolute", "--git-common-dir"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -660,7 +673,7 @@ def unsafe_reachability_reason(worktree: Worktree) -> Optional[str]:
         return "unknown-branch"
 
     branch_name = worktree.branch_ref.removeprefix("refs/heads/")
-    upstream_result = subprocess.run(
+    upstream_result = run_git_readonly(
         [
             "git",
             "-C",
@@ -692,7 +705,7 @@ def unsafe_reachability_reason(worktree: Worktree) -> Optional[str]:
 
 
 def git_config(worktree_path: str, key: str) -> str:
-    result = subprocess.run(
+    result = run_git_readonly(
         ["git", "-C", worktree_path, "config", "--get", key],
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
@@ -703,7 +716,7 @@ def git_config(worktree_path: str, key: str) -> str:
 
 
 def is_ancestor(worktree_path: str, commit: str, ref: str) -> bool:
-    result = subprocess.run(
+    result = run_git_readonly(
         ["git", "-C", worktree_path, "merge-base", "--is-ancestor", commit, ref],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
@@ -997,7 +1010,8 @@ def spawn_async_purge(*, codex_home: str, quarantine_root: str, delete_workers: 
 
 
 def run_text(command: list[str]) -> str:
-    result = subprocess.run(
+    runner = run_git_readonly if command and command[0] == "git" else subprocess.run
+    result = runner(
         command,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/functions/gwt/gwt.zsh
+++ b/functions/gwt/gwt.zsh
@@ -35,6 +35,10 @@ DOTFILES_GWT_CHECKOUT_ROOT=$(
 unset _gwt_loaded_source
 unset -f _gwt_physical_source_path 2>/dev/null || true
 
+_gwt_git_readonly() {
+    GIT_OPTIONAL_LOCKS=0 command git "$@"
+}
+
 _gwt_path_is_clouddocs() {
     case "$1" in
         *"/Library/Mobile Documents/com~apple~CloudDocs"|*"/Library/Mobile Documents/com~apple~CloudDocs/"*)
@@ -79,11 +83,11 @@ _gwt_repo_slug() {
     local top origin slug
 
     if [[ -n "$repo_root" ]]; then
-        top=$(git -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
-        origin=$(git -C "$repo_root" config --get remote.origin.url 2>/dev/null || true)
+        top=$(_gwt_git_readonly -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
+        origin=$(_gwt_git_readonly -C "$repo_root" config --get remote.origin.url 2>/dev/null || true)
     else
-        top=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
-        origin=$(git config --get remote.origin.url 2>/dev/null || true)
+        top=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
+        origin=$(_gwt_git_readonly config --get remote.origin.url 2>/dev/null || true)
     fi
 
     if [[ -n "$origin" ]]; then
@@ -138,10 +142,10 @@ _gwt_worktree_source_checkout_risk() {
     local promisor_filter=""
     local -a reasons
 
-    repo_root=$(git -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
-    shallow=$(git -C "$repo_root" rev-parse --is-shallow-repository 2>/dev/null || echo false)
-    promisor=$(git -C "$repo_root" config --bool remote.origin.promisor 2>/dev/null || echo false)
-    promisor_filter=$(git -C "$repo_root" config --get remote.origin.partialclonefilter 2>/dev/null || true)
+    repo_root=$(_gwt_git_readonly -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
+    shallow=$(_gwt_git_readonly -C "$repo_root" rev-parse --is-shallow-repository 2>/dev/null || echo false)
+    promisor=$(_gwt_git_readonly -C "$repo_root" config --bool remote.origin.promisor 2>/dev/null || echo false)
+    promisor_filter=$(_gwt_git_readonly -C "$repo_root" config --get remote.origin.partialclonefilter 2>/dev/null || true)
 
     [[ "$shallow" == "true" ]] && reasons+=("shallow=true")
     [[ "$promisor" == "true" ]] && reasons+=("promisor=true")
@@ -156,7 +160,7 @@ _gwt_cleanup_failed_worktree() {
     local repo_root=""
 
     [[ -n "$worktree_path" ]] || return 0
-    repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+    repo_root=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null || true)
     if [[ -n "$repo_root" && "$worktree_path" == "$repo_root" ]]; then
         echo "gwt: refusing to clean up the main worktree ($worktree_path)" >&2
         return 1
@@ -215,7 +219,7 @@ _gwt_sparse_apply_profile() {
     local profile="$2"
     local repo_root repo_dir profile_file mode
 
-    repo_root=$(git -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
+    repo_root=$(_gwt_git_readonly -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
     repo_dir=$(_gwt_sparse_repo_dir "$repo_root") || return 1
     _gwt_sparse_enable_worktree_config "$repo_root" || return 1
 
@@ -251,7 +255,7 @@ _gwt_sparse_apply_default_profile() {
     local explicit_profile="${2:-}"
     local repo_root default_profile
 
-    repo_root=$(git -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
+    repo_root=$(_gwt_git_readonly -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
 
     if [[ -n "$explicit_profile" ]]; then
         _gwt_sparse_apply_profile "$worktree_path" "$explicit_profile" || return 1
@@ -268,15 +272,15 @@ _gwt_sparse_status() {
     local repo_root repo_dir repo_slug sparse_enabled current_profile profile_file
 
     if [[ -z "$worktree_path" ]]; then
-        worktree_path=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+        worktree_path=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
     fi
 
-    repo_root=$(git -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
+    repo_root=$(_gwt_git_readonly -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
     repo_slug=$(_gwt_repo_slug "$repo_root") || return 1
     repo_dir=$(_gwt_sparse_repo_dir "$repo_root") || return 1
-    sparse_enabled=$(git -C "$worktree_path" config --bool core.sparseCheckout 2>/dev/null || echo false)
-    current_profile=$(git -C "$worktree_path" config --worktree --get dotfiles.sparseProfile 2>/dev/null || true)
-    profile_file=$(git -C "$worktree_path" config --worktree --get dotfiles.sparseProfileFile 2>/dev/null || true)
+    sparse_enabled=$(_gwt_git_readonly -C "$worktree_path" config --bool core.sparseCheckout 2>/dev/null || echo false)
+    current_profile=$(_gwt_git_readonly -C "$worktree_path" config --worktree --get dotfiles.sparseProfile 2>/dev/null || true)
+    profile_file=$(_gwt_git_readonly -C "$worktree_path" config --worktree --get dotfiles.sparseProfileFile 2>/dev/null || true)
 
     if [[ -z "$current_profile" ]]; then
         if [[ "$sparse_enabled" == "true" ]]; then
@@ -305,9 +309,9 @@ _gwt_sparse_add_paths() {
         return 1
     }
 
-    repo_root=$(git -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
+    repo_root=$(_gwt_git_readonly -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
     _gwt_sparse_enable_worktree_config "$repo_root" || return 1
-    if [[ "$(git -C "$worktree_path" config --bool core.sparseCheckout 2>/dev/null || echo false)" != "true" ]]; then
+    if [[ "$(_gwt_git_readonly -C "$worktree_path" config --bool core.sparseCheckout 2>/dev/null || echo false)" != "true" ]]; then
         git -C "$worktree_path" sparse-checkout init --cone --sparse-index || return 1
     fi
     git -C "$worktree_path" sparse-checkout add "$@" || return 1
@@ -452,14 +456,14 @@ _gwt_discover_worktree_paths() {
     local worktree_path main_worktree
 
     if [[ -z "$repo_root" ]]; then
-        repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+        repo_root=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
     else
-        repo_root=$(git -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
+        repo_root=$(_gwt_git_readonly -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
     fi
 
-    main_worktree=$(git -C "$repo_root" worktree list --porcelain 2>/dev/null \
+    main_worktree=$(_gwt_git_readonly -C "$repo_root" worktree list --porcelain 2>/dev/null \
         | awk '/^worktree / {print substr($0, 10); exit}') || return 1
-    git -C "$repo_root" worktree list --porcelain 2>/dev/null \
+    _gwt_git_readonly -C "$repo_root" worktree list --porcelain 2>/dev/null \
         | awk '/^worktree / {print substr($0, 10)}' \
         | while IFS= read -r worktree_path; do
         [[ -n "$worktree_path" && -d "$worktree_path" ]] || continue
@@ -474,7 +478,7 @@ _gwt_common_dir() {
     local repo_path="$1"
     local common_dir
 
-    common_dir=$(git -C "$repo_path" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+    common_dir=$(_gwt_git_readonly -C "$repo_path" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
     [[ -n "$common_dir" ]] || return 1
     (cd "$common_dir" 2>/dev/null && pwd -P)
 }
@@ -496,7 +500,7 @@ _gwt_registered_worktree_path() {
             printf '%s\n' "$target_path"
             return 0
         fi
-    done < <(git -C "$repo_root" worktree list --porcelain 2>/dev/null | awk '/^worktree / {print substr($0, 10)}')
+    done < <(_gwt_git_readonly -C "$repo_root" worktree list --porcelain 2>/dev/null | awk '/^worktree / {print substr($0, 10)}')
 
     return 1
 }
@@ -709,7 +713,7 @@ _gwt_find_path() {
         return 0
     fi
 
-    repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+    repo_root=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
 
     while IFS= read -r worktree_path; do
         branch=$(_gwt_worktree_branch_label "$worktree_path")
@@ -730,9 +734,9 @@ _gwt_fzf_table() {
     local table
 
     if [[ -z "$repo_root" ]]; then
-        repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+        repo_root=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
     else
-        repo_root=$(git -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
+        repo_root=$(_gwt_git_readonly -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
     fi
     codex_repo_root=$(_gwt_codex_repo_worktree_root "$repo_root" 2>/dev/null || true)
 
@@ -783,26 +787,26 @@ _gwt_default_start_point() {
 
     local remote="origin"
     local remote_head=""
-    if remote_head=$(git symbolic-ref --quiet --short "refs/remotes/$remote/HEAD" 2>/dev/null); then
+    if remote_head=$(_gwt_git_readonly symbolic-ref --quiet --short "refs/remotes/$remote/HEAD" 2>/dev/null); then
         git fetch --quiet "$remote" "${remote_head#${remote}/}" >/dev/null 2>&1 || true
-        if git show-ref --verify --quiet "refs/remotes/$remote_head"; then
+        if _gwt_git_readonly show-ref --verify --quiet "refs/remotes/$remote_head"; then
             printf '%s\n' "$remote_head"
             return 0
         fi
     fi
 
-    if git show-ref --verify --quiet "refs/remotes/$remote/main"; then
+    if _gwt_git_readonly show-ref --verify --quiet "refs/remotes/$remote/main"; then
         git fetch --quiet "$remote" main >/dev/null 2>&1 || true
         printf '%s\n' "$remote/main"
         return 0
     fi
 
     local upstream=""
-    if upstream=$(git rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" 2>/dev/null); then
+    if upstream=$(_gwt_git_readonly rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" 2>/dev/null); then
         local up_remote="${upstream%%/*}"
         local up_branch="${upstream#*/}"
         git fetch --quiet "$up_remote" "$up_branch" >/dev/null 2>&1 || true
-        if git show-ref --verify --quiet "refs/remotes/$upstream"; then
+        if _gwt_git_readonly show-ref --verify --quiet "refs/remotes/$upstream"; then
             printf '%s\n' "$upstream"
             return 0
         fi
@@ -853,7 +857,7 @@ _gwt_resolve_start_point() {
             fi
         fi
 
-        if git rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null 2>&1; then
+        if _gwt_git_readonly rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null 2>&1; then
             if [[ "$candidate" != "$requested" ]]; then
                 echo "gwt: start-point '$requested' not found, using '$candidate'" >&2
             fi
@@ -880,7 +884,7 @@ _gwt_shared_install_source() {
     local main_worktree=""
     local worktrees_root=""
 
-    main_worktree=$(git worktree list --porcelain | awk '/^worktree / {print substr($0, 10); exit}')
+    main_worktree=$(_gwt_git_readonly worktree list --porcelain | awk '/^worktree / {print substr($0, 10); exit}')
     if [[ -n "$main_worktree" && -d "$main_worktree/node_modules" ]]; then
         printf '%s\n' "$main_worktree"
         return 0
@@ -1080,7 +1084,7 @@ EOF
             _gwt_tmux_sync_context
             ;;
         *)
-            if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+            if ! _gwt_git_readonly rev-parse --is-inside-work-tree > /dev/null 2>&1; then
                 echo "gwt: not inside a git repository"
                 return 1
             fi
@@ -1092,7 +1096,7 @@ EOF
             ;;
         ls|list)
             local repo_root list_table color_mode="auto"
-            repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+            repo_root=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
             while [[ $# -gt 0 ]]; do
                 case "$1" in
                     --raw)
@@ -1122,7 +1126,7 @@ EOF
             ;;
         audit)
             local repo_root cleaner_path audit_table worktree_count
-            repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+            repo_root=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
             _gwt_validate_cleanup_args audit "$@" || return 1
             cleaner_path=$(_gwt_tool_path agent-worktree-clean) || {
                 echo "gwt: agent-worktree-clean not found" >&2
@@ -1143,11 +1147,11 @@ EOF
                 _gwt_render_ls "$repo_root" "$(printf '%s\n' "$audit_table" | sed -n '1,12p')" "auto"
             fi
             printf '\n'
-            "$cleaner_path" --repo "$repo_root" "$@" || return 1
+            GIT_OPTIONAL_LOCKS=0 "$cleaner_path" --repo "$repo_root" "$@" || return 1
             ;;
         clean)
             local repo_root maintainer_path
-            repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+            repo_root=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
             _gwt_validate_cleanup_args clean "$@" || return 1
             maintainer_path=$(_gwt_tool_path agent-worktree-maintain) || {
                 echo "gwt: agent-worktree-maintain not found" >&2
@@ -1195,7 +1199,7 @@ EOF
             fi
 
             root="${DOTFILES_WORKTREES_ROOT:-$HOME/.codex/worktrees}"
-            repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+            repo_root=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
             repo_slug=$(_gwt_repo_slug) || return 1
             branch_slug=$(printf '%s' "$branch" | tr '/' '-' | tr -cd '[:alnum:]._-')
             [[ -z "$branch_slug" ]] && branch_slug="$branch"
@@ -1240,7 +1244,7 @@ EOF
                 fi
             fi
 
-            if git show-ref --verify --quiet "refs/heads/$branch"; then
+            if _gwt_git_readonly show-ref --verify --quiet "refs/heads/$branch"; then
                 if [[ "$use_sparse" == true ]]; then
                     git worktree add --no-checkout "$worktree_path" "$branch" || return 1
                 else
@@ -1280,7 +1284,7 @@ EOF
 
             if [[ -z "$target" ]]; then
                 if command -v fzf > /dev/null 2>&1; then
-                    selected=$(_gwt_fzf_table "$(git rev-parse --show-toplevel 2>/dev/null)" | fzf \
+                    selected=$(_gwt_fzf_table "$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null)" | fzf \
                         --delimiter=$'\t' \
                         --with-nth=2,3,4,5 \
                         --prompt='worktree> ' \
@@ -1323,12 +1327,12 @@ EOF
                 return 1
             fi
 
-            repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+            repo_root=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
             target_path=$(_gwt_registered_worktree_path "$repo_root" "$target_path" 2>/dev/null) || {
                 echo "gwt: refusing path not registered to this repository: $target_path" >&2
                 return 1
             }
-            main_worktree=$(git worktree list --porcelain | awk '/^worktree / {print substr($0, 10); exit}')
+            main_worktree=$(_gwt_git_readonly worktree list --porcelain | awk '/^worktree / {print substr($0, 10); exit}')
             main_worktree=$(cd "$main_worktree" 2>/dev/null && pwd -P) || return 1
             if [[ "$target_path" == "$main_worktree" ]]; then
                 echo "gwt: refusing to remove the main worktree ($target_path)"
@@ -1341,7 +1345,7 @@ EOF
                 return 1
             fi
 
-            if ! $force_remove && [[ -n "$(git -C "$target_path" status --porcelain 2>/dev/null)" ]]; then
+            if ! $force_remove && [[ -n "$(_gwt_git_readonly -C "$target_path" status --porcelain 2>/dev/null)" ]]; then
                 echo "gwt: worktree has uncommitted changes. Re-run with --force to remove."
                 return 1
             fi
@@ -1367,7 +1371,7 @@ EOF
                     _gwt_tmux_sync_context
                     ;;
                 list|profiles)
-                    _gwt_sparse_list_profiles "$(git rev-parse --show-toplevel)" || return 1
+                    _gwt_sparse_list_profiles "$(_gwt_git_readonly rev-parse --show-toplevel)" || return 1
                     _gwt_tmux_sync_context
                     ;;
                 set)
@@ -1375,17 +1379,17 @@ EOF
                         echo "Usage: gwt sparse set <profile>"
                         return 1
                     }
-                    _gwt_sparse_apply_profile "$(git rev-parse --show-toplevel)" "$1" || return 1
+                    _gwt_sparse_apply_profile "$(_gwt_git_readonly rev-parse --show-toplevel)" "$1" || return 1
                     _gwt_sparse_sync_shell_env
                     _gwt_tmux_sync_context
                     ;;
                 add|expand)
-                    _gwt_sparse_add_paths "$(git rev-parse --show-toplevel)" "$@" || return 1
+                    _gwt_sparse_add_paths "$(_gwt_git_readonly rev-parse --show-toplevel)" "$@" || return 1
                     _gwt_sparse_sync_shell_env
                     _gwt_tmux_sync_context
                     ;;
                 full|disable)
-                    _gwt_sparse_apply_profile "$(git rev-parse --show-toplevel)" "full" || return 1
+                    _gwt_sparse_apply_profile "$(_gwt_git_readonly rev-parse --show-toplevel)" "full" || return 1
                     _gwt_sparse_sync_shell_env
                     _gwt_tmux_sync_context
                     ;;

--- a/functions/gwt/gwt.zsh
+++ b/functions/gwt/gwt.zsh
@@ -35,7 +35,7 @@ DOTFILES_GWT_CHECKOUT_ROOT=$(
 unset _gwt_loaded_source
 unset -f _gwt_physical_source_path 2>/dev/null || true
 
-_gwt_git_audit() {
+_gwt_git_probe() {
     GIT_OPTIONAL_LOCKS=0 GIT_NO_LAZY_FETCH=1 command git "$@"
 }
 
@@ -83,11 +83,11 @@ _gwt_repo_slug() {
     local top origin slug
 
     if [[ -n "$repo_root" ]]; then
-        top=$(_gwt_git_audit -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
-        origin=$(_gwt_git_audit -C "$repo_root" config --get remote.origin.url 2>/dev/null || true)
+        top=$(_gwt_git_probe -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
+        origin=$(_gwt_git_probe -C "$repo_root" config --get remote.origin.url 2>/dev/null || true)
     else
-        top=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
-        origin=$(_gwt_git_audit config --get remote.origin.url 2>/dev/null || true)
+        top=$(_gwt_git_probe rev-parse --show-toplevel 2>/dev/null) || return 1
+        origin=$(_gwt_git_probe config --get remote.origin.url 2>/dev/null || true)
     fi
 
     if [[ -n "$origin" ]]; then
@@ -142,10 +142,10 @@ _gwt_worktree_source_checkout_risk() {
     local promisor_filter=""
     local -a reasons
 
-    repo_root=$(_gwt_git_audit -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
-    shallow=$(_gwt_git_audit -C "$repo_root" rev-parse --is-shallow-repository 2>/dev/null || echo false)
-    promisor=$(_gwt_git_audit -C "$repo_root" config --bool remote.origin.promisor 2>/dev/null || echo false)
-    promisor_filter=$(_gwt_git_audit -C "$repo_root" config --get remote.origin.partialclonefilter 2>/dev/null || true)
+    repo_root=$(_gwt_git_probe -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
+    shallow=$(_gwt_git_probe -C "$repo_root" rev-parse --is-shallow-repository 2>/dev/null || echo false)
+    promisor=$(_gwt_git_probe -C "$repo_root" config --bool remote.origin.promisor 2>/dev/null || echo false)
+    promisor_filter=$(_gwt_git_probe -C "$repo_root" config --get remote.origin.partialclonefilter 2>/dev/null || true)
 
     [[ "$shallow" == "true" ]] && reasons+=("shallow=true")
     [[ "$promisor" == "true" ]] && reasons+=("promisor=true")
@@ -160,7 +160,7 @@ _gwt_cleanup_failed_worktree() {
     local repo_root=""
 
     [[ -n "$worktree_path" ]] || return 0
-    repo_root=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null || true)
+    repo_root=$(_gwt_git_probe rev-parse --show-toplevel 2>/dev/null || true)
     if [[ -n "$repo_root" && "$worktree_path" == "$repo_root" ]]; then
         echo "gwt: refusing to clean up the main worktree ($worktree_path)" >&2
         return 1
@@ -219,7 +219,7 @@ _gwt_sparse_apply_profile() {
     local profile="$2"
     local repo_root repo_dir profile_file mode
 
-    repo_root=$(_gwt_git_audit -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
+    repo_root=$(_gwt_git_probe -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
     repo_dir=$(_gwt_sparse_repo_dir "$repo_root") || return 1
     _gwt_sparse_enable_worktree_config "$repo_root" || return 1
 
@@ -255,7 +255,7 @@ _gwt_sparse_apply_default_profile() {
     local explicit_profile="${2:-}"
     local repo_root default_profile
 
-    repo_root=$(_gwt_git_audit -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
+    repo_root=$(_gwt_git_probe -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
 
     if [[ -n "$explicit_profile" ]]; then
         _gwt_sparse_apply_profile "$worktree_path" "$explicit_profile" || return 1
@@ -272,15 +272,15 @@ _gwt_sparse_status() {
     local repo_root repo_dir repo_slug sparse_enabled current_profile profile_file
 
     if [[ -z "$worktree_path" ]]; then
-        worktree_path=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
+        worktree_path=$(_gwt_git_probe rev-parse --show-toplevel 2>/dev/null) || return 1
     fi
 
-    repo_root=$(_gwt_git_audit -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
+    repo_root=$(_gwt_git_probe -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
     repo_slug=$(_gwt_repo_slug "$repo_root") || return 1
     repo_dir=$(_gwt_sparse_repo_dir "$repo_root") || return 1
-    sparse_enabled=$(_gwt_git_audit -C "$worktree_path" config --bool core.sparseCheckout 2>/dev/null || echo false)
-    current_profile=$(_gwt_git_audit -C "$worktree_path" config --worktree --get dotfiles.sparseProfile 2>/dev/null || true)
-    profile_file=$(_gwt_git_audit -C "$worktree_path" config --worktree --get dotfiles.sparseProfileFile 2>/dev/null || true)
+    sparse_enabled=$(_gwt_git_probe -C "$worktree_path" config --bool core.sparseCheckout 2>/dev/null || echo false)
+    current_profile=$(_gwt_git_probe -C "$worktree_path" config --worktree --get dotfiles.sparseProfile 2>/dev/null || true)
+    profile_file=$(_gwt_git_probe -C "$worktree_path" config --worktree --get dotfiles.sparseProfileFile 2>/dev/null || true)
 
     if [[ -z "$current_profile" ]]; then
         if [[ "$sparse_enabled" == "true" ]]; then
@@ -309,9 +309,9 @@ _gwt_sparse_add_paths() {
         return 1
     }
 
-    repo_root=$(_gwt_git_audit -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
+    repo_root=$(_gwt_git_probe -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
     _gwt_sparse_enable_worktree_config "$repo_root" || return 1
-    if [[ "$(_gwt_git_audit -C "$worktree_path" config --bool core.sparseCheckout 2>/dev/null || echo false)" != "true" ]]; then
+    if [[ "$(_gwt_git_probe -C "$worktree_path" config --bool core.sparseCheckout 2>/dev/null || echo false)" != "true" ]]; then
         git -C "$worktree_path" sparse-checkout init --cone --sparse-index || return 1
     fi
     git -C "$worktree_path" sparse-checkout add "$@" || return 1
@@ -456,14 +456,14 @@ _gwt_discover_worktree_paths() {
     local worktree_path main_worktree
 
     if [[ -z "$repo_root" ]]; then
-        repo_root=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
+        repo_root=$(_gwt_git_probe rev-parse --show-toplevel 2>/dev/null) || return 1
     else
-        repo_root=$(_gwt_git_audit -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
+        repo_root=$(_gwt_git_probe -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
     fi
 
-    main_worktree=$(_gwt_git_audit -C "$repo_root" worktree list --porcelain 2>/dev/null \
+    main_worktree=$(_gwt_git_probe -C "$repo_root" worktree list --porcelain 2>/dev/null \
         | awk '/^worktree / {print substr($0, 10); exit}') || return 1
-    _gwt_git_audit -C "$repo_root" worktree list --porcelain 2>/dev/null \
+    _gwt_git_probe -C "$repo_root" worktree list --porcelain 2>/dev/null \
         | awk '/^worktree / {print substr($0, 10)}' \
         | while IFS= read -r worktree_path; do
         [[ -n "$worktree_path" && -d "$worktree_path" ]] || continue
@@ -478,7 +478,7 @@ _gwt_common_dir() {
     local repo_path="$1"
     local common_dir
 
-    common_dir=$(_gwt_git_audit -C "$repo_path" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+    common_dir=$(_gwt_git_probe -C "$repo_path" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
     [[ -n "$common_dir" ]] || return 1
     (cd "$common_dir" 2>/dev/null && pwd -P)
 }
@@ -500,7 +500,7 @@ _gwt_registered_worktree_path() {
             printf '%s\n' "$target_path"
             return 0
         fi
-    done < <(_gwt_git_audit -C "$repo_root" worktree list --porcelain 2>/dev/null | awk '/^worktree / {print substr($0, 10)}')
+    done < <(_gwt_git_probe -C "$repo_root" worktree list --porcelain 2>/dev/null | awk '/^worktree / {print substr($0, 10)}')
 
     return 1
 }
@@ -713,7 +713,7 @@ _gwt_find_path() {
         return 0
     fi
 
-    repo_root=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
+    repo_root=$(_gwt_git_probe rev-parse --show-toplevel 2>/dev/null) || return 1
 
     while IFS= read -r worktree_path; do
         branch=$(_gwt_worktree_branch_label "$worktree_path")
@@ -734,9 +734,9 @@ _gwt_fzf_table() {
     local table
 
     if [[ -z "$repo_root" ]]; then
-        repo_root=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
+        repo_root=$(_gwt_git_probe rev-parse --show-toplevel 2>/dev/null) || return 1
     else
-        repo_root=$(_gwt_git_audit -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
+        repo_root=$(_gwt_git_probe -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
     fi
     codex_repo_root=$(_gwt_codex_repo_worktree_root "$repo_root" 2>/dev/null || true)
 
@@ -787,26 +787,26 @@ _gwt_default_start_point() {
 
     local remote="origin"
     local remote_head=""
-    if remote_head=$(_gwt_git_audit symbolic-ref --quiet --short "refs/remotes/$remote/HEAD" 2>/dev/null); then
+    if remote_head=$(_gwt_git_probe symbolic-ref --quiet --short "refs/remotes/$remote/HEAD" 2>/dev/null); then
         git fetch --quiet "$remote" "${remote_head#${remote}/}" >/dev/null 2>&1 || true
-        if _gwt_git_audit show-ref --verify --quiet "refs/remotes/$remote_head"; then
+        if _gwt_git_probe show-ref --verify --quiet "refs/remotes/$remote_head"; then
             printf '%s\n' "$remote_head"
             return 0
         fi
     fi
 
-    if _gwt_git_audit show-ref --verify --quiet "refs/remotes/$remote/main"; then
+    if _gwt_git_probe show-ref --verify --quiet "refs/remotes/$remote/main"; then
         git fetch --quiet "$remote" main >/dev/null 2>&1 || true
         printf '%s\n' "$remote/main"
         return 0
     fi
 
     local upstream=""
-    if upstream=$(_gwt_git_audit rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" 2>/dev/null); then
+    if upstream=$(_gwt_git_probe rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" 2>/dev/null); then
         local up_remote="${upstream%%/*}"
         local up_branch="${upstream#*/}"
         git fetch --quiet "$up_remote" "$up_branch" >/dev/null 2>&1 || true
-        if _gwt_git_audit show-ref --verify --quiet "refs/remotes/$upstream"; then
+        if _gwt_git_probe show-ref --verify --quiet "refs/remotes/$upstream"; then
             printf '%s\n' "$upstream"
             return 0
         fi
@@ -857,7 +857,7 @@ _gwt_resolve_start_point() {
             fi
         fi
 
-        if _gwt_git_audit rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null 2>&1; then
+        if _gwt_git_probe rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null 2>&1; then
             if [[ "$candidate" != "$requested" ]]; then
                 echo "gwt: start-point '$requested' not found, using '$candidate'" >&2
             fi
@@ -884,7 +884,7 @@ _gwt_shared_install_source() {
     local main_worktree=""
     local worktrees_root=""
 
-    main_worktree=$(_gwt_git_audit worktree list --porcelain | awk '/^worktree / {print substr($0, 10); exit}')
+    main_worktree=$(_gwt_git_probe worktree list --porcelain | awk '/^worktree / {print substr($0, 10); exit}')
     if [[ -n "$main_worktree" && -d "$main_worktree/node_modules" ]]; then
         printf '%s\n' "$main_worktree"
         return 0
@@ -1084,7 +1084,7 @@ EOF
             _gwt_tmux_sync_context
             ;;
         *)
-            if ! _gwt_git_audit rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+            if ! _gwt_git_probe rev-parse --is-inside-work-tree > /dev/null 2>&1; then
                 echo "gwt: not inside a git repository"
                 return 1
             fi
@@ -1096,7 +1096,7 @@ EOF
             ;;
         ls|list)
             local repo_root list_table color_mode="auto"
-            repo_root=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
+            repo_root=$(_gwt_git_probe rev-parse --show-toplevel 2>/dev/null) || return 1
             while [[ $# -gt 0 ]]; do
                 case "$1" in
                     --raw)
@@ -1126,7 +1126,7 @@ EOF
             ;;
         audit)
             local repo_root cleaner_path audit_table worktree_count
-            repo_root=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
+            repo_root=$(_gwt_git_probe rev-parse --show-toplevel 2>/dev/null) || return 1
             _gwt_validate_cleanup_args audit "$@" || return 1
             cleaner_path=$(_gwt_tool_path agent-worktree-clean) || {
                 echo "gwt: agent-worktree-clean not found" >&2
@@ -1152,7 +1152,7 @@ EOF
             ;;
         clean)
             local repo_root maintainer_path
-            repo_root=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
+            repo_root=$(_gwt_git_probe rev-parse --show-toplevel 2>/dev/null) || return 1
             _gwt_validate_cleanup_args clean "$@" || return 1
             maintainer_path=$(_gwt_tool_path agent-worktree-maintain) || {
                 echo "gwt: agent-worktree-maintain not found" >&2
@@ -1200,7 +1200,7 @@ EOF
             fi
 
             root="${DOTFILES_WORKTREES_ROOT:-$HOME/.codex/worktrees}"
-            repo_root=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
+            repo_root=$(_gwt_git_probe rev-parse --show-toplevel 2>/dev/null) || return 1
             repo_slug=$(_gwt_repo_slug) || return 1
             branch_slug=$(printf '%s' "$branch" | tr '/' '-' | tr -cd '[:alnum:]._-')
             [[ -z "$branch_slug" ]] && branch_slug="$branch"
@@ -1245,7 +1245,7 @@ EOF
                 fi
             fi
 
-            if _gwt_git_audit show-ref --verify --quiet "refs/heads/$branch"; then
+            if _gwt_git_probe show-ref --verify --quiet "refs/heads/$branch"; then
                 if [[ "$use_sparse" == true ]]; then
                     git worktree add --no-checkout "$worktree_path" "$branch" || return 1
                 else
@@ -1285,7 +1285,7 @@ EOF
 
             if [[ -z "$target" ]]; then
                 if command -v fzf > /dev/null 2>&1; then
-                    selected=$(_gwt_fzf_table "$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null)" | fzf \
+                    selected=$(_gwt_fzf_table "$(_gwt_git_probe rev-parse --show-toplevel 2>/dev/null)" | fzf \
                         --delimiter=$'\t' \
                         --with-nth=2,3,4,5 \
                         --prompt='worktree> ' \
@@ -1328,12 +1328,12 @@ EOF
                 return 1
             fi
 
-            repo_root=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
+            repo_root=$(_gwt_git_probe rev-parse --show-toplevel 2>/dev/null) || return 1
             target_path=$(_gwt_registered_worktree_path "$repo_root" "$target_path" 2>/dev/null) || {
                 echo "gwt: refusing path not registered to this repository: $target_path" >&2
                 return 1
             }
-            main_worktree=$(_gwt_git_audit worktree list --porcelain | awk '/^worktree / {print substr($0, 10); exit}')
+            main_worktree=$(_gwt_git_probe worktree list --porcelain | awk '/^worktree / {print substr($0, 10); exit}')
             main_worktree=$(cd "$main_worktree" 2>/dev/null && pwd -P) || return 1
             if [[ "$target_path" == "$main_worktree" ]]; then
                 echo "gwt: refusing to remove the main worktree ($target_path)"
@@ -1346,7 +1346,7 @@ EOF
                 return 1
             fi
 
-            if ! $force_remove && [[ -n "$(_gwt_git_audit -C "$target_path" status --porcelain 2>/dev/null)" ]]; then
+            if ! $force_remove && [[ -n "$(_gwt_git_probe -C "$target_path" status --porcelain 2>/dev/null)" ]]; then
                 echo "gwt: worktree has uncommitted changes. Re-run with --force to remove."
                 return 1
             fi
@@ -1372,7 +1372,7 @@ EOF
                     _gwt_tmux_sync_context
                     ;;
                 list|profiles)
-                    _gwt_sparse_list_profiles "$(_gwt_git_audit rev-parse --show-toplevel)" || return 1
+                    _gwt_sparse_list_profiles "$(_gwt_git_probe rev-parse --show-toplevel)" || return 1
                     _gwt_tmux_sync_context
                     ;;
                 set)
@@ -1380,17 +1380,17 @@ EOF
                         echo "Usage: gwt sparse set <profile>"
                         return 1
                     }
-                    _gwt_sparse_apply_profile "$(_gwt_git_audit rev-parse --show-toplevel)" "$1" || return 1
+                    _gwt_sparse_apply_profile "$(_gwt_git_probe rev-parse --show-toplevel)" "$1" || return 1
                     _gwt_sparse_sync_shell_env
                     _gwt_tmux_sync_context
                     ;;
                 add|expand)
-                    _gwt_sparse_add_paths "$(_gwt_git_audit rev-parse --show-toplevel)" "$@" || return 1
+                    _gwt_sparse_add_paths "$(_gwt_git_probe rev-parse --show-toplevel)" "$@" || return 1
                     _gwt_sparse_sync_shell_env
                     _gwt_tmux_sync_context
                     ;;
                 full|disable)
-                    _gwt_sparse_apply_profile "$(_gwt_git_audit rev-parse --show-toplevel)" "full" || return 1
+                    _gwt_sparse_apply_profile "$(_gwt_git_probe rev-parse --show-toplevel)" "full" || return 1
                     _gwt_sparse_sync_shell_env
                     _gwt_tmux_sync_context
                     ;;

--- a/functions/gwt/gwt.zsh
+++ b/functions/gwt/gwt.zsh
@@ -35,8 +35,8 @@ DOTFILES_GWT_CHECKOUT_ROOT=$(
 unset _gwt_loaded_source
 unset -f _gwt_physical_source_path 2>/dev/null || true
 
-_gwt_git_readonly() {
-    GIT_OPTIONAL_LOCKS=0 command git "$@"
+_gwt_git_audit() {
+    GIT_OPTIONAL_LOCKS=0 GIT_NO_LAZY_FETCH=1 command git "$@"
 }
 
 _gwt_path_is_clouddocs() {
@@ -83,11 +83,11 @@ _gwt_repo_slug() {
     local top origin slug
 
     if [[ -n "$repo_root" ]]; then
-        top=$(_gwt_git_readonly -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
-        origin=$(_gwt_git_readonly -C "$repo_root" config --get remote.origin.url 2>/dev/null || true)
+        top=$(_gwt_git_audit -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
+        origin=$(_gwt_git_audit -C "$repo_root" config --get remote.origin.url 2>/dev/null || true)
     else
-        top=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
-        origin=$(_gwt_git_readonly config --get remote.origin.url 2>/dev/null || true)
+        top=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
+        origin=$(_gwt_git_audit config --get remote.origin.url 2>/dev/null || true)
     fi
 
     if [[ -n "$origin" ]]; then
@@ -142,10 +142,10 @@ _gwt_worktree_source_checkout_risk() {
     local promisor_filter=""
     local -a reasons
 
-    repo_root=$(_gwt_git_readonly -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
-    shallow=$(_gwt_git_readonly -C "$repo_root" rev-parse --is-shallow-repository 2>/dev/null || echo false)
-    promisor=$(_gwt_git_readonly -C "$repo_root" config --bool remote.origin.promisor 2>/dev/null || echo false)
-    promisor_filter=$(_gwt_git_readonly -C "$repo_root" config --get remote.origin.partialclonefilter 2>/dev/null || true)
+    repo_root=$(_gwt_git_audit -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
+    shallow=$(_gwt_git_audit -C "$repo_root" rev-parse --is-shallow-repository 2>/dev/null || echo false)
+    promisor=$(_gwt_git_audit -C "$repo_root" config --bool remote.origin.promisor 2>/dev/null || echo false)
+    promisor_filter=$(_gwt_git_audit -C "$repo_root" config --get remote.origin.partialclonefilter 2>/dev/null || true)
 
     [[ "$shallow" == "true" ]] && reasons+=("shallow=true")
     [[ "$promisor" == "true" ]] && reasons+=("promisor=true")
@@ -160,7 +160,7 @@ _gwt_cleanup_failed_worktree() {
     local repo_root=""
 
     [[ -n "$worktree_path" ]] || return 0
-    repo_root=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null || true)
+    repo_root=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null || true)
     if [[ -n "$repo_root" && "$worktree_path" == "$repo_root" ]]; then
         echo "gwt: refusing to clean up the main worktree ($worktree_path)" >&2
         return 1
@@ -219,7 +219,7 @@ _gwt_sparse_apply_profile() {
     local profile="$2"
     local repo_root repo_dir profile_file mode
 
-    repo_root=$(_gwt_git_readonly -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
+    repo_root=$(_gwt_git_audit -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
     repo_dir=$(_gwt_sparse_repo_dir "$repo_root") || return 1
     _gwt_sparse_enable_worktree_config "$repo_root" || return 1
 
@@ -255,7 +255,7 @@ _gwt_sparse_apply_default_profile() {
     local explicit_profile="${2:-}"
     local repo_root default_profile
 
-    repo_root=$(_gwt_git_readonly -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
+    repo_root=$(_gwt_git_audit -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
 
     if [[ -n "$explicit_profile" ]]; then
         _gwt_sparse_apply_profile "$worktree_path" "$explicit_profile" || return 1
@@ -272,15 +272,15 @@ _gwt_sparse_status() {
     local repo_root repo_dir repo_slug sparse_enabled current_profile profile_file
 
     if [[ -z "$worktree_path" ]]; then
-        worktree_path=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
+        worktree_path=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
     fi
 
-    repo_root=$(_gwt_git_readonly -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
+    repo_root=$(_gwt_git_audit -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
     repo_slug=$(_gwt_repo_slug "$repo_root") || return 1
     repo_dir=$(_gwt_sparse_repo_dir "$repo_root") || return 1
-    sparse_enabled=$(_gwt_git_readonly -C "$worktree_path" config --bool core.sparseCheckout 2>/dev/null || echo false)
-    current_profile=$(_gwt_git_readonly -C "$worktree_path" config --worktree --get dotfiles.sparseProfile 2>/dev/null || true)
-    profile_file=$(_gwt_git_readonly -C "$worktree_path" config --worktree --get dotfiles.sparseProfileFile 2>/dev/null || true)
+    sparse_enabled=$(_gwt_git_audit -C "$worktree_path" config --bool core.sparseCheckout 2>/dev/null || echo false)
+    current_profile=$(_gwt_git_audit -C "$worktree_path" config --worktree --get dotfiles.sparseProfile 2>/dev/null || true)
+    profile_file=$(_gwt_git_audit -C "$worktree_path" config --worktree --get dotfiles.sparseProfileFile 2>/dev/null || true)
 
     if [[ -z "$current_profile" ]]; then
         if [[ "$sparse_enabled" == "true" ]]; then
@@ -309,9 +309,9 @@ _gwt_sparse_add_paths() {
         return 1
     }
 
-    repo_root=$(_gwt_git_readonly -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
+    repo_root=$(_gwt_git_audit -C "$worktree_path" rev-parse --show-toplevel 2>/dev/null) || return 1
     _gwt_sparse_enable_worktree_config "$repo_root" || return 1
-    if [[ "$(_gwt_git_readonly -C "$worktree_path" config --bool core.sparseCheckout 2>/dev/null || echo false)" != "true" ]]; then
+    if [[ "$(_gwt_git_audit -C "$worktree_path" config --bool core.sparseCheckout 2>/dev/null || echo false)" != "true" ]]; then
         git -C "$worktree_path" sparse-checkout init --cone --sparse-index || return 1
     fi
     git -C "$worktree_path" sparse-checkout add "$@" || return 1
@@ -456,14 +456,14 @@ _gwt_discover_worktree_paths() {
     local worktree_path main_worktree
 
     if [[ -z "$repo_root" ]]; then
-        repo_root=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
+        repo_root=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
     else
-        repo_root=$(_gwt_git_readonly -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
+        repo_root=$(_gwt_git_audit -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
     fi
 
-    main_worktree=$(_gwt_git_readonly -C "$repo_root" worktree list --porcelain 2>/dev/null \
+    main_worktree=$(_gwt_git_audit -C "$repo_root" worktree list --porcelain 2>/dev/null \
         | awk '/^worktree / {print substr($0, 10); exit}') || return 1
-    _gwt_git_readonly -C "$repo_root" worktree list --porcelain 2>/dev/null \
+    _gwt_git_audit -C "$repo_root" worktree list --porcelain 2>/dev/null \
         | awk '/^worktree / {print substr($0, 10)}' \
         | while IFS= read -r worktree_path; do
         [[ -n "$worktree_path" && -d "$worktree_path" ]] || continue
@@ -478,7 +478,7 @@ _gwt_common_dir() {
     local repo_path="$1"
     local common_dir
 
-    common_dir=$(_gwt_git_readonly -C "$repo_path" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
+    common_dir=$(_gwt_git_audit -C "$repo_path" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || return 1
     [[ -n "$common_dir" ]] || return 1
     (cd "$common_dir" 2>/dev/null && pwd -P)
 }
@@ -500,7 +500,7 @@ _gwt_registered_worktree_path() {
             printf '%s\n' "$target_path"
             return 0
         fi
-    done < <(_gwt_git_readonly -C "$repo_root" worktree list --porcelain 2>/dev/null | awk '/^worktree / {print substr($0, 10)}')
+    done < <(_gwt_git_audit -C "$repo_root" worktree list --porcelain 2>/dev/null | awk '/^worktree / {print substr($0, 10)}')
 
     return 1
 }
@@ -713,7 +713,7 @@ _gwt_find_path() {
         return 0
     fi
 
-    repo_root=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
+    repo_root=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
 
     while IFS= read -r worktree_path; do
         branch=$(_gwt_worktree_branch_label "$worktree_path")
@@ -734,9 +734,9 @@ _gwt_fzf_table() {
     local table
 
     if [[ -z "$repo_root" ]]; then
-        repo_root=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
+        repo_root=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
     else
-        repo_root=$(_gwt_git_readonly -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
+        repo_root=$(_gwt_git_audit -C "$repo_root" rev-parse --show-toplevel 2>/dev/null) || return 1
     fi
     codex_repo_root=$(_gwt_codex_repo_worktree_root "$repo_root" 2>/dev/null || true)
 
@@ -787,26 +787,26 @@ _gwt_default_start_point() {
 
     local remote="origin"
     local remote_head=""
-    if remote_head=$(_gwt_git_readonly symbolic-ref --quiet --short "refs/remotes/$remote/HEAD" 2>/dev/null); then
+    if remote_head=$(_gwt_git_audit symbolic-ref --quiet --short "refs/remotes/$remote/HEAD" 2>/dev/null); then
         git fetch --quiet "$remote" "${remote_head#${remote}/}" >/dev/null 2>&1 || true
-        if _gwt_git_readonly show-ref --verify --quiet "refs/remotes/$remote_head"; then
+        if _gwt_git_audit show-ref --verify --quiet "refs/remotes/$remote_head"; then
             printf '%s\n' "$remote_head"
             return 0
         fi
     fi
 
-    if _gwt_git_readonly show-ref --verify --quiet "refs/remotes/$remote/main"; then
+    if _gwt_git_audit show-ref --verify --quiet "refs/remotes/$remote/main"; then
         git fetch --quiet "$remote" main >/dev/null 2>&1 || true
         printf '%s\n' "$remote/main"
         return 0
     fi
 
     local upstream=""
-    if upstream=$(_gwt_git_readonly rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" 2>/dev/null); then
+    if upstream=$(_gwt_git_audit rev-parse --abbrev-ref --symbolic-full-name "@{upstream}" 2>/dev/null); then
         local up_remote="${upstream%%/*}"
         local up_branch="${upstream#*/}"
         git fetch --quiet "$up_remote" "$up_branch" >/dev/null 2>&1 || true
-        if _gwt_git_readonly show-ref --verify --quiet "refs/remotes/$upstream"; then
+        if _gwt_git_audit show-ref --verify --quiet "refs/remotes/$upstream"; then
             printf '%s\n' "$upstream"
             return 0
         fi
@@ -857,7 +857,7 @@ _gwt_resolve_start_point() {
             fi
         fi
 
-        if _gwt_git_readonly rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null 2>&1; then
+        if _gwt_git_audit rev-parse --verify --quiet "${candidate}^{commit}" >/dev/null 2>&1; then
             if [[ "$candidate" != "$requested" ]]; then
                 echo "gwt: start-point '$requested' not found, using '$candidate'" >&2
             fi
@@ -884,7 +884,7 @@ _gwt_shared_install_source() {
     local main_worktree=""
     local worktrees_root=""
 
-    main_worktree=$(_gwt_git_readonly worktree list --porcelain | awk '/^worktree / {print substr($0, 10); exit}')
+    main_worktree=$(_gwt_git_audit worktree list --porcelain | awk '/^worktree / {print substr($0, 10); exit}')
     if [[ -n "$main_worktree" && -d "$main_worktree/node_modules" ]]; then
         printf '%s\n' "$main_worktree"
         return 0
@@ -1084,7 +1084,7 @@ EOF
             _gwt_tmux_sync_context
             ;;
         *)
-            if ! _gwt_git_readonly rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+            if ! _gwt_git_audit rev-parse --is-inside-work-tree > /dev/null 2>&1; then
                 echo "gwt: not inside a git repository"
                 return 1
             fi
@@ -1096,7 +1096,7 @@ EOF
             ;;
         ls|list)
             local repo_root list_table color_mode="auto"
-            repo_root=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
+            repo_root=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
             while [[ $# -gt 0 ]]; do
                 case "$1" in
                     --raw)
@@ -1126,7 +1126,7 @@ EOF
             ;;
         audit)
             local repo_root cleaner_path audit_table worktree_count
-            repo_root=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
+            repo_root=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
             _gwt_validate_cleanup_args audit "$@" || return 1
             cleaner_path=$(_gwt_tool_path agent-worktree-clean) || {
                 echo "gwt: agent-worktree-clean not found" >&2
@@ -1147,11 +1147,12 @@ EOF
                 _gwt_render_ls "$repo_root" "$(printf '%s\n' "$audit_table" | sed -n '1,12p')" "auto"
             fi
             printf '\n'
-            GIT_OPTIONAL_LOCKS=0 "$cleaner_path" --repo "$repo_root" "$@" || return 1
+            GIT_OPTIONAL_LOCKS=0 GIT_NO_LAZY_FETCH=1 \
+                "$cleaner_path" --repo "$repo_root" "$@" || return 1
             ;;
         clean)
             local repo_root maintainer_path
-            repo_root=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
+            repo_root=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
             _gwt_validate_cleanup_args clean "$@" || return 1
             maintainer_path=$(_gwt_tool_path agent-worktree-maintain) || {
                 echo "gwt: agent-worktree-maintain not found" >&2
@@ -1199,7 +1200,7 @@ EOF
             fi
 
             root="${DOTFILES_WORKTREES_ROOT:-$HOME/.codex/worktrees}"
-            repo_root=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
+            repo_root=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
             repo_slug=$(_gwt_repo_slug) || return 1
             branch_slug=$(printf '%s' "$branch" | tr '/' '-' | tr -cd '[:alnum:]._-')
             [[ -z "$branch_slug" ]] && branch_slug="$branch"
@@ -1244,7 +1245,7 @@ EOF
                 fi
             fi
 
-            if _gwt_git_readonly show-ref --verify --quiet "refs/heads/$branch"; then
+            if _gwt_git_audit show-ref --verify --quiet "refs/heads/$branch"; then
                 if [[ "$use_sparse" == true ]]; then
                     git worktree add --no-checkout "$worktree_path" "$branch" || return 1
                 else
@@ -1284,7 +1285,7 @@ EOF
 
             if [[ -z "$target" ]]; then
                 if command -v fzf > /dev/null 2>&1; then
-                    selected=$(_gwt_fzf_table "$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null)" | fzf \
+                    selected=$(_gwt_fzf_table "$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null)" | fzf \
                         --delimiter=$'\t' \
                         --with-nth=2,3,4,5 \
                         --prompt='worktree> ' \
@@ -1327,12 +1328,12 @@ EOF
                 return 1
             fi
 
-            repo_root=$(_gwt_git_readonly rev-parse --show-toplevel 2>/dev/null) || return 1
+            repo_root=$(_gwt_git_audit rev-parse --show-toplevel 2>/dev/null) || return 1
             target_path=$(_gwt_registered_worktree_path "$repo_root" "$target_path" 2>/dev/null) || {
                 echo "gwt: refusing path not registered to this repository: $target_path" >&2
                 return 1
             }
-            main_worktree=$(_gwt_git_readonly worktree list --porcelain | awk '/^worktree / {print substr($0, 10); exit}')
+            main_worktree=$(_gwt_git_audit worktree list --porcelain | awk '/^worktree / {print substr($0, 10); exit}')
             main_worktree=$(cd "$main_worktree" 2>/dev/null && pwd -P) || return 1
             if [[ "$target_path" == "$main_worktree" ]]; then
                 echo "gwt: refusing to remove the main worktree ($target_path)"
@@ -1345,7 +1346,7 @@ EOF
                 return 1
             fi
 
-            if ! $force_remove && [[ -n "$(_gwt_git_readonly -C "$target_path" status --porcelain 2>/dev/null)" ]]; then
+            if ! $force_remove && [[ -n "$(_gwt_git_audit -C "$target_path" status --porcelain 2>/dev/null)" ]]; then
                 echo "gwt: worktree has uncommitted changes. Re-run with --force to remove."
                 return 1
             fi
@@ -1371,7 +1372,7 @@ EOF
                     _gwt_tmux_sync_context
                     ;;
                 list|profiles)
-                    _gwt_sparse_list_profiles "$(_gwt_git_readonly rev-parse --show-toplevel)" || return 1
+                    _gwt_sparse_list_profiles "$(_gwt_git_audit rev-parse --show-toplevel)" || return 1
                     _gwt_tmux_sync_context
                     ;;
                 set)
@@ -1379,17 +1380,17 @@ EOF
                         echo "Usage: gwt sparse set <profile>"
                         return 1
                     }
-                    _gwt_sparse_apply_profile "$(_gwt_git_readonly rev-parse --show-toplevel)" "$1" || return 1
+                    _gwt_sparse_apply_profile "$(_gwt_git_audit rev-parse --show-toplevel)" "$1" || return 1
                     _gwt_sparse_sync_shell_env
                     _gwt_tmux_sync_context
                     ;;
                 add|expand)
-                    _gwt_sparse_add_paths "$(_gwt_git_readonly rev-parse --show-toplevel)" "$@" || return 1
+                    _gwt_sparse_add_paths "$(_gwt_git_audit rev-parse --show-toplevel)" "$@" || return 1
                     _gwt_sparse_sync_shell_env
                     _gwt_tmux_sync_context
                     ;;
                 full|disable)
-                    _gwt_sparse_apply_profile "$(_gwt_git_readonly rev-parse --show-toplevel)" "full" || return 1
+                    _gwt_sparse_apply_profile "$(_gwt_git_audit rev-parse --show-toplevel)" "full" || return 1
                     _gwt_sparse_sync_shell_env
                     _gwt_tmux_sync_context
                     ;;

--- a/tests/agent-worktree-ops-test.py
+++ b/tests/agent-worktree-ops-test.py
@@ -192,6 +192,7 @@ class WorktreeCleanerTests(unittest.TestCase):
         environment = os.environ.copy()
         environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
         environment["GIT_OPTIONAL_LOCKS"] = "caller-value"
+        environment["GIT_NO_LAZY_FETCH"] = "caller-lazy-value"
 
         before = snapshot_worktree_metadata(self.repo)
         index_before = path_metadata(removable_index)
@@ -221,6 +222,7 @@ class WorktreeCleanerTests(unittest.TestCase):
         stale_before = snapshot_tree(stale_admin)
         apply_environment = environment.copy()
         apply_environment.pop("GIT_OPTIONAL_LOCKS")
+        apply_environment.pop("GIT_NO_LAZY_FETCH")
         apply = subprocess.run(
             [
                 str(CLEANER_PATH),
@@ -322,13 +324,21 @@ class WorktreeCleanerTests(unittest.TestCase):
         self.assertEqual(command[:4], ["git", "-C", "/tmp/example", "status"])
         self.assertNotIn("diff", command)
 
-    def test_readonly_git_env_is_command_local(self) -> None:
-        with mock.patch.dict(os.environ, {"GIT_OPTIONAL_LOCKS": "caller-value"}):
+    def test_audit_git_env_is_command_local(self) -> None:
+        with mock.patch.dict(
+            os.environ,
+            {
+                "GIT_OPTIONAL_LOCKS": "caller-value",
+                "GIT_NO_LAZY_FETCH": "caller-lazy-value",
+            },
+        ):
             with mock.patch.object(CLEANER.subprocess, "run") as run:
-                CLEANER.run_git_readonly(["git", "status"], check=False)
+                CLEANER.run_git_audit(["git", "status"], check=False)
 
             self.assertEqual(os.environ["GIT_OPTIONAL_LOCKS"], "caller-value")
+            self.assertEqual(os.environ["GIT_NO_LAZY_FETCH"], "caller-lazy-value")
             self.assertEqual(run.call_args.kwargs["env"]["GIT_OPTIONAL_LOCKS"], "0")
+            self.assertEqual(run.call_args.kwargs["env"]["GIT_NO_LAZY_FETCH"], "1")
 
     def test_live_ownership_probe_failures_are_fatal(self) -> None:
         worktree = CLEANER.Worktree("/tmp/example", "abc", "refs/heads/test", False, 10)

--- a/tests/agent-worktree-ops-test.py
+++ b/tests/agent-worktree-ops-test.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import hashlib
 import importlib.util
 import io
 import os
@@ -53,6 +54,72 @@ def add_worktree(repo: Path, path: Path, branch: str, start: str = "main") -> No
     git(repo, "worktree", "add", "-b", branch, str(path), start)
 
 
+def path_metadata(path: Path) -> tuple[str, int, int, int, str]:
+    stats = path.lstat()
+    if path.is_symlink():
+        kind = "symlink"
+        content = os.readlink(path).encode()
+    elif path.is_dir():
+        kind = "directory"
+        content = b""
+    else:
+        kind = "file"
+        content = path.read_bytes()
+    return (
+        kind,
+        stats.st_mode,
+        stats.st_size,
+        stats.st_mtime_ns,
+        hashlib.sha256(content).hexdigest(),
+    )
+
+
+def snapshot_tree(root: Path) -> dict[str, tuple[str, int, int, int, str]]:
+    if not root.exists():
+        return {}
+    paths = [root, *sorted(root.rglob("*"))]
+    return {
+        "." if path == root else str(path.relative_to(root)): path_metadata(path)
+        for path in paths
+    }
+
+
+def snapshot_worktree_metadata(repo: Path) -> dict[str, object]:
+    common_dir = Path(
+        git(repo, "rev-parse", "--path-format=absolute", "--git-common-dir").stdout.strip()
+    )
+    return {
+        "common_dir": path_metadata(common_dir),
+        "worktrees": snapshot_tree(common_dir / "worktrees"),
+    }
+
+
+def worktree_index(worktree: Path) -> Path:
+    return Path(
+        git(
+            worktree,
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-path",
+            "index",
+        ).stdout.strip()
+    )
+
+
+def invalidate_index_stat_cache(worktree: Path) -> Path:
+    tracked_file = worktree / "README.md"
+    original = tracked_file.read_bytes()
+    original_stats = tracked_file.stat()
+    tracked_file.write_bytes(original)
+    os.utime(
+        tracked_file,
+        ns=(original_stats.st_atime_ns, original_stats.st_mtime_ns + 5_000_000_000),
+    )
+    index = worktree_index(worktree)
+    os.chmod(index, 0o644)
+    return index
+
+
 class WorktreeCleanerTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
@@ -102,7 +169,16 @@ class WorktreeCleanerTests(unittest.TestCase):
         stale = self.slug_root / "stale"
         add_worktree(self.repo, removable, "removable")
         add_worktree(self.repo, stale, "stale")
+        stale_admin = Path(
+            git(
+                stale,
+                "rev-parse",
+                "--path-format=absolute",
+                "--git-dir",
+            ).stdout.strip()
+        )
         shutil.rmtree(stale)
+        removable_index = invalidate_index_stat_cache(removable)
 
         fake_bin = self.base / "bin"
         fake_bin.mkdir()
@@ -115,8 +191,10 @@ class WorktreeCleanerTests(unittest.TestCase):
         os.chmod(fake_bin / "tmux", 0o755)
         environment = os.environ.copy()
         environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
+        environment["GIT_OPTIONAL_LOCKS"] = "caller-value"
 
-        before = git(self.repo, "worktree", "list", "--porcelain").stdout
+        before = snapshot_worktree_metadata(self.repo)
+        index_before = path_metadata(removable_index)
         audit = subprocess.run(
             [
                 str(CLEANER_PATH),
@@ -136,9 +214,14 @@ class WorktreeCleanerTests(unittest.TestCase):
             check=True,
         )
         self.assertIn("mode: dry-run", audit.stdout)
-        self.assertEqual(before, git(self.repo, "worktree", "list", "--porcelain").stdout)
+        self.assertEqual(before, snapshot_worktree_metadata(self.repo))
+        self.assertEqual(index_before, path_metadata(removable_index))
+        self.assertEqual(removable_index.stat().st_mode & 0o777, 0o644)
 
-        subprocess.run(
+        stale_before = snapshot_tree(stale_admin)
+        apply_environment = environment.copy()
+        apply_environment.pop("GIT_OPTIONAL_LOCKS")
+        apply = subprocess.run(
             [
                 str(CLEANER_PATH),
                 "--repo",
@@ -151,15 +234,16 @@ class WorktreeCleanerTests(unittest.TestCase):
                 "999",
                 "--apply",
             ],
-            env=environment,
+            env=apply_environment,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
             check=True,
         )
         after = git(self.repo, "worktree", "list", "--porcelain").stdout
-        self.assertFalse(removable.exists())
+        self.assertFalse(removable.exists(), apply.stdout)
         self.assertIn(f"worktree {CLEANER.normalize_path(str(stale))}", after)
+        self.assertEqual(stale_before, snapshot_tree(stale_admin))
 
     def test_reachability_matrix(self) -> None:
         safe_upstream = self.slug_root / "safe-upstream"
@@ -229,6 +313,22 @@ class WorktreeCleanerTests(unittest.TestCase):
         git(parent, "commit", "-am", "add submodule")
         (parent / "vendor" / "child" / "README.md").write_text("dirty\n", encoding="utf-8")
         self.assertTrue(CLEANER.is_worktree_dirty(str(parent)))
+
+    def test_dirty_probe_uses_status_without_git_diff(self) -> None:
+        with mock.patch.object(CLEANER, "run_text", return_value="") as run_text:
+            self.assertFalse(CLEANER.is_worktree_dirty("/tmp/example"))
+
+        command = run_text.call_args.args[0]
+        self.assertEqual(command[:4], ["git", "-C", "/tmp/example", "status"])
+        self.assertNotIn("diff", command)
+
+    def test_readonly_git_env_is_command_local(self) -> None:
+        with mock.patch.dict(os.environ, {"GIT_OPTIONAL_LOCKS": "caller-value"}):
+            with mock.patch.object(CLEANER.subprocess, "run") as run:
+                CLEANER.run_git_readonly(["git", "status"], check=False)
+
+            self.assertEqual(os.environ["GIT_OPTIONAL_LOCKS"], "caller-value")
+            self.assertEqual(run.call_args.kwargs["env"]["GIT_OPTIONAL_LOCKS"], "0")
 
     def test_live_ownership_probe_failures_are_fatal(self) -> None:
         worktree = CLEANER.Worktree("/tmp/example", "abc", "refs/heads/test", False, 10)

--- a/tests/gwt-cleanup-test.zsh
+++ b/tests/gwt-cleanup-test.zsh
@@ -47,7 +47,7 @@ TEST_GIT_AUDIT_ENV="$temporary/git-audit-env.out" \
 zsh -f -c '
   source "$1"
   unset GIT_OPTIONAL_LOCKS GIT_NO_LAZY_FETCH
-  _gwt_git_audit status
+  _gwt_git_probe status
   (( ${+GIT_OPTIONAL_LOCKS} == 0 ))
   (( ${+GIT_NO_LAZY_FETCH} == 0 ))
  ' zsh "$gwt_source"

--- a/tests/gwt-cleanup-test.zsh
+++ b/tests/gwt-cleanup-test.zsh
@@ -17,6 +17,142 @@ cp "$root/functions/gwt/gwt.zsh" "$gwt_source"
 cp "$root/bin/agent-worktree-ops/agent-worktree-clean" "$runtime/agent-worktree-clean"
 chmod +x "$runtime/agent-worktree-clean"
 
+fake_bin="$temporary/bin"
+mkdir -p "$fake_bin"
+cat >"$fake_bin/lsof" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+cat >"$fake_bin/tmux" <<'EOF'
+#!/bin/sh
+echo 'no server running' >&2
+exit 1
+EOF
+chmod +x "$fake_bin/lsof" "$fake_bin/tmux"
+
+metadata_snapshot() {
+  GIT_OPTIONAL_LOCKS=0 python3 - "$1" <<'PY'
+import hashlib
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+repo = Path(sys.argv[1])
+environment = os.environ.copy()
+environment["GIT_OPTIONAL_LOCKS"] = "0"
+common_dir = Path(
+    subprocess.check_output(
+        ["git", "-C", str(repo), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        env=environment,
+        text=True,
+    ).strip()
+)
+worktrees_dir = common_dir / "worktrees"
+
+
+def metadata(path):
+    details = path.lstat()
+    if path.is_symlink():
+        kind = "symlink"
+        content = os.readlink(path).encode()
+    elif path.is_dir():
+        kind = "directory"
+        content = b""
+    else:
+        kind = "file"
+        content = path.read_bytes()
+    return {
+        "type": kind,
+        "mode": stat.S_IMODE(details.st_mode),
+        "size": details.st_size,
+        "mtime_ns": details.st_mtime_ns,
+        "sha256": hashlib.sha256(content).hexdigest(),
+    }
+
+
+snapshot = {"common_dir": metadata(common_dir), "worktrees": {}}
+if worktrees_dir.exists():
+    for path in [worktrees_dir, *sorted(worktrees_dir.rglob("*"))]:
+        relative = "." if path == worktrees_dir else str(path.relative_to(worktrees_dir))
+        snapshot["worktrees"][relative] = metadata(path)
+print(json.dumps(snapshot, sort_keys=True, separators=(",", ":")))
+PY
+}
+
+tree_snapshot() {
+  python3 - "$1" <<'PY'
+import hashlib
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+snapshot = {}
+if root.exists():
+    for path in [root, *sorted(root.rglob("*"))]:
+        details = path.lstat()
+        if path.is_symlink():
+            kind = "symlink"
+            content = os.readlink(path).encode()
+        elif path.is_dir():
+            kind = "directory"
+            content = b""
+        else:
+            kind = "file"
+            content = path.read_bytes()
+        relative = "." if path == root else str(path.relative_to(root))
+        snapshot[relative] = {
+            "type": kind,
+            "mode": stat.S_IMODE(details.st_mode),
+            "size": details.st_size,
+            "mtime_ns": details.st_mtime_ns,
+            "sha256": hashlib.sha256(content).hexdigest(),
+        }
+print(json.dumps(snapshot, sort_keys=True, separators=(",", ":")))
+PY
+}
+
+invalidate_index_stat_cache() {
+  python3 - "$1" <<'PY'
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+worktree = Path(sys.argv[1])
+tracked = worktree / "README.md"
+details = tracked.stat()
+tracked.write_bytes(tracked.read_bytes())
+os.utime(tracked, ns=(details.st_atime_ns, details.st_mtime_ns + 5_000_000_000))
+environment = os.environ.copy()
+environment["GIT_OPTIONAL_LOCKS"] = "0"
+index = Path(
+    subprocess.check_output(
+        [
+            "git",
+            "-C",
+            str(worktree),
+            "rev-parse",
+            "--path-format=absolute",
+            "--git-path",
+            "index",
+        ],
+        env=environment,
+        text=True,
+    ).strip()
+)
+os.chmod(index, 0o644)
+details = index.stat()
+print(f"{index}\t{stat.S_IMODE(details.st_mode):04o}\t{details.st_mtime_ns}")
+PY
+}
+
 git init -b main "$repo" >/dev/null
 git -C "$repo" config user.name "Worktree Test"
 git -C "$repo" config user.email "worktree@example.test"
@@ -26,10 +162,92 @@ git -C "$repo" add README.md
 git -C "$repo" commit -m fixture >/dev/null
 
 remove_path="$temporary/remove-me"
+apply_path="$temporary/apply-me"
 stale_path="$temporary/stale"
+foreign_row="$home/.codex/worktrees/owner-repo/foreign-row"
 git -C "$repo" worktree add -b remove-me "$remove_path" main >/dev/null
+git -C "$repo" worktree add -b apply-me "$apply_path" main >/dev/null
 git -C "$repo" worktree add -b stale "$stale_path" main >/dev/null
+stale_admin="$(GIT_OPTIONAL_LOCKS=0 git -C "$stale_path" rev-parse --path-format=absolute --git-dir)"
 rm -rf "$stale_path"
+git init -b main "$foreign_row" >/dev/null
+
+index_before="$(invalidate_index_stat_cache "$remove_path")"
+metadata_before="$(metadata_snapshot "$repo")"
+PATH="$fake_bin:$PATH" \
+GIT_OPTIONAL_LOCKS=caller-value \
+"$runtime/agent-worktree-clean" \
+  --repo "$repo" \
+  --codex-home "$home/.codex" \
+  --min-age-days 999 \
+  --trim-artifacts-age-days 999 \
+  >"$temporary/direct-audit.out"
+[[ "$metadata_before" == "$(metadata_snapshot "$repo")" ]]
+if [[ -d "$foreign_row/.git" ]]; then
+  grep -Fq "${foreign_row:A}  (foreign-common-dir)" "$temporary/direct-audit.out"
+fi
+[[ "$index_before" == "$(python3 - "${index_before%%$'\t'*}" <<'PY'
+import stat
+import sys
+from pathlib import Path
+
+index = Path(sys.argv[1])
+details = index.stat()
+print(f"{index}\t{stat.S_IMODE(details.st_mode):04o}\t{details.st_mtime_ns}")
+PY
+)" ]]
+[[ "$(printf '%s\n' "$index_before" | cut -f2)" == "0644" ]]
+
+PATH="$fake_bin:$PATH" \
+HOME="$home" \
+DOTFILES_WORKTREES_ROOT="$worktrees_root" \
+zsh -f -c '
+  source "$1"
+  cd "$2"
+  unset GIT_OPTIONAL_LOCKS
+  gwt audit --min-age-days 999 --trim-artifacts-age-days 999
+  (( ${+GIT_OPTIONAL_LOCKS} == 0 ))
+ ' zsh "$gwt_source" "$repo" >"$temporary/gwt-audit-unset.out"
+[[ "$metadata_before" == "$(metadata_snapshot "$repo")" ]]
+
+PATH="$fake_bin:$PATH" \
+HOME="$home" \
+DOTFILES_WORKTREES_ROOT="$worktrees_root" \
+GIT_OPTIONAL_LOCKS=caller-value \
+zsh -f -c '
+  source "$1"
+  cd "$2"
+  gwt audit --min-age-days 999 --trim-artifacts-age-days 999
+  [[ "$GIT_OPTIONAL_LOCKS" == "caller-value" ]]
+ ' zsh "$gwt_source" "$repo" >"$temporary/gwt-audit-custom.out"
+[[ "$metadata_before" == "$(metadata_snapshot "$repo")" ]]
+[[ "$index_before" == "$(python3 - "${index_before%%$'\t'*}" <<'PY'
+import stat
+import sys
+from pathlib import Path
+
+index = Path(sys.argv[1])
+details = index.stat()
+print(f"{index}\t{stat.S_IMODE(details.st_mode):04o}\t{details.st_mtime_ns}")
+PY
+)" ]]
+
+git -C "$repo" worktree lock "$remove_path"
+stale_before="$(tree_snapshot "$stale_admin")"
+PATH="$fake_bin:$PATH" \
+"$runtime/agent-worktree-clean" \
+  --repo "$repo" \
+  --codex-home "$home/.codex" \
+  --min-age-days 0 \
+  --trim-artifacts-age-days 999 \
+  --apply \
+  >"$temporary/direct-apply.out"
+[[ ! -d "$apply_path" ]]
+grep -Fq "worktree ${stale_path:A}" <<< "$(
+  GIT_OPTIONAL_LOCKS=0 git -C "$repo" worktree list --porcelain
+)"
+[[ "$stale_before" == "$(tree_snapshot "$stale_admin")" ]]
+git -C "$repo" worktree unlock "$remove_path"
 
 HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
   source "$1"
@@ -38,7 +256,9 @@ HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
  ' zsh "$gwt_source" "$repo"
 
 [[ ! -d "$remove_path" ]]
-git -C "$repo" worktree list --porcelain | grep -Fq "worktree ${stale_path:A}"
+grep -Fq "worktree ${stale_path:A}" <<< "$(
+  GIT_OPTIONAL_LOCKS=0 git -C "$repo" worktree list --porcelain
+)"
 
 if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
   source "$1"

--- a/tests/gwt-cleanup-test.zsh
+++ b/tests/gwt-cleanup-test.zsh
@@ -30,8 +30,31 @@ exit 1
 EOF
 chmod +x "$fake_bin/lsof" "$fake_bin/tmux"
 
+audit_probe_bin="$temporary/audit-probe-bin"
+mkdir -p "$audit_probe_bin"
+cat >"$audit_probe_bin/git" <<'EOF'
+#!/bin/sh
+printf '%s\t%s\n' \
+  "${GIT_OPTIONAL_LOCKS-unset}" \
+  "${GIT_NO_LAZY_FETCH-unset}" \
+  >"$TEST_GIT_AUDIT_ENV"
+EOF
+chmod +x "$audit_probe_bin/git"
+
+PATH="$audit_probe_bin:$PATH" \
+HOME="$home" \
+TEST_GIT_AUDIT_ENV="$temporary/git-audit-env.out" \
+zsh -f -c '
+  source "$1"
+  unset GIT_OPTIONAL_LOCKS GIT_NO_LAZY_FETCH
+  _gwt_git_audit status
+  (( ${+GIT_OPTIONAL_LOCKS} == 0 ))
+  (( ${+GIT_NO_LAZY_FETCH} == 0 ))
+ ' zsh "$gwt_source"
+grep -Fxq $'0\t1' "$temporary/git-audit-env.out"
+
 metadata_snapshot() {
-  GIT_OPTIONAL_LOCKS=0 python3 - "$1" <<'PY'
+  GIT_OPTIONAL_LOCKS=0 GIT_NO_LAZY_FETCH=1 python3 - "$1" <<'PY'
 import hashlib
 import json
 import os
@@ -43,6 +66,7 @@ from pathlib import Path
 repo = Path(sys.argv[1])
 environment = os.environ.copy()
 environment["GIT_OPTIONAL_LOCKS"] = "0"
+environment["GIT_NO_LAZY_FETCH"] = "1"
 common_dir = Path(
     subprocess.check_output(
         ["git", "-C", str(repo), "rev-parse", "--path-format=absolute", "--git-common-dir"],
@@ -132,6 +156,7 @@ tracked.write_bytes(tracked.read_bytes())
 os.utime(tracked, ns=(details.st_atime_ns, details.st_mtime_ns + 5_000_000_000))
 environment = os.environ.copy()
 environment["GIT_OPTIONAL_LOCKS"] = "0"
+environment["GIT_NO_LAZY_FETCH"] = "1"
 index = Path(
     subprocess.check_output(
         [
@@ -176,6 +201,7 @@ index_before="$(invalidate_index_stat_cache "$remove_path")"
 metadata_before="$(metadata_snapshot "$repo")"
 PATH="$fake_bin:$PATH" \
 GIT_OPTIONAL_LOCKS=caller-value \
+GIT_NO_LAZY_FETCH=caller-lazy-value \
 "$runtime/agent-worktree-clean" \
   --repo "$repo" \
   --codex-home "$home/.codex" \
@@ -204,9 +230,10 @@ DOTFILES_WORKTREES_ROOT="$worktrees_root" \
 zsh -f -c '
   source "$1"
   cd "$2"
-  unset GIT_OPTIONAL_LOCKS
+  unset GIT_OPTIONAL_LOCKS GIT_NO_LAZY_FETCH
   gwt audit --min-age-days 999 --trim-artifacts-age-days 999
   (( ${+GIT_OPTIONAL_LOCKS} == 0 ))
+  (( ${+GIT_NO_LAZY_FETCH} == 0 ))
  ' zsh "$gwt_source" "$repo" >"$temporary/gwt-audit-unset.out"
 [[ "$metadata_before" == "$(metadata_snapshot "$repo")" ]]
 
@@ -214,11 +241,13 @@ PATH="$fake_bin:$PATH" \
 HOME="$home" \
 DOTFILES_WORKTREES_ROOT="$worktrees_root" \
 GIT_OPTIONAL_LOCKS=caller-value \
+GIT_NO_LAZY_FETCH=caller-lazy-value \
 zsh -f -c '
   source "$1"
   cd "$2"
   gwt audit --min-age-days 999 --trim-artifacts-age-days 999
   [[ "$GIT_OPTIONAL_LOCKS" == "caller-value" ]]
+  [[ "$GIT_NO_LAZY_FETCH" == "caller-lazy-value" ]]
  ' zsh "$gwt_source" "$repo" >"$temporary/gwt-audit-custom.out"
 [[ "$metadata_before" == "$(metadata_snapshot "$repo")" ]]
 [[ "$index_before" == "$(python3 - "${index_before%%$'\t'*}" <<'PY'


### PR DESCRIPTION
## Summary

- run every Git inspection probe with command-local `GIT_OPTIONAL_LOCKS=0` so audits cannot refresh linked-worktree indexes or administrative metadata
- add `GIT_NO_LAZY_FETCH=1` to the same probe boundary so missing objects fail closed instead of hydrating during an audit
- keep fetches, configuration writes, sparse-checkout operations, worktree add/remove/prune, checkout, and read-tree mutations on the normal Git path
- strengthen Python and Zsh fixtures with recursive `.git/worktrees` metadata snapshots, invalidated index stat caches, stale and foreign registrations, caller environment restoration, and apply-mode removal coverage

## Verification

- `python3 -m unittest tests/agent-worktree-ops-test.py`
- `zsh tests/functions-authority-test.zsh`
- `zsh tests/gwt-cleanup-test.zsh`
- `bash tests/agent-worktree-maintain-test.sh`
- `bash tests/install-agent-worktree-ops-test.sh`
- `zsh tests/deepclean-test.zsh`
- Zsh and Bash syntax checks
- Python bytecode compilation
- ShellCheck
- `git diff --check`
- real `gwt audit` with an empty `CODEX_HOME`, verifying exact before/after Git administrative metadata equality
