### PR TITLE
fix(gwt): harden scheduled maintenance safety

### DIFF
--- a/bin/agent-worktree-ops/README.md
+++ b/bin/agent-worktree-ops/README.md
@@ -10,8 +10,16 @@ Bins in this folder:
   - foreign, unregistered, non-Git, and stale-registration paths are report-only
   - apply mode revalidates dirtiness, reachability, sessions, tmux panes, and process CWDs
   - removals are serial, non-force `git worktree remove` operations
+  - apply exits nonzero when a selected trim or removal fails
+  - pass `--skip-legacy-purge` to leave legacy quarantine cleanup to a separate job
 - `agent-worktree-maintain`
   - pressure-aware maintenance runner using the cleaner's registered inventory
+  - pass `--state-dir` to keep its private lock and log outside `~/.codex`
+  - explicit state directories must already exist, be owned by the current user,
+    use private permissions, and not be symlinks
+  - verified same-user lock contention is a successful skip; malformed or
+    untrusted lock state exits with status 73
+  - pass `--skip-legacy-purge` to forward the cleaner's purge opt-out
 - `agent-worktree-purge`
   - background purge of entries left in the legacy quarantine directory
 - `install-agent-worktree-ops`

--- a/bin/agent-worktree-ops/README.md
+++ b/bin/agent-worktree-ops/README.md
@@ -15,11 +15,14 @@ Bins in this folder:
 - `agent-worktree-maintain`
   - pressure-aware maintenance runner using the cleaner's registered inventory
   - pass `--state-dir` to keep its private lock and log outside `~/.codex`
+  - always coordinates through the canonical Codex lock first; a distinct
+    state directory adds a second private lock acquired after it
   - explicit state directories must already exist, be owned by the current user,
     use private permissions, and not be symlinks
   - verified same-user lock contention is a successful skip; malformed or
     untrusted lock state exits with status 73
   - pass `--skip-legacy-purge` to forward the cleaner's purge opt-out
+  - pass `--no-log` to emit output for ephemeral capture without creating a log
 - `agent-worktree-purge`
   - background purge of entries left in the legacy quarantine directory
 - `install-agent-worktree-ops`

--- a/bin/agent-worktree-ops/agent-worktree-clean
+++ b/bin/agent-worktree-ops/agent-worktree-clean
@@ -129,6 +129,11 @@ def parse_args() -> argparse.Namespace:
         help="legacy quarantine directory to purge after apply (new removals are not quarantined)",
     )
     parser.add_argument(
+        "--skip-legacy-purge",
+        action="store_true",
+        help="do not start the asynchronous legacy quarantine purge after apply",
+    )
+    parser.add_argument(
         "--shared-node-modules-source",
         default=None,
         help="shared repo node_modules directory to symlink stale worktrees back to",
@@ -298,7 +303,7 @@ def main() -> int:
     if not args.apply:
         return 0
 
-    apply_trims(
+    failed_mutations = apply_trims(
         repo_root=repo_root,
         codex_home=codex_home,
         candidates=trimmable,
@@ -306,7 +311,7 @@ def main() -> int:
         session_limit=args.limit,
         scan_limit=args.scan_limit,
     )
-    apply_removals(
+    failed_mutations += apply_removals(
         repo_root=repo_root,
         codex_home=codex_home,
         candidates=removable,
@@ -314,11 +319,18 @@ def main() -> int:
         session_limit=args.limit,
         scan_limit=args.scan_limit,
     )
-    spawn_async_purge(
-        codex_home=codex_home,
-        quarantine_root=quarantine_root,
-        delete_workers=args.delete_workers,
-    )
+    if not args.skip_legacy_purge:
+        spawn_async_purge(
+            codex_home=codex_home,
+            quarantine_root=quarantine_root,
+            delete_workers=args.delete_workers,
+        )
+    if failed_mutations:
+        print(
+            f"agent-worktree-clean: {failed_mutations} selected mutation(s) failed",
+            file=sys.stderr,
+        )
+        return 1
     return 0
 
 
@@ -824,29 +836,36 @@ def simplify_branch_label(worktree: Worktree) -> str:
     return "unknown"
 
 
-def trim_worktree_artifacts(worktree_path: str, shared_node_modules_source: str) -> None:
+def trim_worktree_artifacts(worktree_path: str, shared_node_modules_source: str) -> bool:
     node_modules_path = os.path.join(worktree_path, "node_modules")
     dist_path = os.path.join(worktree_path, "dist")
     dist_runtime_path = os.path.join(worktree_path, "dist-runtime")
     ui_node_modules_path = os.path.join(worktree_path, "ui", "node_modules")
     extensions_root = Path(worktree_path) / "extensions"
 
+    succeeded = True
     if (
         path_is_dir(node_modules_path)
         and not os.path.islink(node_modules_path)
         and path_is_dir(shared_node_modules_source)
     ):
-        delete_paths([node_modules_path])
-        os.symlink(shared_node_modules_source, node_modules_path)
+        if delete_paths([node_modules_path]):
+            try:
+                os.symlink(shared_node_modules_source, node_modules_path)
+            except OSError as error:
+                print(f"trim-failed  {node_modules_path}  ({error})")
+                succeeded = False
+        else:
+            succeeded = False
 
     if path_is_dir(dist_path):
-        delete_paths([dist_path])
+        succeeded = delete_paths([dist_path]) and succeeded
 
     if path_is_dir(dist_runtime_path):
-        delete_paths([dist_runtime_path])
+        succeeded = delete_paths([dist_runtime_path]) and succeeded
 
     if path_is_dir(ui_node_modules_path):
-        delete_paths([ui_node_modules_path])
+        succeeded = delete_paths([ui_node_modules_path]) and succeeded
 
     extension_node_modules_paths = [
         str(extension_path / "node_modules")
@@ -854,18 +873,25 @@ def trim_worktree_artifacts(worktree_path: str, shared_node_modules_source: str)
         if extension_path.is_dir() and path_is_dir(str(extension_path / "node_modules"))
     ] if extensions_root.is_dir() else []
     if extension_node_modules_paths:
-        delete_paths(extension_node_modules_paths)
+        succeeded = delete_paths(extension_node_modules_paths) and succeeded
+    return succeeded
 
 
-def delete_paths(paths: list[str]) -> None:
+def delete_paths(paths: list[str]) -> bool:
     if not paths:
-        return
-    subprocess.run(
+        return True
+    result = subprocess.run(
         ["/bin/rm", "-rf", *paths],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
         check=False,
     )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or str(result.returncode)
+        print(f"trim-failed  {' '.join(paths)}  (remove-failed: {detail})")
+        return False
+    return True
 
 
 def apply_trims(
@@ -876,7 +902,8 @@ def apply_trims(
     shared_node_modules_source: str,
     session_limit: int,
     scan_limit: int,
-) -> None:
+) -> int:
+    failed_mutations = 0
     with progress_bar(total=len(candidates), desc="trimming artifacts") as progress:
         for candidate in candidates:
             reason = revalidate_candidate(
@@ -891,8 +918,10 @@ def apply_trims(
             if reason:
                 print(f"skip  {candidate.path}  (changed: {reason})")
             else:
-                trim_worktree_artifacts(candidate.path, shared_node_modules_source)
+                if not trim_worktree_artifacts(candidate.path, shared_node_modules_source):
+                    failed_mutations += 1
             progress.update(1)
+    return failed_mutations
 
 
 def apply_removals(
@@ -903,7 +932,8 @@ def apply_removals(
     include_detached: bool,
     session_limit: int,
     scan_limit: int,
-) -> None:
+) -> int:
+    failed_mutations = 0
     with progress_bar(total=len(candidates), desc="removing worktrees") as progress:
         for candidate in candidates:
             reason = revalidate_candidate(
@@ -928,6 +958,7 @@ def apply_removals(
                 check=False,
             )
             if result.returncode != 0:
+                failed_mutations += 1
                 print(
                     f"skip  {candidate.path}  "
                     f"(remove-failed: {result.stderr.strip() or result.returncode})"
@@ -935,6 +966,7 @@ def apply_removals(
             else:
                 print(f"drop  {candidate.path}")
             progress.update(1)
+    return failed_mutations
 
 
 def revalidate_candidate(

--- a/bin/agent-worktree-ops/agent-worktree-maintain
+++ b/bin/agent-worktree-ops/agent-worktree-maintain
@@ -280,7 +280,7 @@ create_lock() {
 inspect_existing_lock() {
   local lock_path="$1"
   local allow_legacy_modes="$2"
-  local owner_pid process_uid
+  local owner_pid process_output process_status process_uid
 
   validate_lock_contents "$lock_path" "$allow_legacy_modes" || return "$LOCK_STATE_ERROR"
   owner_pid="$(cat "$lock_path/pid" 2>/dev/null || true)"
@@ -289,14 +289,27 @@ inspect_existing_lock() {
     return "$LOCK_STATE_ERROR"
   }
 
-  process_uid="$(ps -o uid= -p "$owner_pid" 2>/dev/null | tr -d '[:space:]' || true)"
-  if [[ -n "$process_uid" ]]; then
+  if process_output="$(ps -o uid= -p "$owner_pid" 2>/dev/null)"; then
+    process_status=0
+  else
+    process_status=$?
+  fi
+  process_uid="$(printf '%s' "$process_output" | tr -d '[:space:]')"
+  if (( process_status == 0 )); then
+    [[ "$process_uid" =~ ^[0-9]+$ ]] || {
+      fail_lock_state "$lock_path/pid"
+      return "$LOCK_STATE_ERROR"
+    }
     [[ "$process_uid" == "$(id -u)" ]] || {
       fail_lock_state "$lock_path/pid"
       return "$LOCK_STATE_ERROR"
     }
     contention_pid="$owner_pid"
     return 10
+  fi
+  if (( process_status != 1 )) || [[ -n "$process_uid" ]]; then
+    fail_lock_state "$lock_path/pid"
+    return "$LOCK_STATE_ERROR"
   fi
 
   rm -f "$lock_path/pid" || {

--- a/bin/agent-worktree-ops/agent-worktree-maintain
+++ b/bin/agent-worktree-ops/agent-worktree-maintain
@@ -31,7 +31,9 @@ force=0
 state_dir=""
 state_dir_explicit=0
 skip_legacy_purge=0
-lock_owned=0
+no_log=0
+owned_lock_dirs=()
+contention_pid=""
 LOCK_STATE_ERROR=73
 
 path_owner_uid() {
@@ -71,6 +73,12 @@ path_is_private() {
   local mode="$1"
   [[ "$mode" =~ ^[0-7]{3,4}$ ]] || return 1
   (( (8#$mode & 077) == 0 ))
+}
+
+path_has_no_group_or_other_write() {
+  local mode="$1"
+  [[ "$mode" =~ ^[0-7]{3,4}$ ]] || return 1
+  (( (8#$mode & 022) == 0 ))
 }
 
 path_has_no_symlink_components() {
@@ -127,6 +135,24 @@ validate_owned_single_link_file() {
   [[ "$links" == "1" ]]
 }
 
+validate_compatible_directory() {
+  local path="$1"
+  local mode
+
+  validate_owned_directory "$path" 0 || return 1
+  mode="$(path_mode "$path")" || return 1
+  path_has_no_group_or_other_write "$mode"
+}
+
+validate_compatible_file() {
+  local path="$1"
+  local mode
+
+  validate_owned_single_link_file "$path" || return 1
+  mode="$(path_mode "$path")" || return 1
+  path_has_no_group_or_other_write "$mode"
+}
+
 fail_lock_state() {
   echo "agent-worktree-maintain: untrusted lock/state path: $1" >&2
   return "$LOCK_STATE_ERROR"
@@ -159,6 +185,21 @@ ensure_private_directory() {
   fi
 }
 
+ensure_coordination_directory() {
+  local path="$1"
+
+  if [[ ! -e "$path" ]]; then
+    if ! mkdir -m 700 "$path"; then
+      fail_lock_state "$path"
+      return "$LOCK_STATE_ERROR"
+    fi
+  fi
+  if ! validate_compatible_directory "$path"; then
+    fail_lock_state "$path"
+    return "$LOCK_STATE_ERROR"
+  fi
+}
+
 prepare_private_file() {
   local path="$1"
 
@@ -184,96 +225,108 @@ prepare_private_file() {
 }
 
 validate_lock_contents() {
+  local lock_path="$1"
+  local allow_legacy_modes="$2"
   local entries=()
-  local pid_file="$lock_dir/pid"
+  local pid_file="$lock_path/pid"
 
-  if ! validate_owned_directory "$lock_dir" 1; then
-    fail_lock_state "$lock_dir"
+  if (( allow_legacy_modes == 1 )); then
+    if ! validate_compatible_directory "$lock_path"; then
+      fail_lock_state "$lock_path"
+      return "$LOCK_STATE_ERROR"
+    fi
+  elif ! validate_owned_directory "$lock_path" 1; then
+    fail_lock_state "$lock_path"
     return "$LOCK_STATE_ERROR"
   fi
   shopt -s nullglob dotglob
-  entries=("$lock_dir"/*)
+  entries=("$lock_path"/*)
   shopt -u nullglob dotglob
   if (( ${#entries[@]} != 1 )) || [[ "${entries[0]}" != "$pid_file" ]]; then
-    fail_lock_state "$lock_dir"
+    fail_lock_state "$lock_path"
     return "$LOCK_STATE_ERROR"
   fi
-  if ! validate_owned_file "$pid_file"; then
+  if (( allow_legacy_modes == 1 )); then
+    if ! validate_compatible_file "$pid_file"; then
+      fail_lock_state "$pid_file"
+      return "$LOCK_STATE_ERROR"
+    fi
+  elif ! validate_owned_file "$pid_file"; then
     fail_lock_state "$pid_file"
     return "$LOCK_STATE_ERROR"
   fi
 }
 
 create_lock() {
-  mkdir -m 700 "$lock_dir" 2>/dev/null || return 1
-  if ! printf '%s\n' "$$" >"$lock_dir/pid"; then
-    rmdir "$lock_dir" 2>/dev/null || true
-    fail_lock_state "$lock_dir/pid"
+  local lock_path="$1"
+
+  mkdir -m 700 "$lock_path" 2>/dev/null || return 1
+  if ! printf '%s\n' "$$" >"$lock_path/pid"; then
+    rmdir "$lock_path" 2>/dev/null || true
+    fail_lock_state "$lock_path/pid"
     return "$LOCK_STATE_ERROR"
   fi
-  chmod 600 "$lock_dir/pid" || {
-    rm -f "$lock_dir/pid"
-    rmdir "$lock_dir" 2>/dev/null || true
-    fail_lock_state "$lock_dir/pid"
+  chmod 600 "$lock_path/pid" || {
+    rm -f "$lock_path/pid"
+    rmdir "$lock_path" 2>/dev/null || true
+    fail_lock_state "$lock_path/pid"
     return "$LOCK_STATE_ERROR"
   }
-  validate_lock_contents || return "$LOCK_STATE_ERROR"
-  lock_owned=1
+  validate_lock_contents "$lock_path" 0 || return "$LOCK_STATE_ERROR"
+  owned_lock_dirs+=("$lock_path")
   return 0
 }
 
 inspect_existing_lock() {
+  local lock_path="$1"
+  local allow_legacy_modes="$2"
   local owner_pid process_uid
 
-  validate_lock_contents || return "$LOCK_STATE_ERROR"
-  owner_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
+  validate_lock_contents "$lock_path" "$allow_legacy_modes" || return "$LOCK_STATE_ERROR"
+  owner_pid="$(cat "$lock_path/pid" 2>/dev/null || true)"
   [[ "$owner_pid" =~ ^[1-9][0-9]*$ ]] || {
-    fail_lock_state "$lock_dir/pid"
+    fail_lock_state "$lock_path/pid"
     return "$LOCK_STATE_ERROR"
   }
 
   process_uid="$(ps -o uid= -p "$owner_pid" 2>/dev/null | tr -d '[:space:]' || true)"
   if [[ -n "$process_uid" ]]; then
     [[ "$process_uid" == "$(id -u)" ]] || {
-      fail_lock_state "$lock_dir/pid"
+      fail_lock_state "$lock_path/pid"
       return "$LOCK_STATE_ERROR"
     }
-    if kill -0 "$owner_pid" 2>/dev/null; then
-      return 10
-    fi
-    process_uid="$(ps -o uid= -p "$owner_pid" 2>/dev/null | tr -d '[:space:]' || true)"
-    [[ -z "$process_uid" ]] || {
-      fail_lock_state "$lock_dir/pid"
-      return "$LOCK_STATE_ERROR"
-    }
+    contention_pid="$owner_pid"
+    return 10
   fi
 
-  rm -f "$lock_dir/pid" || {
-    fail_lock_state "$lock_dir/pid"
+  rm -f "$lock_path/pid" || {
+    fail_lock_state "$lock_path/pid"
     return "$LOCK_STATE_ERROR"
   }
-  rmdir "$lock_dir" || {
-    fail_lock_state "$lock_dir"
+  rmdir "$lock_path" || {
+    fail_lock_state "$lock_path"
     return "$LOCK_STATE_ERROR"
   }
   return 0
 }
 
 acquire_lock() {
+  local lock_path="$1"
+  local allow_legacy_modes="$2"
   local status
 
-  if create_lock; then
+  if create_lock "$lock_path"; then
     return 0
   else
     status=$?
   fi
   (( status == LOCK_STATE_ERROR )) && return "$status"
 
-  if inspect_existing_lock; then
-    if create_lock; then
+  if inspect_existing_lock "$lock_path" "$allow_legacy_modes"; then
+    if create_lock "$lock_path"; then
       return 0
     fi
-    fail_lock_state "$lock_dir"
+    fail_lock_state "$lock_path"
     return "$LOCK_STATE_ERROR"
   else
     status=$?
@@ -282,17 +335,19 @@ acquire_lock() {
   return "$status"
 }
 
-cleanup_lock() {
-  local owner_pid
+cleanup_locks() {
+  local index lock_path owner_pid
 
-  (( lock_owned == 1 )) || return 0
-  if ! validate_lock_contents >/dev/null 2>&1; then
-    return 0
-  fi
-  owner_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
-  [[ "$owner_pid" == "$$" ]] || return 0
-  rm -f "$lock_dir/pid" 2>/dev/null || return 0
-  rmdir "$lock_dir" 2>/dev/null || true
+  for (( index=${#owned_lock_dirs[@]} - 1; index >= 0; index-- )); do
+    lock_path="${owned_lock_dirs[$index]}"
+    if ! validate_lock_contents "$lock_path" 0 >/dev/null 2>&1; then
+      continue
+    fi
+    owner_pid="$(cat "$lock_path/pid" 2>/dev/null || true)"
+    [[ "$owner_pid" == "$$" ]] || continue
+    rm -f "$lock_path/pid" 2>/dev/null || continue
+    rmdir "$lock_path" 2>/dev/null || true
+  done
 }
 
 list_managed_worktrees() {
@@ -325,6 +380,16 @@ sum_real_node_modules_kib() {
       fi
     done
   done <<< "$managed_worktrees" | awk '{sum += $1} END {print sum + 0}'
+}
+
+emit_status() {
+  local message="$1"
+
+  if (( no_log == 1 )); then
+    echo "$message"
+  else
+    echo "$message" >>"$log_file"
+  fi
 }
 
 while [[ $# -gt 0 ]]; do
@@ -382,6 +447,10 @@ while [[ $# -gt 0 ]]; do
       skip_legacy_purge=1
       shift
       ;;
+    --no-log)
+      no_log=1
+      shift
+      ;;
     --help|-h)
       cat <<'EOF'
 Usage: agent-worktree-maintain [options]
@@ -402,6 +471,7 @@ Options:
   --max-dist-gib <n>       Run cleanup when top-level worktree dist exceeds this GiB cap.
   --force                  Run cleanup even below the threshold.
   --skip-legacy-purge      Do not start the cleaner's legacy quarantine purge.
+  --no-log                 Write status and cleaner output to stdout/stderr only.
 EOF
       exit 0
       ;;
@@ -414,6 +484,11 @@ done
 
 if (( state_dir_explicit == 0 )); then
   state_dir="$codex_home"
+fi
+
+if ! validate_compatible_directory "$codex_home"; then
+  fail_lock_state "$codex_home"
+  exit "$LOCK_STATE_ERROR"
 fi
 
 if (( state_dir_explicit == 1 )); then
@@ -429,28 +504,61 @@ else
   }
 fi
 
-lock_parent="$state_dir/locks"
-lock_dir="$lock_parent/agent-worktree-maintain.lock"
+canonical_lock_parent="$codex_home/locks"
+canonical_lock_dir="$canonical_lock_parent/agent-worktree-maintain.lock"
+private_lock_parent="$state_dir/locks"
+private_lock_dir="$private_lock_parent/agent-worktree-maintain.lock"
 log_dir="$state_dir/log"
 log_file="$log_dir/agent-worktree-maintain.log"
+separate_private_lock=0
+if [[ ! "$state_dir" -ef "$codex_home" ]]; then
+  separate_private_lock=1
+fi
 
-ensure_private_directory "$log_dir" || exit "$LOCK_STATE_ERROR"
-ensure_private_directory "$lock_parent" || exit "$LOCK_STATE_ERROR"
-prepare_private_file "$log_file" || exit "$LOCK_STATE_ERROR"
+ensure_coordination_directory "$canonical_lock_parent" || exit "$LOCK_STATE_ERROR"
+if (( separate_private_lock == 1 )); then
+  ensure_private_directory "$private_lock_parent" || exit "$LOCK_STATE_ERROR"
+fi
+if (( no_log == 0 )); then
+  ensure_private_directory "$log_dir" || exit "$LOCK_STATE_ERROR"
+  prepare_private_file "$log_file" || exit "$LOCK_STATE_ERROR"
+fi
 
-if acquire_lock; then
+trap cleanup_locks EXIT
+
+if acquire_lock "$canonical_lock_dir" 1; then
   :
 else
   lock_status=$?
   if (( lock_status == 10 )); then
-    owner_pid="$(cat "$lock_dir/pid")"
-    echo "[$(date '+%F %T')] agent-worktree-maintain: already running (pid=$owner_pid)" >>"$log_file"
+    contention_message="[$(date '+%F %T')] agent-worktree-maintain: already running (pid=$contention_pid)"
+    if (( no_log == 1 )); then
+      echo "$contention_message"
+    else
+      echo "$contention_message" >>"$log_file"
+    fi
     exit 0
   fi
   exit "$lock_status"
 fi
 
-trap cleanup_lock EXIT
+if (( separate_private_lock == 1 )); then
+  if acquire_lock "$private_lock_dir" 0; then
+    :
+  else
+    lock_status=$?
+    if (( lock_status == 10 )); then
+      contention_message="[$(date '+%F %T')] agent-worktree-maintain: already running (pid=$contention_pid)"
+      if (( no_log == 1 )); then
+        echo "$contention_message"
+      else
+        echo "$contention_message" >>"$log_file"
+      fi
+      exit 0
+    fi
+    exit "$lock_status"
+  fi
+fi
 
 managed_worktrees="$(list_managed_worktrees)"
 worktree_count="$(printf '%s\n' "$managed_worktrees" | awk 'NF {count++} END {print count + 0}')"
@@ -485,11 +593,14 @@ elif awk "BEGIN { exit !($dist_gib >= $max_dist_gib) }"; then
 fi
 
 if (( should_skip == 1 )); then
-  echo "[$(date '+%F %T')] agent-worktree-maintain: skip $skip_reason repo=$repo" >>"$log_file"
+  emit_status "[$(date '+%F %T')] agent-worktree-maintain: skip $skip_reason repo=$repo"
   exit 0
 fi
 
-{
+run_cleanup() {
+  local status
+  local cleaner_args=()
+
   echo "[$(date '+%F %T')] agent-worktree-maintain: start count=$worktree_count threshold=$threshold free_gib=$free_gib min_free_gib=$min_free_gib real_node_modules_gib=$real_node_modules_gib max_real_node_modules_gib=$max_real_node_modules_gib dist_gib=$dist_gib max_dist_gib=$max_dist_gib repo=$repo"
   cleaner_args=(
     --repo "$repo" \
@@ -508,6 +619,12 @@ fi
   else
     status=$?
     echo "[$(date '+%F %T')] agent-worktree-maintain: failed status=$status"
-    exit "$status"
+    return "$status"
   fi
-} >>"$log_file" 2>&1
+}
+
+if (( no_log == 1 )); then
+  run_cleanup
+else
+  run_cleanup >>"$log_file" 2>&1
+fi

--- a/bin/agent-worktree-ops/agent-worktree-maintain
+++ b/bin/agent-worktree-ops/agent-worktree-maintain
@@ -56,6 +56,17 @@ path_mode() {
   stat -c '%a' "$1" 2>/dev/null
 }
 
+path_link_count() {
+  local value
+
+  value="$(stat -f '%l' "$1" 2>/dev/null || true)"
+  if [[ "$value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  stat -c '%h' "$1" 2>/dev/null
+}
+
 path_is_private() {
   local mode="$1"
   [[ "$mode" =~ ^[0-7]{3,4}$ ]] || return 1
@@ -94,13 +105,26 @@ validate_owned_directory() {
 
 validate_owned_file() {
   local path="$1"
-  local owner mode
+  local owner mode links
 
   [[ -f "$path" && ! -L "$path" ]] || return 1
   owner="$(path_owner_uid "$path")" || return 1
   [[ "$owner" == "$(id -u)" ]] || return 1
+  links="$(path_link_count "$path")" || return 1
+  [[ "$links" == "1" ]] || return 1
   mode="$(path_mode "$path")" || return 1
   path_is_private "$mode"
+}
+
+validate_owned_single_link_file() {
+  local path="$1"
+  local owner links
+
+  [[ -f "$path" && ! -L "$path" ]] || return 1
+  owner="$(path_owner_uid "$path")" || return 1
+  [[ "$owner" == "$(id -u)" ]] || return 1
+  links="$(path_link_count "$path")" || return 1
+  [[ "$links" == "1" ]]
 }
 
 fail_lock_state() {
@@ -139,7 +163,7 @@ prepare_private_file() {
   local path="$1"
 
   if [[ -e "$path" || -L "$path" ]]; then
-    if ! validate_owned_file "$path"; then
+    if ! validate_owned_single_link_file "$path"; then
       fail_lock_state "$path"
       return "$LOCK_STATE_ERROR"
     fi

--- a/bin/agent-worktree-ops/agent-worktree-maintain
+++ b/bin/agent-worktree-ops/agent-worktree-maintain
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -euo pipefail
+umask 077
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export GIT_CONFIG_GLOBAL="${GIT_CONFIG_GLOBAL:-/dev/null}"
@@ -27,6 +28,248 @@ min_free_gib="$DEFAULT_MIN_FREE_GIB"
 max_real_node_modules_gib="$DEFAULT_MAX_REAL_NODE_MODULES_GIB"
 max_dist_gib="$DEFAULT_MAX_DIST_GIB"
 force=0
+state_dir=""
+state_dir_explicit=0
+skip_legacy_purge=0
+lock_owned=0
+LOCK_STATE_ERROR=73
+
+path_owner_uid() {
+  local value
+
+  value="$(stat -f '%u' "$1" 2>/dev/null || true)"
+  if [[ "$value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  stat -c '%u' "$1" 2>/dev/null
+}
+
+path_mode() {
+  local value
+
+  value="$(stat -f '%Lp' "$1" 2>/dev/null || true)"
+  if [[ "$value" =~ ^[0-7]{3,4}$ ]]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  stat -c '%a' "$1" 2>/dev/null
+}
+
+path_is_private() {
+  local mode="$1"
+  [[ "$mode" =~ ^[0-7]{3,4}$ ]] || return 1
+  (( (8#$mode & 077) == 0 ))
+}
+
+path_has_no_symlink_components() {
+  local path="$1"
+  local current="/"
+  local component
+  local components=()
+
+  [[ "$path" == /* ]] || return 1
+  IFS='/' read -r -a components <<<"${path#/}"
+  for component in "${components[@]}"; do
+    [[ -n "$component" && "$component" != "." && "$component" != ".." ]] || return 1
+    current="${current%/}/$component"
+    [[ ! -L "$current" ]] || return 1
+  done
+}
+
+validate_owned_directory() {
+  local path="$1"
+  local require_private="$2"
+  local owner mode
+
+  [[ -d "$path" && ! -L "$path" ]] || return 1
+  [[ "$path" == /* ]] || return 1
+  owner="$(path_owner_uid "$path")" || return 1
+  [[ "$owner" == "$(id -u)" ]] || return 1
+  if (( require_private == 1 )); then
+    mode="$(path_mode "$path")" || return 1
+    path_is_private "$mode" || return 1
+  fi
+}
+
+validate_owned_file() {
+  local path="$1"
+  local owner mode
+
+  [[ -f "$path" && ! -L "$path" ]] || return 1
+  owner="$(path_owner_uid "$path")" || return 1
+  [[ "$owner" == "$(id -u)" ]] || return 1
+  mode="$(path_mode "$path")" || return 1
+  path_is_private "$mode"
+}
+
+fail_lock_state() {
+  echo "agent-worktree-maintain: untrusted lock/state path: $1" >&2
+  return "$LOCK_STATE_ERROR"
+}
+
+ensure_private_directory() {
+  local path="$1"
+
+  if [[ ! -e "$path" ]]; then
+    if ! mkdir -m 700 "$path"; then
+      fail_lock_state "$path"
+      return "$LOCK_STATE_ERROR"
+    fi
+  fi
+  if [[ ! -d "$path" || -L "$path" ]]; then
+    fail_lock_state "$path"
+    return "$LOCK_STATE_ERROR"
+  fi
+  if [[ "$(path_owner_uid "$path" 2>/dev/null || true)" != "$(id -u)" ]]; then
+    fail_lock_state "$path"
+    return "$LOCK_STATE_ERROR"
+  fi
+  if ! chmod 700 "$path"; then
+    fail_lock_state "$path"
+    return "$LOCK_STATE_ERROR"
+  fi
+  if ! validate_owned_directory "$path" 1; then
+    fail_lock_state "$path"
+    return "$LOCK_STATE_ERROR"
+  fi
+}
+
+prepare_private_file() {
+  local path="$1"
+
+  if [[ -e "$path" || -L "$path" ]]; then
+    if ! validate_owned_file "$path"; then
+      fail_lock_state "$path"
+      return "$LOCK_STATE_ERROR"
+    fi
+  else
+    if ! : >"$path"; then
+      fail_lock_state "$path"
+      return "$LOCK_STATE_ERROR"
+    fi
+  fi
+  if ! chmod 600 "$path"; then
+    fail_lock_state "$path"
+    return "$LOCK_STATE_ERROR"
+  fi
+  if ! validate_owned_file "$path"; then
+    fail_lock_state "$path"
+    return "$LOCK_STATE_ERROR"
+  fi
+}
+
+validate_lock_contents() {
+  local entries=()
+  local pid_file="$lock_dir/pid"
+
+  if ! validate_owned_directory "$lock_dir" 1; then
+    fail_lock_state "$lock_dir"
+    return "$LOCK_STATE_ERROR"
+  fi
+  shopt -s nullglob dotglob
+  entries=("$lock_dir"/*)
+  shopt -u nullglob dotglob
+  if (( ${#entries[@]} != 1 )) || [[ "${entries[0]}" != "$pid_file" ]]; then
+    fail_lock_state "$lock_dir"
+    return "$LOCK_STATE_ERROR"
+  fi
+  if ! validate_owned_file "$pid_file"; then
+    fail_lock_state "$pid_file"
+    return "$LOCK_STATE_ERROR"
+  fi
+}
+
+create_lock() {
+  mkdir -m 700 "$lock_dir" 2>/dev/null || return 1
+  if ! printf '%s\n' "$$" >"$lock_dir/pid"; then
+    rmdir "$lock_dir" 2>/dev/null || true
+    fail_lock_state "$lock_dir/pid"
+    return "$LOCK_STATE_ERROR"
+  fi
+  chmod 600 "$lock_dir/pid" || {
+    rm -f "$lock_dir/pid"
+    rmdir "$lock_dir" 2>/dev/null || true
+    fail_lock_state "$lock_dir/pid"
+    return "$LOCK_STATE_ERROR"
+  }
+  validate_lock_contents || return "$LOCK_STATE_ERROR"
+  lock_owned=1
+  return 0
+}
+
+inspect_existing_lock() {
+  local owner_pid process_uid
+
+  validate_lock_contents || return "$LOCK_STATE_ERROR"
+  owner_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
+  [[ "$owner_pid" =~ ^[1-9][0-9]*$ ]] || {
+    fail_lock_state "$lock_dir/pid"
+    return "$LOCK_STATE_ERROR"
+  }
+
+  process_uid="$(ps -o uid= -p "$owner_pid" 2>/dev/null | tr -d '[:space:]' || true)"
+  if [[ -n "$process_uid" ]]; then
+    [[ "$process_uid" == "$(id -u)" ]] || {
+      fail_lock_state "$lock_dir/pid"
+      return "$LOCK_STATE_ERROR"
+    }
+    if kill -0 "$owner_pid" 2>/dev/null; then
+      return 10
+    fi
+    process_uid="$(ps -o uid= -p "$owner_pid" 2>/dev/null | tr -d '[:space:]' || true)"
+    [[ -z "$process_uid" ]] || {
+      fail_lock_state "$lock_dir/pid"
+      return "$LOCK_STATE_ERROR"
+    }
+  fi
+
+  rm -f "$lock_dir/pid" || {
+    fail_lock_state "$lock_dir/pid"
+    return "$LOCK_STATE_ERROR"
+  }
+  rmdir "$lock_dir" || {
+    fail_lock_state "$lock_dir"
+    return "$LOCK_STATE_ERROR"
+  }
+  return 0
+}
+
+acquire_lock() {
+  local status
+
+  if create_lock; then
+    return 0
+  else
+    status=$?
+  fi
+  (( status == LOCK_STATE_ERROR )) && return "$status"
+
+  if inspect_existing_lock; then
+    if create_lock; then
+      return 0
+    fi
+    fail_lock_state "$lock_dir"
+    return "$LOCK_STATE_ERROR"
+  else
+    status=$?
+  fi
+  (( status == 10 )) && return 10
+  return "$status"
+}
+
+cleanup_lock() {
+  local owner_pid
+
+  (( lock_owned == 1 )) || return 0
+  if ! validate_lock_contents >/dev/null 2>&1; then
+    return 0
+  fi
+  owner_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
+  [[ "$owner_pid" == "$$" ]] || return 0
+  rm -f "$lock_dir/pid" 2>/dev/null || return 0
+  rmdir "$lock_dir" 2>/dev/null || true
+}
 
 list_managed_worktrees() {
   "$DEFAULT_CLEANER" \
@@ -70,6 +313,11 @@ while [[ $# -gt 0 ]]; do
       codex_home="$2"
       shift 2
       ;;
+    --state-dir)
+      state_dir="$2"
+      state_dir_explicit=1
+      shift 2
+      ;;
     --limit)
       session_limit="$2"
       shift 2
@@ -106,6 +354,10 @@ while [[ $# -gt 0 ]]; do
       force=1
       shift
       ;;
+    --skip-legacy-purge)
+      skip_legacy_purge=1
+      shift
+      ;;
     --help|-h)
       cat <<'EOF'
 Usage: agent-worktree-maintain [options]
@@ -113,6 +365,7 @@ Usage: agent-worktree-maintain [options]
 Options:
   --repo <path>            Repo root to maintain.
   --codex-home <path>      Codex home directory.
+  --state-dir <path>       Private directory for this runner's lock and log.
   --limit <n>              Session keep-set passed to agent-worktree-clean.
   --min-age-days <n>       Minimum worktree age before cleanup.
   --trim-artifacts-age-days <n>
@@ -124,6 +377,7 @@ Options:
                            Run cleanup when real worktree node_modules exceeds this GiB cap.
   --max-dist-gib <n>       Run cleanup when top-level worktree dist exceeds this GiB cap.
   --force                  Run cleanup even below the threshold.
+  --skip-legacy-purge      Do not start the cleaner's legacy quarantine purge.
 EOF
       exit 0
       ;;
@@ -134,30 +388,44 @@ EOF
   esac
 done
 
-lock_dir="$codex_home/locks/agent-worktree-maintain.lock"
-log_dir="$codex_home/log"
-log_file="$log_dir/agent-worktree-maintain.log"
-
-mkdir -p "$log_dir" "$(dirname "$lock_dir")"
-
-if mkdir "$lock_dir" 2>/dev/null; then
-  printf '%s\n' "$$" >"$lock_dir/pid"
-else
-  if [[ -f "$lock_dir/pid" ]]; then
-    owner_pid="$(cat "$lock_dir/pid" 2>/dev/null || true)"
-    if [[ -n "${owner_pid:-}" ]] && kill -0 "$owner_pid" 2>/dev/null; then
-      echo "[$(date '+%F %T')] agent-worktree-maintain: already running (pid=$owner_pid)" >>"$log_file"
-      exit 0
-    fi
-  fi
-  rm -rf "$lock_dir"
-  mkdir "$lock_dir"
-  printf '%s\n' "$$" >"$lock_dir/pid"
+if (( state_dir_explicit == 0 )); then
+  state_dir="$codex_home"
 fi
 
-cleanup_lock() {
-  rm -rf "$lock_dir"
-}
+if (( state_dir_explicit == 1 )); then
+  if ! path_has_no_symlink_components "$state_dir" ||
+    ! validate_owned_directory "$state_dir" 1; then
+    fail_lock_state "$state_dir"
+    exit "$LOCK_STATE_ERROR"
+  fi
+else
+  validate_owned_directory "$state_dir" 0 || {
+    fail_lock_state "$state_dir"
+    exit "$LOCK_STATE_ERROR"
+  }
+fi
+
+lock_parent="$state_dir/locks"
+lock_dir="$lock_parent/agent-worktree-maintain.lock"
+log_dir="$state_dir/log"
+log_file="$log_dir/agent-worktree-maintain.log"
+
+ensure_private_directory "$log_dir" || exit "$LOCK_STATE_ERROR"
+ensure_private_directory "$lock_parent" || exit "$LOCK_STATE_ERROR"
+prepare_private_file "$log_file" || exit "$LOCK_STATE_ERROR"
+
+if acquire_lock; then
+  :
+else
+  lock_status=$?
+  if (( lock_status == 10 )); then
+    owner_pid="$(cat "$lock_dir/pid")"
+    echo "[$(date '+%F %T')] agent-worktree-maintain: already running (pid=$owner_pid)" >>"$log_file"
+    exit 0
+  fi
+  exit "$lock_status"
+fi
+
 trap cleanup_lock EXIT
 
 managed_worktrees="$(list_managed_worktrees)"
@@ -199,7 +467,7 @@ fi
 
 {
   echo "[$(date '+%F %T')] agent-worktree-maintain: start count=$worktree_count threshold=$threshold free_gib=$free_gib min_free_gib=$min_free_gib real_node_modules_gib=$real_node_modules_gib max_real_node_modules_gib=$max_real_node_modules_gib dist_gib=$dist_gib max_dist_gib=$max_dist_gib repo=$repo"
-  "$DEFAULT_CLEANER" \
+  cleaner_args=(
     --repo "$repo" \
     --codex-home "$codex_home" \
     --limit "$session_limit" \
@@ -207,5 +475,15 @@ fi
     --trim-artifacts-age-days "$trim_artifacts_age_days" \
     --delete-workers "$delete_workers" \
     --apply
-  echo "[$(date '+%F %T')] agent-worktree-maintain: done"
+  )
+  if (( skip_legacy_purge == 1 )); then
+    cleaner_args+=(--skip-legacy-purge)
+  fi
+  if "$DEFAULT_CLEANER" "${cleaner_args[@]}"; then
+    echo "[$(date '+%F %T')] agent-worktree-maintain: done"
+  else
+    status=$?
+    echo "[$(date '+%F %T')] agent-worktree-maintain: failed status=$status"
+    exit "$status"
+  fi
 } >>"$log_file" 2>&1

--- a/tests/agent-worktree-maintain-test.sh
+++ b/tests/agent-worktree-maintain-test.sh
@@ -72,9 +72,110 @@ grep -q -- '--apply' "$temporary/cleaner.args"
 grep -q -- '--skip-legacy-purge' "$temporary/cleaner.args"
 [[ ! -e "$codex_home/log/agent-worktree-maintain.log" ]]
 [[ ! -e "$state_dir/locks/agent-worktree-maintain.lock" ]]
+[[ ! -e "$codex_home/locks/agent-worktree-maintain.lock" ]]
 [[ "$(mode_of "$state_dir/log")" == "700" ]]
 [[ "$(mode_of "$state_dir/locks")" == "700" ]]
 [[ "$(mode_of "$log_file")" == "600" ]]
+
+legacy_codex_home="$temporary/legacy-codex"
+legacy_state_dir="$temporary/legacy-state"
+legacy_lock_dir="$legacy_codex_home/locks/agent-worktree-maintain.lock"
+mkdir -m 755 "$legacy_codex_home" "$legacy_codex_home/locks" "$legacy_lock_dir"
+mkdir -m 700 "$legacy_state_dir"
+printf '%s\n' "$$" >"$legacy_lock_dir/pid"
+chmod 644 "$legacy_lock_dir/pid"
+TEST_REGISTERED="$registered" \
+TEST_CLEANER_ARGS="$temporary/legacy-cleaner.args" \
+CODEX_HOME="$legacy_codex_home" \
+"$runtime/agent-worktree-maintain" \
+  --repo "$repo" \
+  --codex-home "$legacy_codex_home" \
+  --state-dir "$legacy_state_dir" \
+  --force \
+  --no-log >"$temporary/legacy-contention.out"
+grep -q "already running (pid=$$)" "$temporary/legacy-contention.out"
+[[ "$(mode_of "$legacy_lock_dir")" == "755" ]]
+[[ "$(mode_of "$legacy_lock_dir/pid")" == "644" ]]
+[[ ! -e "$legacy_state_dir/locks/agent-worktree-maintain.lock" ]]
+rm "$legacy_lock_dir/pid"
+rmdir "$legacy_lock_dir"
+
+unsafe_codex_home="$temporary/unsafe-codex"
+unsafe_state_dir="$temporary/unsafe-state"
+unsafe_lock_dir="$unsafe_codex_home/locks/agent-worktree-maintain.lock"
+mkdir -m 755 "$unsafe_codex_home" "$unsafe_codex_home/locks" "$unsafe_lock_dir"
+chmod 777 "$unsafe_lock_dir"
+mkdir -m 700 "$unsafe_state_dir"
+printf '%s\n' "$$" >"$unsafe_lock_dir/pid"
+chmod 644 "$unsafe_lock_dir/pid"
+set +e
+TEST_REGISTERED="$registered" \
+TEST_CLEANER_ARGS="$temporary/unsafe-cleaner.args" \
+CODEX_HOME="$unsafe_codex_home" \
+"$runtime/agent-worktree-maintain" \
+  --repo "$repo" \
+  --codex-home "$unsafe_codex_home" \
+  --state-dir "$unsafe_state_dir" \
+  --force \
+  --no-log >"$temporary/unsafe-lock.out" 2>&1
+status=$?
+set -e
+[[ "$status" == "73" ]]
+grep -q 'untrusted lock/state path' "$temporary/unsafe-lock.out"
+[[ -d "$unsafe_lock_dir" ]]
+
+no_log_codex_home="$temporary/no-log-codex"
+no_log_state_dir="$temporary/no-log-state"
+fake_bin="$temporary/fake-bin"
+release_log="$temporary/release-order"
+mkdir -m 700 "$no_log_codex_home" "$no_log_state_dir"
+mkdir "$fake_bin"
+cat >"$fake_bin/rmdir" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$1" >>"$TEST_RMDIR_LOG"
+exec /bin/rmdir "$@"
+EOF
+chmod +x "$fake_bin/rmdir"
+TEST_REGISTERED="$registered" \
+TEST_CLEANER_ARGS="$temporary/no-log-cleaner.args" \
+TEST_RMDIR_LOG="$release_log" \
+CODEX_HOME="$no_log_codex_home" \
+PATH="$fake_bin:$PATH" \
+"$runtime/agent-worktree-maintain" \
+  --repo "$repo" \
+  --codex-home "$no_log_codex_home" \
+  --state-dir "$no_log_state_dir" \
+  --force \
+  --skip-legacy-purge \
+  --no-log >"$temporary/no-log.out"
+grep -q 'agent-worktree-maintain: start ' "$temporary/no-log.out"
+grep -q 'agent-worktree-maintain: done' "$temporary/no-log.out"
+[[ ! -e "$no_log_state_dir/log" ]]
+[[ ! -e "$no_log_codex_home/log" ]]
+expected_release_order="$no_log_state_dir/locks/agent-worktree-maintain.lock
+$no_log_codex_home/locks/agent-worktree-maintain.lock"
+[[ "$(cat "$release_log")" == "$expected_release_order" ]]
+: >"$release_log"
+set +e
+TEST_REGISTERED="$registered" \
+TEST_CLEANER_ARGS="$temporary/no-log-cleaner.args" \
+TEST_CLEANER_EXIT=42 \
+TEST_RMDIR_LOG="$release_log" \
+CODEX_HOME="$no_log_codex_home" \
+PATH="$fake_bin:$PATH" \
+"$runtime/agent-worktree-maintain" \
+  --repo "$repo" \
+  --codex-home "$no_log_codex_home" \
+  --state-dir "$no_log_state_dir" \
+  --force \
+  --skip-legacy-purge \
+  --no-log >"$temporary/no-log-failure.out" 2>&1
+status=$?
+set -e
+[[ "$status" == "42" ]]
+grep -q 'failed status=42' "$temporary/no-log-failure.out"
+[[ ! -e "$no_log_state_dir/log" ]]
+[[ ! -e "$no_log_codex_home/log" ]]
 
 hardlink_state="$temporary/hardlink-state"
 mkdir -m 700 "$hardlink_state" "$hardlink_state/log"
@@ -102,6 +203,7 @@ chmod 600 "$lock_dir/pid"
 run_maintainer
 grep -q "already running (pid=$$)" "$log_file"
 [[ -d "$lock_dir" ]]
+[[ ! -e "$codex_home/locks/agent-worktree-maintain.lock" ]]
 rm "$lock_dir/pid"
 rmdir "$lock_dir"
 

--- a/tests/agent-worktree-maintain-test.sh
+++ b/tests/agent-worktree-maintain-test.sh
@@ -124,6 +124,39 @@ set -e
 grep -q 'untrusted lock/state path' "$temporary/unsafe-lock.out"
 [[ -d "$unsafe_lock_dir" ]]
 
+probe_codex_home="$temporary/probe-codex"
+probe_state_dir="$temporary/probe-state"
+probe_lock_dir="$probe_codex_home/locks/agent-worktree-maintain.lock"
+probe_bin="$temporary/probe-bin"
+probe_cleaner_args="$temporary/probe-cleaner.args"
+mkdir -m 700 "$probe_codex_home" "$probe_codex_home/locks" "$probe_lock_dir"
+mkdir -m 700 "$probe_state_dir" "$probe_bin"
+printf '%s\n' "$$" >"$probe_lock_dir/pid"
+chmod 600 "$probe_lock_dir/pid"
+cat >"$probe_bin/ps" <<'EOF'
+#!/usr/bin/env bash
+exit 2
+EOF
+chmod +x "$probe_bin/ps"
+set +e
+TEST_REGISTERED="$registered" \
+TEST_CLEANER_ARGS="$probe_cleaner_args" \
+CODEX_HOME="$probe_codex_home" \
+PATH="$probe_bin:$PATH" \
+"$runtime/agent-worktree-maintain" \
+  --repo "$repo" \
+  --codex-home "$probe_codex_home" \
+  --state-dir "$probe_state_dir" \
+  --force \
+  --no-log >"$temporary/probe-error.out" 2>&1
+status=$?
+set -e
+[[ "$status" == "73" ]]
+grep -q 'untrusted lock/state path' "$temporary/probe-error.out"
+[[ -d "$probe_lock_dir" ]]
+[[ "$(cat "$probe_lock_dir/pid")" == "$$" ]]
+[[ ! -e "$probe_cleaner_args" ]]
+
 no_log_codex_home="$temporary/no-log-codex"
 no_log_state_dir="$temporary/no-log-state"
 fake_bin="$temporary/fake-bin"

--- a/tests/agent-worktree-maintain-test.sh
+++ b/tests/agent-worktree-maintain-test.sh
@@ -4,12 +4,15 @@ set -euo pipefail
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 temporary="$(mktemp -d)"
 trap 'rm -rf "$temporary"' EXIT
+temporary="$(cd "$temporary" && pwd -P)"
 
 runtime="$temporary/runtime"
 repo="$temporary/repo"
 codex_home="$temporary/codex"
+state_dir="$temporary/state"
 registered="$temporary/registered"
-mkdir -p "$runtime" "$repo" "$registered"
+mkdir -p "$runtime" "$repo" "$codex_home" "$state_dir" "$registered"
+chmod 700 "$state_dir"
 cp "$root/bin/agent-worktree-ops/agent-worktree-maintain" "$runtime/agent-worktree-maintain"
 
 cat >"$runtime/agent-worktree-clean" <<'EOF'
@@ -20,20 +23,113 @@ if [[ " $* " == *" --list-registered "* ]]; then
   exit 0
 fi
 printf '%s\n' "$*" >"$TEST_CLEANER_ARGS"
+exit "${TEST_CLEANER_EXIT:-0}"
 EOF
 chmod +x "$runtime/agent-worktree-clean" "$runtime/agent-worktree-maintain"
 
+mode_of() {
+  stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1"
+}
+
+default_codex_home="$temporary/default-codex"
+mkdir -m 700 "$default_codex_home"
+TEST_REGISTERED="$registered" \
+TEST_CLEANER_ARGS="$temporary/default-cleaner.args" \
+CODEX_HOME="$default_codex_home" \
+"$runtime/agent-worktree-maintain" \
+  --repo "$repo" \
+  --codex-home "$default_codex_home" \
+  --force
+grep -q 'start count=1 ' "$default_codex_home/log/agent-worktree-maintain.log"
+if grep -q -- '--skip-legacy-purge' "$temporary/default-cleaner.args"; then
+  echo 'default maintainer unexpectedly disabled legacy purge' >&2
+  exit 1
+fi
+
+run_maintainer() {
+  TEST_REGISTERED="$registered" \
+  TEST_CLEANER_ARGS="$temporary/cleaner.args" \
+  TEST_CLEANER_EXIT="${TEST_CLEANER_EXIT:-0}" \
+  CODEX_HOME="$codex_home" \
+  "$runtime/agent-worktree-maintain" \
+    --repo "$repo" \
+    --codex-home "$codex_home" \
+    --state-dir "$state_dir" \
+    --force \
+    --skip-legacy-purge
+}
+
+run_maintainer
+
+log_file="$state_dir/log/agent-worktree-maintain.log"
+grep -q 'start count=1 ' "$log_file"
+grep -q -- "--repo $repo" "$temporary/cleaner.args"
+grep -q -- "--codex-home $codex_home" "$temporary/cleaner.args"
+grep -q -- '--apply' "$temporary/cleaner.args"
+grep -q -- '--skip-legacy-purge' "$temporary/cleaner.args"
+[[ ! -e "$codex_home/log/agent-worktree-maintain.log" ]]
+[[ ! -e "$state_dir/locks/agent-worktree-maintain.lock" ]]
+[[ "$(mode_of "$state_dir/log")" == "700" ]]
+[[ "$(mode_of "$state_dir/locks")" == "700" ]]
+[[ "$(mode_of "$log_file")" == "600" ]]
+
+lock_dir="$state_dir/locks/agent-worktree-maintain.lock"
+mkdir -m 700 "$lock_dir"
+printf '%s\n' "$$" >"$lock_dir/pid"
+chmod 600 "$lock_dir/pid"
+run_maintainer
+grep -q "already running (pid=$$)" "$log_file"
+[[ -d "$lock_dir" ]]
+rm "$lock_dir/pid"
+rmdir "$lock_dir"
+
+mkdir -m 700 "$lock_dir"
+printf 'not-a-pid\n' >"$lock_dir/pid"
+chmod 600 "$lock_dir/pid"
+set +e
+run_maintainer >"$temporary/malformed.out" 2>&1
+status=$?
+set -e
+[[ "$status" == "73" ]]
+grep -q 'untrusted lock/state path' "$temporary/malformed.out"
+rm "$lock_dir/pid"
+rmdir "$lock_dir"
+
+mkdir -m 700 "$lock_dir"
+printf '99999999\n' >"$lock_dir/pid"
+chmod 600 "$lock_dir/pid"
+run_maintainer
+[[ ! -e "$lock_dir" ]]
+
+chmod 755 "$state_dir"
+set +e
+run_maintainer >"$temporary/public-state.out" 2>&1
+status=$?
+set -e
+[[ "$status" == "73" ]]
+chmod 700 "$state_dir"
+
+state_link="$temporary/state-link"
+ln -s "$state_dir" "$state_link"
+set +e
 TEST_REGISTERED="$registered" \
 TEST_CLEANER_ARGS="$temporary/cleaner.args" \
 CODEX_HOME="$codex_home" \
 "$runtime/agent-worktree-maintain" \
   --repo "$repo" \
   --codex-home "$codex_home" \
-  --force
+  --state-dir "$state_link" \
+  --force >"$temporary/symlink-state.out" 2>&1
+status=$?
+set -e
+[[ "$status" == "73" ]]
 
-grep -q 'start count=1 ' "$codex_home/log/agent-worktree-maintain.log"
-grep -q -- "--repo $repo" "$temporary/cleaner.args"
-grep -q -- "--codex-home $codex_home" "$temporary/cleaner.args"
-grep -q -- '--apply' "$temporary/cleaner.args"
+set +e
+TEST_CLEANER_EXIT=42 run_maintainer
+status=$?
+set -e
+[[ "$status" == "42" ]]
+grep -q 'failed status=42' "$log_file"
+[[ ! -e "$lock_dir" ]]
 
 printf 'agent worktree maintainer tests passed\n'

--- a/tests/agent-worktree-maintain-test.sh
+++ b/tests/agent-worktree-maintain-test.sh
@@ -13,6 +13,9 @@ state_dir="$temporary/state"
 registered="$temporary/registered"
 mkdir -p "$runtime" "$repo" "$codex_home" "$state_dir" "$registered"
 chmod 700 "$state_dir"
+mkdir -m 700 "$state_dir/log"
+: >"$state_dir/log/agent-worktree-maintain.log"
+chmod 644 "$state_dir/log/agent-worktree-maintain.log"
 cp "$root/bin/agent-worktree-ops/agent-worktree-maintain" "$runtime/agent-worktree-maintain"
 
 cat >"$runtime/agent-worktree-clean" <<'EOF'
@@ -72,6 +75,25 @@ grep -q -- '--skip-legacy-purge' "$temporary/cleaner.args"
 [[ "$(mode_of "$state_dir/log")" == "700" ]]
 [[ "$(mode_of "$state_dir/locks")" == "700" ]]
 [[ "$(mode_of "$log_file")" == "600" ]]
+
+hardlink_state="$temporary/hardlink-state"
+mkdir -m 700 "$hardlink_state" "$hardlink_state/log"
+: >"$temporary/hardlink-anchor"
+chmod 600 "$temporary/hardlink-anchor"
+ln "$temporary/hardlink-anchor" "$hardlink_state/log/agent-worktree-maintain.log"
+set +e
+TEST_REGISTERED="$registered" \
+TEST_CLEANER_ARGS="$temporary/cleaner.args" \
+CODEX_HOME="$codex_home" \
+"$runtime/agent-worktree-maintain" \
+  --repo "$repo" \
+  --codex-home "$codex_home" \
+  --state-dir "$hardlink_state" \
+  --force >"$temporary/hardlink-state.out" 2>&1
+status=$?
+set -e
+[[ "$status" == "73" ]]
+grep -q 'untrusted lock/state path' "$temporary/hardlink-state.out"
 
 lock_dir="$state_dir/locks/agent-worktree-maintain.lock"
 mkdir -m 700 "$lock_dir"

--- a/tests/agent-worktree-ops-test.py
+++ b/tests/agent-worktree-ops-test.py
@@ -407,6 +407,116 @@ class WorktreeCleanerTests(unittest.TestCase):
                             CLEANER.parse_args()
                 self.assertNotEqual(raised.exception.code, 0)
 
+    def test_skip_legacy_purge_flag_prevents_spawn(self) -> None:
+        with mock.patch.object(
+            CLEANER.sys,
+            "argv",
+            ["agent-worktree-clean", "--skip-legacy-purge"],
+        ):
+            self.assertTrue(CLEANER.parse_args().skip_legacy_purge)
+
+        args = SimpleNamespace(
+            repo=str(self.repo),
+            codex_home=str(self.codex_home),
+            quarantine_root=str(self.codex_home / "quarantine"),
+            shared_node_modules_source=str(self.repo / "node_modules"),
+            list_registered=False,
+            scan_limit=200,
+            limit=30,
+            min_age_days=2,
+            trim_artifacts_age_days=0.25,
+            include_detached=False,
+            apply=True,
+            delete_workers=4,
+            skip_legacy_purge=True,
+        )
+        inventory = CLEANER.Inventory(
+            common_dir=str(self.repo / ".git"),
+            worktrees=[],
+            report_only=[],
+        )
+        with mock.patch.object(CLEANER, "parse_args", return_value=args):
+            with mock.patch.object(CLEANER, "build_inventory", return_value=inventory):
+                with mock.patch.object(CLEANER, "find_latest_state_db", return_value=None):
+                    with mock.patch.object(CLEANER, "collect_owned_worktree_paths", return_value=set()):
+                        with mock.patch.object(CLEANER, "print_summary"):
+                            with mock.patch.object(CLEANER, "apply_trims", return_value=0):
+                                with mock.patch.object(CLEANER, "apply_removals", return_value=0):
+                                    with mock.patch.object(CLEANER, "spawn_async_purge") as spawn:
+                                        self.assertEqual(CLEANER.main(), 0)
+        spawn.assert_not_called()
+
+    def test_delete_failure_is_reported(self) -> None:
+        failed_remove = SimpleNamespace(returncode=5, stdout="", stderr="permission denied")
+        with mock.patch.object(CLEANER.subprocess, "run", return_value=failed_remove):
+            self.assertFalse(CLEANER.delete_paths(["/tmp/example"]))
+
+    def test_apply_aggregates_trim_and_removal_failures(self) -> None:
+        candidate = CLEANER.Worktree(
+            path="/tmp/example",
+            head="abc",
+            branch_ref="refs/heads/example",
+            detached=False,
+            age_days=10,
+        )
+        failed_remove = SimpleNamespace(returncode=1, stdout="", stderr="refused")
+
+        with mock.patch.object(CLEANER, "progress_bar", return_value=mock.MagicMock()):
+            with mock.patch.object(CLEANER, "revalidate_candidate", return_value=None):
+                with mock.patch.object(CLEANER, "trim_worktree_artifacts", return_value=False):
+                    trim_failures = CLEANER.apply_trims(
+                        repo_root="/tmp/repo",
+                        codex_home="/tmp/codex",
+                        candidates=[candidate],
+                        shared_node_modules_source="/tmp/repo/node_modules",
+                        session_limit=30,
+                        scan_limit=200,
+                    )
+                with mock.patch.object(CLEANER.subprocess, "run", return_value=failed_remove):
+                    removal_failures = CLEANER.apply_removals(
+                        repo_root="/tmp/repo",
+                        codex_home="/tmp/codex",
+                        candidates=[candidate],
+                        include_detached=False,
+                        session_limit=30,
+                        scan_limit=200,
+                    )
+
+        self.assertEqual(trim_failures, 1)
+        self.assertEqual(removal_failures, 1)
+
+    def test_main_returns_nonzero_when_selected_mutations_fail(self) -> None:
+        args = SimpleNamespace(
+            repo=str(self.repo),
+            codex_home=str(self.codex_home),
+            quarantine_root=str(self.codex_home / "quarantine"),
+            shared_node_modules_source=str(self.repo / "node_modules"),
+            list_registered=False,
+            scan_limit=200,
+            limit=30,
+            min_age_days=2,
+            trim_artifacts_age_days=0.25,
+            include_detached=False,
+            apply=True,
+            delete_workers=4,
+            skip_legacy_purge=False,
+        )
+        inventory = CLEANER.Inventory(
+            common_dir=str(self.repo / ".git"),
+            worktrees=[],
+            report_only=[],
+        )
+        with mock.patch.object(CLEANER, "parse_args", return_value=args):
+            with mock.patch.object(CLEANER, "build_inventory", return_value=inventory):
+                with mock.patch.object(CLEANER, "find_latest_state_db", return_value=None):
+                    with mock.patch.object(CLEANER, "collect_owned_worktree_paths", return_value=set()):
+                        with mock.patch.object(CLEANER, "print_summary"):
+                            with mock.patch.object(CLEANER, "apply_trims", return_value=1):
+                                with mock.patch.object(CLEANER, "apply_removals", return_value=2):
+                                    with mock.patch.object(CLEANER, "spawn_async_purge") as spawn:
+                                        self.assertEqual(CLEANER.main(), 1)
+        spawn.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- add a scheduler-safe purge opt-out and propagate selected cleanup failures
- coordinate maintenance through the canonical lock plus an optional private state lock
- validate private state and legacy lock ownership/modes fail-closed
- add `--no-log` for ephemeral output capture without persistent path-bearing logs

## Verification

- `tests/agent-worktree-maintain-test.sh`
- `python3 tests/agent-worktree-ops-test.py`
- `tests/gwt-cleanup-test.zsh`
- ShellCheck, Bash 3.2 syntax, Python compile, and `git diff --check`

This PR only hardens the maintenance tools. It does not activate cleanup schedules or run cleanup.
