### PR TITLE
fix(gwt): harden read-only machine audits

### DIFF
--- a/bin/agent-worktree-ops/README.md
+++ b/bin/agent-worktree-ops/README.md
@@ -8,6 +8,21 @@ Bins in this folder:
   - dry-run/apply cleanup of idle worktrees and stale artifacts
   - only registered, non-main worktrees from the selected Git common dir are actionable
   - foreign, unregistered, non-Git, and stale-registration paths are report-only
+  - requires exactly one same-user, single-link `state*.sqlite` database; accepts
+    either the database alone or the database with both `-wal` and `-shm`
+    sidecars, and refuses ambiguous, asymmetric, journaled, or unexpected state
+    artifacts before classifying worktrees
+  - retains no-follow descriptors for the state directory and every accepted
+    artifact, then reads a relative SQLite `mode=ro` URI from an isolated child
+    anchored to that directory
+  - enables and verifies `query_only`, verifies the `threads` schema and the
+    database/WAL descriptors SQLite opened, then rechecks the anchored directory
+    and artifact identities after the child exits
+  - SQLite `mode=ro` alone may update an active WAL `-shm` file. Scheduled
+    zero-touch audits must additionally run inside the private scheduler's
+    physical-path write-denial sandbox; there is no writable fallback.
+  - pass `--machine` for one compact, sorted schema-v1 JSON audit line with
+    counts only; it is incompatible with `--apply` and `--list-registered`
   - apply mode revalidates dirtiness, reachability, sessions, tmux panes, and process CWDs
   - removals are serial, non-force `git worktree remove` operations
   - apply exits nonzero when a selected trim or removal fails

--- a/bin/agent-worktree-ops/agent-worktree-clean
+++ b/bin/agent-worktree-ops/agent-worktree-clean
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
 
 import argparse
+import json
 import os
 import shutil
 import sqlite3
+import stat
+import struct
 import subprocess
 import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
+from urllib.parse import quote
 
 try:
     from tqdm import tqdm
@@ -24,6 +28,33 @@ DEFAULT_MIN_AGE_DAYS = 2
 DEFAULT_TRIM_ARTIFACTS_AGE_DAYS = 0.25
 DEFAULT_CODEX_HOME = os.environ.get("CODEX_HOME", str(Path.home() / ".codex"))
 DEFAULT_QUARANTINE_ROOT = os.path.join(DEFAULT_CODEX_HOME, "quarantine", "worktrees")
+STATE_READER_MAX_BYTES = 8 * 1024 * 1024
+STATE_READER_SOURCE_MAX_BYTES = 2 * 1024 * 1024
+STATE_READER_BOOTSTRAP = """\
+import os
+import sys
+
+source_fd = int(sys.argv[1])
+source_limit = int(sys.argv[2])
+source = bytearray()
+while len(source) <= source_limit:
+    chunk = os.read(source_fd, min(65536, source_limit + 1 - len(source)))
+    if not chunk:
+        break
+    source.extend(chunk)
+if len(source) > source_limit:
+    raise SystemExit(2)
+source_path = f"/dev/fd/{source_fd}"
+sys.argv = [source_path, *sys.argv[3:]]
+namespace = {
+    "__cached__": None,
+    "__file__": source_path,
+    "__name__": "__main__",
+    "__package__": None,
+    "__spec__": None,
+}
+exec(compile(source, source_path, "exec"), namespace)
+"""
 
 
 def audit_git_env() -> dict[str, str]:
@@ -61,6 +92,45 @@ class Inventory:
     common_dir: str
     worktrees: list[Worktree]
     report_only: list[ReportOnlyPath]
+
+
+@dataclass(frozen=True)
+class StateArtifactIdentity:
+    path: str
+    device: int
+    inode: int
+    mode: int
+    uid: int
+    gid: int
+    links: int
+    size: int
+    mtime_ns: int
+    ctime_ns: int
+
+
+@dataclass(frozen=True)
+class StateDirectoryIdentity:
+    device: int
+    inode: int
+    mode: int
+    uid: int
+    gid: int
+
+
+@dataclass(frozen=True)
+class OpenStateArtifact:
+    name: str
+    fd: int
+    identity: StateArtifactIdentity
+
+
+@dataclass(frozen=True)
+class OpenStateDirectory:
+    path: str
+    fd: int
+    identity: StateDirectoryIdentity
+    database_name: str
+    artifacts: tuple[OpenStateArtifact, ...]
 
 
 def parse_args() -> argparse.Namespace:
@@ -143,7 +213,17 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="print registered non-main worktree paths and exit",
     )
-    return parser.parse_args()
+    parser.add_argument(
+        "--machine",
+        action="store_true",
+        help="print one compact JSON audit summary",
+    )
+    args = parser.parse_args()
+    if args.machine and args.apply:
+        parser.error("--machine is audit-only and cannot be combined with --apply")
+    if args.machine and args.list_registered:
+        parser.error("--machine cannot be combined with --list-registered")
+    return args
 
 
 def positive_int(raw: str) -> int:
@@ -190,7 +270,9 @@ def progress_bar(*, total: int, desc: str):
     return SimpleProgress(total, desc)
 
 
-def progress_iter(items, *, desc: str, total: int):
+def progress_iter(items, *, desc: str, total: int, enabled: bool = True):
+    if not enabled:
+        return items
     if tqdm is not None:
         return tqdm(items, desc=desc, total=total, unit="worktree")
     return items
@@ -204,24 +286,22 @@ def main() -> int:
     shared_node_modules_source = normalize_path(
         args.shared_node_modules_source or os.path.join(repo_root, "node_modules")
     )
-    inventory = build_inventory(repo_root, codex_home)
-    managed_worktrees = inventory.worktrees
     if args.list_registered:
+        inventory = build_inventory(repo_root, codex_home)
+        managed_worktrees = inventory.worktrees
         for worktree in managed_worktrees:
             print(worktree.path)
         return 0
 
-    state_db = find_latest_state_db(codex_home)
-    recent_session_cwds = (
-        read_recent_session_cwds(
-            state_db=state_db,
-            scan_limit=args.scan_limit,
-            keep_limit=args.limit,
-            repo_root=repo_root,
-            worktrees=managed_worktrees,
-        )
-        if state_db
-        else []
+    state_db, _ = discover_state_artifacts(codex_home)
+    inventory = build_inventory(repo_root, codex_home)
+    managed_worktrees = inventory.worktrees
+    recent_session_cwds = read_recent_session_cwds(
+        state_db=state_db,
+        scan_limit=args.scan_limit,
+        keep_limit=args.limit,
+        repo_root=repo_root,
+        worktrees=managed_worktrees,
     )
     keep_paths = select_session_backed_worktrees(managed_worktrees, recent_session_cwds)
     busy_paths = collect_owned_worktree_paths(managed_worktrees)
@@ -238,6 +318,7 @@ def main() -> int:
             dirty_candidates,
             desc="checking clean worktrees",
             total=len(dirty_candidates),
+            enabled=not args.machine,
         )
         if is_worktree_dirty(worktree.path)
     }
@@ -282,23 +363,34 @@ def main() -> int:
             continue
         kept_for_safety.append((worktree, "kept"))
 
-    print_summary(
-        repo_root=repo_root,
-        common_dir=inventory.common_dir,
-        state_db=state_db,
-        managed_worktrees=managed_worktrees,
-        report_only=inventory.report_only,
-        recent_session_cwds=recent_session_cwds,
-        kept_by_session=kept_by_session,
-        kept_for_safety=kept_for_safety,
-        trimmable=trimmable,
-        removable=removable,
-        apply=args.apply,
-        min_age_days=args.min_age_days,
-        trim_artifacts_age_days=args.trim_artifacts_age_days,
-        quarantine_root=quarantine_root,
-        shared_node_modules_source=shared_node_modules_source,
-    )
+    if args.machine:
+        print_machine_summary(
+            managed_worktrees=managed_worktrees,
+            report_only=inventory.report_only,
+            recent_session_cwds=recent_session_cwds,
+            kept_by_session=kept_by_session,
+            kept_for_safety=kept_for_safety,
+            trimmable=trimmable,
+            removable=removable,
+        )
+    else:
+        print_summary(
+            repo_root=repo_root,
+            common_dir=inventory.common_dir,
+            state_db=state_db,
+            managed_worktrees=managed_worktrees,
+            report_only=inventory.report_only,
+            recent_session_cwds=recent_session_cwds,
+            kept_by_session=kept_by_session,
+            kept_for_safety=kept_for_safety,
+            trimmable=trimmable,
+            removable=removable,
+            apply=args.apply,
+            min_age_days=args.min_age_days,
+            trim_artifacts_age_days=args.trim_artifacts_age_days,
+            quarantine_root=quarantine_root,
+            shared_node_modules_source=shared_node_modules_source,
+        )
 
     if not args.apply:
         return 0
@@ -540,26 +632,303 @@ def compute_path_age_days(file_path: str) -> float:
     return age_seconds / 86400
 
 
-def find_latest_state_db(codex_home: str) -> Optional[str]:
-    root = Path(codex_home)
-    candidates = sorted(root.glob("state*.sqlite"), key=lambda candidate: candidate.stat().st_mtime, reverse=True)
-    return str(candidates[0]) if candidates else None
+def select_state_artifact_names(names: list[str]) -> tuple[str, tuple[str, ...]]:
+    databases = sorted(
+        name for name in names if name.startswith("state") and name.endswith(".sqlite")
+    )
+    if len(databases) != 1:
+        raise RuntimeError(
+            f"expected exactly one Codex state*.sqlite database; found {len(databases)}"
+        )
+
+    database_name = databases[0]
+    related_names = {
+        name for name in names if name.startswith("state") and ".sqlite" in name
+    }
+    wal_name = f"{database_name}-wal"
+    shm_name = f"{database_name}-shm"
+    has_wal = wal_name in related_names
+    has_shm = shm_name in related_names
+    if has_wal != has_shm:
+        raise RuntimeError("Codex state WAL and SHM sidecars must both be present or both be absent")
+
+    allowed_names = {database_name}
+    if has_wal:
+        allowed_names.update((wal_name, shm_name))
+    unexpected_names = related_names - allowed_names
+    if unexpected_names:
+        if f"{database_name}-journal" in unexpected_names:
+            raise RuntimeError("Codex state rollback journal is not allowed")
+        raise RuntimeError("unexpected Codex state database artifacts")
+
+    return database_name, tuple(sorted(allowed_names))
 
 
-def read_recent_session_cwds(
+def discover_state_artifacts(codex_home: str) -> tuple[str, tuple[str, ...]]:
+    root = Path(normalize_path(codex_home))
+    try:
+        names = os.listdir(root)
+    except OSError as error:
+        raise RuntimeError("unable to inspect the Codex state directory") from error
+
+    database_name, artifact_names = select_state_artifact_names(names)
+    artifact_paths = tuple(str(root / name) for name in artifact_names)
+    snapshot_state_artifacts(artifact_paths)
+    return str(root / database_name), artifact_paths
+
+
+def state_artifact_identity(path: str, details: os.stat_result) -> StateArtifactIdentity:
+    if not stat.S_ISREG(details.st_mode):
+        raise RuntimeError("Codex state artifacts must be regular non-symlink files")
+    if details.st_uid != os.getuid():
+        raise RuntimeError("Codex state artifacts must be owned by the current user")
+    if details.st_nlink != 1:
+        raise RuntimeError("Codex state artifacts must have exactly one hard link")
+    return StateArtifactIdentity(
+        path=path,
+        device=details.st_dev,
+        inode=details.st_ino,
+        mode=details.st_mode,
+        uid=details.st_uid,
+        gid=details.st_gid,
+        links=details.st_nlink,
+        size=details.st_size,
+        mtime_ns=details.st_mtime_ns,
+        ctime_ns=details.st_ctime_ns,
+    )
+
+
+def snapshot_state_artifact(path: str) -> StateArtifactIdentity:
+    try:
+        details = os.stat(path, follow_symlinks=False)
+    except OSError as error:
+        raise RuntimeError("unable to inspect a Codex state artifact") from error
+    return state_artifact_identity(path, details)
+
+
+def snapshot_state_artifacts(paths: tuple[str, ...]) -> tuple[StateArtifactIdentity, ...]:
+    return tuple(snapshot_state_artifact(path) for path in paths)
+
+
+def state_directory_identity(details: os.stat_result) -> StateDirectoryIdentity:
+    if not stat.S_ISDIR(details.st_mode):
+        raise RuntimeError("Codex state root must be a directory")
+    if details.st_uid != os.getuid():
+        raise RuntimeError("Codex state root must be owned by the current user")
+    return StateDirectoryIdentity(
+        device=details.st_dev,
+        inode=details.st_ino,
+        mode=details.st_mode,
+        uid=details.st_uid,
+        gid=details.st_gid,
+    )
+
+
+def open_state_directory(state_db: str) -> OpenStateDirectory:
+    root_path = normalize_path(str(Path(state_db).parent))
+    expected_database_name = Path(state_db).name
+    if not hasattr(os, "O_DIRECTORY") or not hasattr(os, "O_NOFOLLOW"):
+        raise RuntimeError("platform lacks no-follow directory open support")
+
+    directory_flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    try:
+        directory_fd = os.open(root_path, directory_flags)
+    except OSError as error:
+        raise RuntimeError("unable to anchor the Codex state directory") from error
+
+    opened_artifacts: list[OpenStateArtifact] = []
+    try:
+        directory_details = os.fstat(directory_fd)
+        directory_identity = state_directory_identity(directory_details)
+        path_directory_identity = state_directory_identity(
+            os.stat(root_path, follow_symlinks=False)
+        )
+        if path_directory_identity != directory_identity:
+            raise RuntimeError("Codex state directory identity changed before read")
+
+        database_name, artifact_names = select_state_artifact_names(
+            os.listdir(directory_fd)
+        )
+        if database_name != expected_database_name:
+            raise RuntimeError("Codex state database identity changed before read")
+
+        file_flags = os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
+        for name in artifact_names:
+            artifact_path = os.path.join(root_path, name)
+            before = state_artifact_identity(
+                artifact_path,
+                os.stat(name, dir_fd=directory_fd, follow_symlinks=False),
+            )
+            try:
+                artifact_fd = os.open(name, file_flags, dir_fd=directory_fd)
+            except OSError as error:
+                raise RuntimeError("unable to anchor a Codex state artifact") from error
+            try:
+                opened = state_artifact_identity(artifact_path, os.fstat(artifact_fd))
+                after = state_artifact_identity(
+                    artifact_path,
+                    os.stat(name, dir_fd=directory_fd, follow_symlinks=False),
+                )
+                if before != opened or opened != after:
+                    raise RuntimeError("Codex state artifact identity changed before read")
+            except Exception:
+                os.close(artifact_fd)
+                raise
+            opened_artifacts.append(
+                OpenStateArtifact(name=name, fd=artifact_fd, identity=opened)
+            )
+
+        return OpenStateDirectory(
+            path=root_path,
+            fd=directory_fd,
+            identity=directory_identity,
+            database_name=database_name,
+            artifacts=tuple(opened_artifacts),
+        )
+    except Exception:
+        for artifact in opened_artifacts:
+            os.close(artifact.fd)
+        os.close(directory_fd)
+        raise
+
+
+def revalidate_open_state(opened: OpenStateDirectory) -> None:
+    if state_directory_identity(os.fstat(opened.fd)) != opened.identity:
+        raise RuntimeError("Codex state directory identity changed during read")
+    try:
+        path_identity = state_directory_identity(
+            os.stat(opened.path, follow_symlinks=False)
+        )
+    except OSError as error:
+        raise RuntimeError("unable to revalidate the Codex state directory") from error
+    if path_identity != opened.identity:
+        raise RuntimeError("Codex state directory identity changed during read")
+
+    database_name, artifact_names = select_state_artifact_names(os.listdir(opened.fd))
+    if (
+        database_name != opened.database_name
+        or artifact_names != tuple(artifact.name for artifact in opened.artifacts)
+    ):
+        raise RuntimeError("Codex state artifact set changed during read")
+
+    for artifact in opened.artifacts:
+        try:
+            path_details = os.stat(
+                artifact.name,
+                dir_fd=opened.fd,
+                follow_symlinks=False,
+            )
+        except OSError as error:
+            raise RuntimeError("unable to revalidate a Codex state artifact") from error
+        path_identity = state_artifact_identity(artifact.identity.path, path_details)
+        fd_identity = state_artifact_identity(
+            artifact.identity.path,
+            os.fstat(artifact.fd),
+        )
+        if path_identity != artifact.identity or fd_identity != artifact.identity:
+            raise RuntimeError("Codex state artifact identity changed during read")
+
+
+def close_open_state(opened: OpenStateDirectory) -> None:
+    for artifact in opened.artifacts:
+        os.close(artifact.fd)
+    os.close(opened.fd)
+
+
+def open_regular_fd_counts() -> dict[tuple[int, int], int]:
+    fd_root = "/dev/fd" if os.path.isdir("/dev/fd") else "/proc/self/fd"
+    try:
+        names = os.listdir(fd_root)
+    except OSError as error:
+        raise RuntimeError("unable to inspect SQLite file descriptors") from error
+
+    counts: dict[tuple[int, int], int] = {}
+    for name in names:
+        try:
+            fd = int(name)
+            details = os.fstat(fd)
+        except (OSError, ValueError):
+            continue
+        if not stat.S_ISREG(details.st_mode):
+            continue
+        identity = (details.st_dev, details.st_ino)
+        counts[identity] = counts.get(identity, 0) + 1
+    return counts
+
+
+def require_new_open_fd(
+    artifact: OpenStateArtifact,
+    baseline: dict[tuple[int, int], int],
+) -> None:
+    current = open_regular_fd_counts()
+    identity = (artifact.identity.device, artifact.identity.inode)
+    if current.get(identity, 0) <= baseline.get(identity, 0):
+        raise RuntimeError("SQLite did not open the anchored Codex state artifact")
+
+
+def state_database_uri(database_name: str) -> str:
+    return f"file:{quote(database_name, safe='')}?mode=ro"
+
+
+def query_recent_session_cwds(
     *,
-    state_db: str,
+    opened: OpenStateDirectory,
     scan_limit: int,
     keep_limit: int,
     repo_root: str,
-    worktrees: list[Worktree],
+    worktree_paths: list[str],
 ) -> list[str]:
-    repo_paths = [repo_root, *[worktree.path for worktree in worktrees]]
+    os.fchdir(opened.fd)
+    repo_paths = [repo_root, *worktree_paths]
     seen: set[str] = set()
     accepted: list[str] = []
 
-    connection = sqlite3.connect(state_db)
+    baseline_fds = open_regular_fd_counts()
+    database_artifact = next(
+        artifact
+        for artifact in opened.artifacts
+        if artifact.name == opened.database_name
+    )
     try:
+        connection = sqlite3.connect(
+            state_database_uri(opened.database_name),
+            uri=True,
+            timeout=0.0,
+        )
+    except sqlite3.Error as error:
+        raise RuntimeError("unable to open the Codex state database read-only") from error
+    try:
+        require_new_open_fd(database_artifact, baseline_fds)
+        connection.execute("PRAGMA query_only = ON")
+        query_only = connection.execute("PRAGMA query_only").fetchone()
+        if query_only != (1,):
+            raise RuntimeError("failed to enable SQLite query_only mode")
+
+        table_rows = connection.execute(
+            "SELECT type FROM sqlite_schema WHERE name = 'threads'"
+        ).fetchall()
+        if table_rows != [("table",)]:
+            raise RuntimeError("Codex state database is missing the threads table")
+        columns = {
+            row[1]
+            for row in connection.execute("PRAGMA table_info('threads')")
+            if len(row) > 1
+        }
+        required_columns = {"archived", "cwd", "updated_at"}
+        if not required_columns.issubset(columns):
+            raise RuntimeError("Codex state threads table is missing required columns")
+
+        wal_artifact = next(
+            (
+                artifact
+                for artifact in opened.artifacts
+                if artifact.name == f"{opened.database_name}-wal"
+            ),
+            None,
+        )
+        if wal_artifact is not None:
+            require_new_open_fd(wal_artifact, baseline_fds)
+
         cursor = connection.execute(
             """
             SELECT cwd
@@ -573,6 +942,10 @@ def read_recent_session_cwds(
             (scan_limit,),
         )
         for (cwd,) in cursor:
+            if not isinstance(cwd, str):
+                raise RuntimeError("Codex state threads.cwd must contain text")
+            if not os.path.isabs(cwd):
+                raise RuntimeError("Codex state threads.cwd must contain absolute paths")
             normalized_cwd = normalize_path(cwd)
             if normalized_cwd in seen:
                 continue
@@ -586,6 +959,285 @@ def read_recent_session_cwds(
         connection.close()
 
     return accepted
+
+
+def write_all(fd: int, data: bytes) -> None:
+    offset = 0
+    while offset < len(data):
+        written = os.write(fd, data[offset:])
+        if written <= 0:
+            raise RuntimeError("failed to write SQLite child result")
+        offset += written
+
+
+def write_state_child_payload(fd: int, payload: dict[str, object]) -> None:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > STATE_READER_MAX_BYTES:
+        encoded = json.dumps(
+            {"error": "SQLite child result exceeds the size limit", "ok": False},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    write_all(fd, struct.pack(">I", len(encoded)))
+    write_all(fd, encoded)
+
+
+def read_exact(fd: int, size: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = size
+    while remaining:
+        chunk = os.read(fd, remaining)
+        if not chunk:
+            raise RuntimeError("SQLite child result was truncated")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def read_framed_json(fd: int) -> object:
+    header = read_exact(fd, 4)
+    payload_size = struct.unpack(">I", header)[0]
+    if payload_size > STATE_READER_MAX_BYTES:
+        raise RuntimeError("SQLite child payload exceeds the size limit")
+    payload_bytes = read_exact(fd, payload_size)
+    if os.read(fd, 1):
+        raise RuntimeError("SQLite child payload has trailing data")
+    try:
+        return json.loads(payload_bytes)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise RuntimeError("SQLite child payload is not valid JSON") from error
+
+
+def parse_state_reader_request(
+    request: object,
+    *,
+    directory_fd: int,
+) -> tuple[OpenStateDirectory, int, int, str, list[str]]:
+    if not isinstance(request, dict) or set(request) != {
+        "artifact_fds",
+        "database_name",
+        "keep_limit",
+        "repo_root",
+        "scan_limit",
+        "schema_version",
+        "worktree_paths",
+    }:
+        raise RuntimeError("SQLite child request has an invalid schema")
+    if type(request["schema_version"]) is not int or request["schema_version"] != 1:
+        raise RuntimeError("SQLite child request has an unsupported schema")
+    if (
+        type(request["scan_limit"]) is not int
+        or request["scan_limit"] <= 0
+        or type(request["keep_limit"]) is not int
+        or request["keep_limit"] <= 0
+        or not isinstance(request["repo_root"], str)
+        or not isinstance(request["database_name"], str)
+        or not isinstance(request["worktree_paths"], list)
+        or any(not isinstance(path, str) for path in request["worktree_paths"])
+        or not isinstance(request["artifact_fds"], dict)
+    ):
+        raise RuntimeError("SQLite child request has invalid field types")
+
+    directory_identity = state_directory_identity(os.fstat(directory_fd))
+    database_name, artifact_names = select_state_artifact_names(os.listdir(directory_fd))
+    if database_name != request["database_name"]:
+        raise RuntimeError("SQLite child database name changed before read")
+    if set(request["artifact_fds"]) != set(artifact_names):
+        raise RuntimeError("SQLite child artifact set changed before read")
+
+    artifacts: list[OpenStateArtifact] = []
+    for name in artifact_names:
+        artifact_fd = request["artifact_fds"][name]
+        if type(artifact_fd) is not int or artifact_fd < 0:
+            raise RuntimeError("SQLite child artifact descriptor is invalid")
+        fd_identity = state_artifact_identity(name, os.fstat(artifact_fd))
+        path_identity = state_artifact_identity(
+            name,
+            os.stat(name, dir_fd=directory_fd, follow_symlinks=False),
+        )
+        if fd_identity != path_identity:
+            raise RuntimeError("SQLite child artifact identity changed before read")
+        artifacts.append(
+            OpenStateArtifact(name=name, fd=artifact_fd, identity=fd_identity)
+        )
+
+    return (
+        OpenStateDirectory(
+            path="",
+            fd=directory_fd,
+            identity=directory_identity,
+            database_name=database_name,
+            artifacts=tuple(artifacts),
+        ),
+        request["scan_limit"],
+        request["keep_limit"],
+        request["repo_root"],
+        request["worktree_paths"],
+    )
+
+
+def run_internal_state_reader(argv: list[str]) -> int:
+    if len(argv) != 3:
+        return 2
+    try:
+        directory_fd, request_fd, result_fd = (int(value) for value in argv)
+        request = read_framed_json(request_fd)
+        opened, scan_limit, keep_limit, repo_root, worktree_paths = (
+            parse_state_reader_request(request, directory_fd=directory_fd)
+        )
+        cwds = query_recent_session_cwds(
+            opened=opened,
+            scan_limit=scan_limit,
+            keep_limit=keep_limit,
+            repo_root=repo_root,
+            worktree_paths=worktree_paths,
+        )
+        payload: dict[str, object] = {"cwds": cwds, "ok": True}
+        exit_code = 0
+    except BaseException as error:
+        payload = {
+            "error": f"{type(error).__name__}: {error}",
+            "ok": False,
+        }
+        exit_code = 1
+    try:
+        write_state_child_payload(result_fd, payload)
+    except BaseException:
+        return 1
+    return exit_code
+
+
+def run_state_reader_child(
+    *,
+    opened: OpenStateDirectory,
+    scan_limit: int,
+    keep_limit: int,
+    repo_root: str,
+    worktrees: list[Worktree],
+) -> list[str]:
+    request_read_fd, request_write_fd = os.pipe()
+    result_read_fd, result_write_fd = os.pipe()
+    source_fd = os.open(__file__, os.O_RDONLY | getattr(os, "O_CLOEXEC", 0))
+    source_details = os.fstat(source_fd)
+    if not stat.S_ISREG(source_details.st_mode):
+        os.close(source_fd)
+        os.close(request_read_fd)
+        os.close(request_write_fd)
+        os.close(result_read_fd)
+        os.close(result_write_fd)
+        raise RuntimeError("cleaner source is not a regular file")
+    os.lseek(source_fd, 0, os.SEEK_SET)
+
+    request = {
+        "artifact_fds": {
+            artifact.name: artifact.fd for artifact in opened.artifacts
+        },
+        "database_name": opened.database_name,
+        "keep_limit": keep_limit,
+        "repo_root": repo_root,
+        "scan_limit": scan_limit,
+        "schema_version": 1,
+        "worktree_paths": [worktree.path for worktree in worktrees],
+    }
+    pass_fds = (
+        source_fd,
+        opened.fd,
+        request_read_fd,
+        result_write_fd,
+        *(artifact.fd for artifact in opened.artifacts),
+    )
+    try:
+        child = subprocess.Popen(
+            [
+                sys.executable,
+                "-I",
+                "-c",
+                STATE_READER_BOOTSTRAP,
+                str(source_fd),
+                str(STATE_READER_SOURCE_MAX_BYTES),
+                "--internal-state-reader",
+                str(opened.fd),
+                str(request_read_fd),
+                str(result_write_fd),
+            ],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+            pass_fds=tuple(sorted(set(pass_fds))),
+        )
+    except OSError as error:
+        os.close(source_fd)
+        os.close(request_read_fd)
+        os.close(request_write_fd)
+        os.close(result_read_fd)
+        os.close(result_write_fd)
+        raise RuntimeError("unable to launch the SQLite reader child") from error
+
+    os.close(source_fd)
+    os.close(request_read_fd)
+    os.close(result_write_fd)
+    protocol_error: Optional[Exception] = None
+    payload: object = None
+    try:
+        write_state_child_payload(request_write_fd, request)
+        os.close(request_write_fd)
+        request_write_fd = -1
+        payload = read_framed_json(result_read_fd)
+    except Exception as error:
+        protocol_error = error
+    finally:
+        if request_write_fd >= 0:
+            os.close(request_write_fd)
+        os.close(result_read_fd)
+        exit_code = child.wait()
+
+    if protocol_error is not None:
+        raise protocol_error
+    if not isinstance(payload, dict) or type(payload.get("ok")) is not bool:
+        raise RuntimeError("SQLite child emitted an invalid result envelope")
+
+    if payload["ok"] is False:
+        if set(payload) != {"error", "ok"} or not isinstance(payload.get("error"), str):
+            raise RuntimeError("SQLite child emitted an invalid error envelope")
+        raise RuntimeError(f"SQLite child failed: {payload['error']}")
+    if exit_code != 0:
+        raise RuntimeError("SQLite child exited unexpectedly")
+    if set(payload) != {"cwds", "ok"} or not isinstance(payload.get("cwds"), list):
+        raise RuntimeError("SQLite child emitted an invalid success envelope")
+
+    cwds = payload["cwds"]
+    if (
+        len(cwds) > keep_limit
+        or any(not isinstance(cwd, str) for cwd in cwds)
+        or len(set(cwds)) != len(cwds)
+    ):
+        raise RuntimeError("SQLite child emitted invalid session paths")
+    return cwds
+
+
+def read_recent_session_cwds(
+    *,
+    state_db: str,
+    scan_limit: int,
+    keep_limit: int,
+    repo_root: str,
+    worktrees: list[Worktree],
+) -> list[str]:
+    opened = open_state_directory(state_db)
+    try:
+        try:
+            return run_state_reader_child(
+                opened=opened,
+                scan_limit=scan_limit,
+                keep_limit=keep_limit,
+                repo_root=repo_root,
+                worktrees=worktrees,
+            )
+        finally:
+            revalidate_open_state(opened)
+    finally:
+        close_open_state(opened)
 
 
 def select_session_backed_worktrees(worktrees: list[Worktree], recent_session_cwds: list[str]) -> set[str]:
@@ -764,11 +1416,35 @@ def path_is_dir(raw_path: str) -> bool:
     return os.path.isdir(raw_path)
 
 
+def print_machine_summary(
+    *,
+    managed_worktrees: list[Worktree],
+    report_only: list[ReportOnlyPath],
+    recent_session_cwds: list[str],
+    kept_by_session: list[Worktree],
+    kept_for_safety: list[tuple[Worktree, str]],
+    trimmable: list[Worktree],
+    removable: list[Worktree],
+) -> None:
+    payload = {
+        "artifact_trim_candidates": len(trimmable),
+        "kept_by_recent_sessions": len(kept_by_session),
+        "kept_for_safety": len(kept_for_safety),
+        "mode": "dry-run",
+        "recent_sessions_scanned": len(recent_session_cwds),
+        "registered_non_main_worktrees": len(managed_worktrees),
+        "removal_candidates": len(removable),
+        "report_only_paths": len(report_only),
+        "schema_version": 1,
+    }
+    print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+
+
 def print_summary(
     *,
     repo_root: str,
     common_dir: str,
-    state_db: Optional[str],
+    state_db: str,
     managed_worktrees: list[Worktree],
     report_only: list[ReportOnlyPath],
     recent_session_cwds: list[str],
@@ -997,17 +1673,16 @@ def revalidate_candidate(
     if current.path in owned_paths:
         return "busy"
 
-    state_db = find_latest_state_db(codex_home)
-    if state_db:
-        session_cwds = read_recent_session_cwds(
-            state_db=state_db,
-            scan_limit=scan_limit,
-            keep_limit=session_limit,
-            repo_root=repo_root,
-            worktrees=inventory.worktrees,
-        )
-        if current.path in select_session_backed_worktrees(inventory.worktrees, session_cwds):
-            return "recent-session"
+    state_db, _ = discover_state_artifacts(codex_home)
+    session_cwds = read_recent_session_cwds(
+        state_db=state_db,
+        scan_limit=scan_limit,
+        keep_limit=session_limit,
+        repo_root=repo_root,
+        worktrees=inventory.worktrees,
+    )
+    if current.path in select_session_backed_worktrees(inventory.worktrees, session_cwds):
+        return "recent-session"
 
     if current.detached and not include_detached:
         return "detached"
@@ -1058,6 +1733,8 @@ def run_text(command: list[str]) -> str:
 
 if __name__ == "__main__":
     try:
+        if len(sys.argv) >= 2 and sys.argv[1] == "--internal-state-reader":
+            raise SystemExit(run_internal_state_reader(sys.argv[2:]))
         raise SystemExit(main())
     except KeyboardInterrupt:
         raise SystemExit(130)

--- a/functions/gwt/README.md
+++ b/functions/gwt/README.md
@@ -26,7 +26,10 @@ Key responsibilities:
 Cleanup behavior:
 
 - `gwt audit` is metadata-immutable, rejects `--apply`, and reports foreign or stale paths.
+- `gwt audit --machine` suppresses the wrapper preamble and emits the cleaner's
+  single compact schema-v1 JSON count line. It never prints worktree paths.
 - `gwt clean` deliberately runs pressure maintenance immediately with `--force`.
+- `gwt clean --machine` is rejected because machine output is audit-only.
 - Both cleanup wrappers reject repository/Codex-home scope overrides.
 - The module locator chooses the local functions tree; `gwt` then resolves its
   physical source checkout and uses the adjacent cleanup helpers.
@@ -37,3 +40,10 @@ Cleanup behavior:
 - `gwt rm` resolves targets to an absolute path registered to the current Git common dir.
 - `gwt rm` never prunes unrelated stale worktree registrations.
 - `gwt prune` is the only wrapper command that prunes worktree metadata.
+
+The cleaner retains no-follow state directory and artifact descriptors, then
+opens the unique database through a relative SQLite `mode=ro` URI in an isolated
+child anchored to that directory. It verifies `query_only`, schema, and the
+database/WAL descriptors SQLite opened. An unsandboxed reader can still update
+an active WAL shared memory file, so headless zero-touch audits also require the
+private scheduler's physical-path write-denial sandbox.

--- a/functions/gwt/gwt.zsh
+++ b/functions/gwt/gwt.zsh
@@ -569,7 +569,7 @@ _gwt_tool_path() {
 _gwt_validate_cleanup_args() {
     local command_name="$1"
     shift
-    local arg
+    local arg machine_mode=false
 
     for arg in "$@"; do
         case "$arg" in
@@ -583,8 +583,16 @@ _gwt_validate_cleanup_args() {
                     return 1
                 fi
                 ;;
+            --machine)
+                machine_mode=true
+                ;;
         esac
     done
+
+    if [[ "$command_name" == "clean" && "$machine_mode" == true ]]; then
+        echo "gwt: clean does not support audit-only --machine output" >&2
+        return 1
+    fi
 }
 
 _gwt_should_use_color() {
@@ -1125,13 +1133,24 @@ EOF
             fi
             ;;
         audit)
-            local repo_root cleaner_path audit_table worktree_count
+            local repo_root cleaner_path audit_table worktree_count machine_mode=false arg
             repo_root=$(_gwt_git_probe rev-parse --show-toplevel 2>/dev/null) || return 1
             _gwt_validate_cleanup_args audit "$@" || return 1
             cleaner_path=$(_gwt_tool_path agent-worktree-clean) || {
                 echo "gwt: agent-worktree-clean not found" >&2
                 return 1
             }
+            for arg in "$@"; do
+                if [[ "$arg" == "--machine" ]]; then
+                    machine_mode=true
+                    break
+                fi
+            done
+            if [[ "$machine_mode" == true ]]; then
+                GIT_OPTIONAL_LOCKS=0 GIT_NO_LAZY_FETCH=1 \
+                    "$cleaner_path" --repo "$repo_root" "$@" || return 1
+                return 0
+            fi
             audit_table=$(_gwt_fzf_table "$repo_root" 2>/dev/null || true)
             if [[ -n "$audit_table" ]]; then
                 worktree_count=$(printf '%s\n' "$audit_table" | awk 'NF {count++} END {print count+0}')

--- a/tests/agent-worktree-ops-test.py
+++ b/tests/agent-worktree-ops-test.py
@@ -3,13 +3,15 @@
 import hashlib
 import importlib.util
 import io
+import json
 import os
 import shutil
+import sqlite3
 import subprocess
 import sys
 import tempfile
 import unittest
-from contextlib import redirect_stderr
+from contextlib import redirect_stderr, redirect_stdout
 from importlib.machinery import SourceFileLoader
 from pathlib import Path
 from types import SimpleNamespace
@@ -54,7 +56,7 @@ def add_worktree(repo: Path, path: Path, branch: str, start: str = "main") -> No
     git(repo, "worktree", "add", "-b", branch, str(path), start)
 
 
-def path_metadata(path: Path) -> tuple[str, int, int, int, str]:
+def path_metadata(path: Path) -> tuple[object, ...]:
     stats = path.lstat()
     if path.is_symlink():
         kind = "symlink"
@@ -68,13 +70,19 @@ def path_metadata(path: Path) -> tuple[str, int, int, int, str]:
     return (
         kind,
         stats.st_mode,
+        stats.st_dev,
+        stats.st_ino,
+        stats.st_uid,
+        stats.st_gid,
+        stats.st_nlink,
         stats.st_size,
         stats.st_mtime_ns,
+        stats.st_ctime_ns,
         hashlib.sha256(content).hexdigest(),
     )
 
 
-def snapshot_tree(root: Path) -> dict[str, tuple[str, int, int, int, str]]:
+def snapshot_tree(root: Path) -> dict[str, tuple[object, ...]]:
     if not root.exists():
         return {}
     paths = [root, *sorted(root.rglob("*"))]
@@ -120,6 +128,48 @@ def invalidate_index_stat_cache(worktree: Path) -> Path:
     return index
 
 
+def create_state_db(path: Path, sessions: tuple[tuple[str, int, int], ...] = ()) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(str(path))
+    try:
+        connection.execute(
+            "CREATE TABLE threads (cwd TEXT, archived INTEGER, updated_at INTEGER)"
+        )
+        connection.executemany(
+            "INSERT INTO threads (cwd, archived, updated_at) VALUES (?, ?, ?)",
+            sessions,
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def open_active_wal_state(path: Path, cwd: str) -> sqlite3.Connection:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(str(path))
+    mode = connection.execute("PRAGMA journal_mode = WAL").fetchone()
+    if mode != ("wal",):
+        connection.close()
+        raise AssertionError(f"failed to enable WAL mode: {mode}")
+    connection.execute("PRAGMA wal_autocheckpoint = 0")
+    connection.execute(
+        "CREATE TABLE threads (cwd TEXT, archived INTEGER, updated_at INTEGER)"
+    )
+    connection.execute(
+        "INSERT INTO threads (cwd, archived, updated_at) VALUES (?, 0, 1)",
+        (cwd,),
+    )
+    connection.commit()
+    return connection
+
+
+def snapshot_state_artifacts(path: Path) -> dict[str, tuple[object, ...]]:
+    return {
+        candidate.name: path_metadata(candidate)
+        for candidate in sorted(path.parent.glob(f"{path.name}*"))
+    }
+
+
 class WorktreeCleanerTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
@@ -129,6 +179,8 @@ class WorktreeCleanerTests(unittest.TestCase):
         init_repo(self.repo)
         self.slug_root = self.codex_home / "worktrees" / "openclaw-openclaw"
         self.slug_root.mkdir(parents=True)
+        self.state_db = self.codex_home / "state.sqlite"
+        create_state_db(self.state_db)
 
     def tearDown(self) -> None:
         self.temporary.cleanup()
@@ -340,6 +392,451 @@ class WorktreeCleanerTests(unittest.TestCase):
             self.assertEqual(run.call_args.kwargs["env"]["GIT_OPTIONAL_LOCKS"], "0")
             self.assertEqual(run.call_args.kwargs["env"]["GIT_NO_LAZY_FETCH"], "1")
 
+    def test_state_database_artifact_set_is_strict(self) -> None:
+        valid_root = self.base / "valid-state"
+        valid_db = valid_root / "state.sqlite"
+        create_state_db(valid_db)
+        discovered, artifacts = CLEANER.discover_state_artifacts(str(valid_root))
+        self.assertEqual(discovered, CLEANER.normalize_path(str(valid_db)))
+        self.assertEqual(artifacts, (CLEANER.normalize_path(str(valid_db)),))
+
+        wal_root = self.base / "wal-state"
+        wal_db = wal_root / "state-v1.sqlite"
+        create_state_db(wal_db)
+        (wal_root / "state-v1.sqlite-wal").write_bytes(b"wal")
+        (wal_root / "state-v1.sqlite-shm").write_bytes(b"shm")
+        _, wal_artifacts = CLEANER.discover_state_artifacts(str(wal_root))
+        self.assertEqual(
+            wal_artifacts,
+            (
+                CLEANER.normalize_path(str(wal_db)),
+                CLEANER.normalize_path(str(wal_root / "state-v1.sqlite-shm")),
+                CLEANER.normalize_path(str(wal_root / "state-v1.sqlite-wal")),
+            ),
+        )
+
+        missing_root = self.base / "missing-state"
+        missing_root.mkdir()
+        with self.assertRaisesRegex(RuntimeError, "exactly one"):
+            CLEANER.discover_state_artifacts(str(missing_root))
+
+        ambiguous_root = self.base / "ambiguous-state"
+        create_state_db(ambiguous_root / "state.sqlite")
+        create_state_db(ambiguous_root / "state-old.sqlite")
+        with self.assertRaisesRegex(RuntimeError, "found 2"):
+            CLEANER.discover_state_artifacts(str(ambiguous_root))
+
+        for suffix in ("-wal", "-shm"):
+            with self.subTest(asymmetric_sidecar=suffix):
+                sidecar_root = self.base / f"sidecar-{suffix[1:]}"
+                sidecar_db = sidecar_root / "state.sqlite"
+                create_state_db(sidecar_db)
+                (sidecar_root / f"state.sqlite{suffix}").write_bytes(b"sidecar")
+                with self.assertRaisesRegex(RuntimeError, "both be present"):
+                    CLEANER.discover_state_artifacts(str(sidecar_root))
+
+        journal_root = self.base / "journal-state"
+        journal_db = journal_root / "state.sqlite"
+        create_state_db(journal_db)
+        (journal_root / "state.sqlite-journal").write_bytes(b"journal")
+        with self.assertRaisesRegex(RuntimeError, "journal"):
+            CLEANER.discover_state_artifacts(str(journal_root))
+
+        extra_root = self.base / "extra-state"
+        extra_db = extra_root / "state.sqlite"
+        create_state_db(extra_db)
+        (extra_root / "state.sqlite.backup").write_bytes(b"backup")
+        with self.assertRaisesRegex(RuntimeError, "unexpected"):
+            CLEANER.discover_state_artifacts(str(extra_root))
+
+    def test_state_artifacts_require_regular_single_link_same_user_files(self) -> None:
+        symlink_root = self.base / "symlink-state"
+        symlink_root.mkdir()
+        backing = symlink_root / "backing.db"
+        create_state_db(backing)
+        (symlink_root / "state.sqlite").symlink_to(backing)
+        with self.assertRaisesRegex(RuntimeError, "regular non-symlink"):
+            CLEANER.discover_state_artifacts(str(symlink_root))
+
+        hardlink_root = self.base / "hardlink-state"
+        hardlink_db = hardlink_root / "state.sqlite"
+        create_state_db(hardlink_db)
+        os.link(hardlink_db, hardlink_root / "state.sqlite-wal")
+        (hardlink_root / "state.sqlite-shm").write_bytes(b"shm")
+        with self.assertRaisesRegex(RuntimeError, "one hard link"):
+            CLEANER.discover_state_artifacts(str(hardlink_root))
+
+        owner_root = self.base / "owner-state"
+        owner_db = owner_root / "state.sqlite"
+        create_state_db(owner_db)
+        with mock.patch.object(CLEANER.os, "getuid", return_value=os.getuid() + 1):
+            with self.assertRaisesRegex(RuntimeError, "current user"):
+                CLEANER.discover_state_artifacts(str(owner_root))
+
+    def test_state_database_uses_relative_read_only_uri_and_required_schema(self) -> None:
+        expected_uri = "file:state%20v1.sqlite?mode=ro"
+        self.assertEqual(CLEANER.state_database_uri("state v1.sqlite"), expected_uri)
+        self.assertNotIn("immutable", expected_uri)
+        self.assertNotIn("nolock", expected_uri)
+        self.assertNotIn("vfs", expected_uri)
+        self.assertEqual(
+            CLEANER.read_recent_session_cwds(
+                state_db=str(self.state_db),
+                scan_limit=10,
+                keep_limit=5,
+                repo_root=str(self.repo),
+                worktrees=[],
+            ),
+            [],
+        )
+        connection = sqlite3.connect(str(self.state_db))
+        connection.execute(
+            "INSERT INTO threads (cwd, archived, updated_at) VALUES ('.', 0, 1)"
+        )
+        connection.commit()
+        connection.close()
+        with self.assertRaisesRegex(RuntimeError, "absolute paths"):
+            CLEANER.read_recent_session_cwds(
+                state_db=str(self.state_db),
+                scan_limit=10,
+                keep_limit=5,
+                repo_root=str(self.repo),
+                worktrees=[],
+            )
+
+        invalid_root = self.base / "invalid-schema"
+        invalid_db = invalid_root / "state.sqlite"
+        invalid_root.mkdir()
+        connection = sqlite3.connect(str(invalid_db))
+        connection.execute("CREATE TABLE threads (cwd TEXT)")
+        connection.commit()
+        connection.close()
+        with self.assertRaisesRegex(RuntimeError, "required columns"):
+            CLEANER.read_recent_session_cwds(
+                state_db=str(invalid_db),
+                scan_limit=10,
+                keep_limit=5,
+                repo_root=str(self.repo),
+                worktrees=[],
+            )
+
+    def test_state_reader_uses_anchored_directory_during_pathname_swap(self) -> None:
+        original_root = self.base / "anchored-state"
+        original_db = original_root / "state.sqlite"
+        parked_root = self.base / "parked-state"
+        forged_root = self.base / "forged-state"
+        create_state_db(original_db, ((str(self.repo), 0, 2),))
+        create_state_db(forged_root / "state.sqlite")
+
+        opened = CLEANER.open_state_directory(str(original_db))
+        try:
+            original_root.rename(parked_root)
+            forged_root.rename(original_root)
+            try:
+                recent = CLEANER.run_state_reader_child(
+                    opened=opened,
+                    scan_limit=10,
+                    keep_limit=5,
+                    repo_root=str(self.repo),
+                    worktrees=[],
+                )
+            finally:
+                original_root.rename(forged_root)
+                parked_root.rename(original_root)
+            CLEANER.revalidate_open_state(opened)
+        finally:
+            CLEANER.close_open_state(opened)
+
+        self.assertEqual(recent, [CLEANER.normalize_path(str(self.repo))])
+
+    def test_machine_reader_runs_from_anonymous_cleaner_source_fd(self) -> None:
+        source_fd = os.open(CLEANER_PATH, os.O_RDONLY)
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-I",
+                    "-c",
+                    CLEANER.STATE_READER_BOOTSTRAP,
+                    str(source_fd),
+                    str(CLEANER.STATE_READER_SOURCE_MAX_BYTES),
+                    "--repo",
+                    str(self.repo),
+                    "--codex-home",
+                    str(self.codex_home),
+                    "--machine",
+                ],
+                pass_fds=(source_fd,),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=True,
+            )
+        finally:
+            os.close(source_fd)
+
+        self.assertEqual(result.stderr, "")
+        self.assertEqual(json.loads(result.stdout)["schema_version"], 1)
+
+    def test_state_reader_child_ignores_repo_local_python_modules(self) -> None:
+        marker = self.base / "repo-module-loaded"
+        (self.repo / "tqdm.py").write_text(
+            f"open({str(marker)!r}, 'w', encoding='utf-8').write('loaded')\n",
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(CLEANER_PATH),
+                "--repo",
+                str(self.repo),
+                "--codex-home",
+                str(self.codex_home),
+                "--machine",
+            ],
+            cwd=self.repo,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+
+        self.assertEqual(result.stderr, "")
+        self.assertEqual(json.loads(result.stdout)["schema_version"], 1)
+        self.assertFalse(marker.exists())
+
+    def test_missing_state_fails_before_inventory_and_does_not_create_database(self) -> None:
+        self.state_db.unlink()
+        before = snapshot_tree(self.codex_home)
+        args = SimpleNamespace(
+            repo=str(self.repo),
+            codex_home=str(self.codex_home),
+            quarantine_root=str(self.codex_home / "quarantine"),
+            shared_node_modules_source=str(self.repo / "node_modules"),
+            list_registered=False,
+            machine=True,
+            scan_limit=200,
+            limit=30,
+            min_age_days=2,
+            trim_artifacts_age_days=0.25,
+            include_detached=False,
+            apply=False,
+            delete_workers=4,
+            skip_legacy_purge=True,
+        )
+        with mock.patch.object(CLEANER, "parse_args", return_value=args):
+            with mock.patch.object(CLEANER, "build_inventory") as build_inventory:
+                with self.assertRaisesRegex(RuntimeError, "exactly one"):
+                    CLEANER.main()
+        build_inventory.assert_not_called()
+        self.assertEqual(before, snapshot_tree(self.codex_home))
+
+        result = subprocess.run(
+            [
+                str(CLEANER_PATH),
+                "--repo",
+                str(self.repo),
+                "--codex-home",
+                str(self.codex_home),
+                "--machine",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("expected exactly one", result.stderr)
+        self.assertEqual(before, snapshot_tree(self.codex_home))
+
+    def test_machine_output_is_exact_and_keeps_active_session(self) -> None:
+        active = self.slug_root / "active-session"
+        add_worktree(self.repo, active, "active-session")
+        connection = sqlite3.connect(str(self.state_db))
+        connection.execute(
+            "INSERT INTO threads (cwd, archived, updated_at) VALUES (?, 0, 1)",
+            (str(active),),
+        )
+        connection.commit()
+        connection.close()
+
+        fake_bin = self.base / "machine-bin"
+        fake_bin.mkdir()
+        (fake_bin / "lsof").write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+        (fake_bin / "tmux").write_text(
+            "#!/bin/sh\necho 'no server running' >&2\nexit 1\n",
+            encoding="utf-8",
+        )
+        os.chmod(fake_bin / "lsof", 0o755)
+        os.chmod(fake_bin / "tmux", 0o755)
+        environment = os.environ.copy()
+        environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
+
+        result = subprocess.run(
+            [
+                str(CLEANER_PATH),
+                "--repo",
+                str(self.repo),
+                "--codex-home",
+                str(self.codex_home),
+                "--min-age-days",
+                "0",
+                "--trim-artifacts-age-days",
+                "0",
+                "--machine",
+            ],
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+        expected = {
+            "artifact_trim_candidates": 0,
+            "kept_by_recent_sessions": 1,
+            "kept_for_safety": 0,
+            "mode": "dry-run",
+            "recent_sessions_scanned": 1,
+            "registered_non_main_worktrees": 1,
+            "removal_candidates": 0,
+            "report_only_paths": 0,
+            "schema_version": 1,
+        }
+        self.assertEqual(
+            result.stdout,
+            json.dumps(expected, sort_keys=True, separators=(",", ":")) + "\n",
+        )
+        self.assertEqual(result.stderr, "")
+        parsed = json.loads(result.stdout)
+        self.assertEqual(list(parsed), sorted(expected))
+        self.assertNotIn(str(active), result.stdout)
+        for key, value in parsed.items():
+            if key == "mode":
+                self.assertIsInstance(value, str)
+            else:
+                self.assertIsInstance(value, int)
+
+    def test_machine_mode_rejects_mutating_or_path_output_modes(self) -> None:
+        for argv, diagnostic in (
+            (
+                ["agent-worktree-clean", "--machine", "--apply"],
+                "--machine is audit-only and cannot be combined with --apply",
+            ),
+            (
+                ["agent-worktree-clean", "--machine", "--list-registered"],
+                "--machine cannot be combined with --list-registered",
+            ),
+        ):
+            with self.subTest(argv=argv):
+                stdout = io.StringIO()
+                stderr = io.StringIO()
+                with mock.patch.object(CLEANER.sys, "argv", argv):
+                    with redirect_stdout(stdout), redirect_stderr(stderr):
+                        with self.assertRaises(SystemExit) as raised:
+                            CLEANER.parse_args()
+                self.assertNotEqual(raised.exception.code, 0)
+                self.assertEqual(stdout.getvalue(), "")
+                self.assertIn(diagnostic, stderr.getvalue())
+
+    @unittest.skipUnless(
+        sys.platform == "darwin" and Path("/usr/bin/sandbox-exec").is_file(),
+        "requires macOS sandbox-exec",
+    )
+    def test_active_wal_is_zero_touch_only_under_write_denial(self) -> None:
+        active = self.slug_root / "active-wal"
+        add_worktree(self.repo, active, "active-wal")
+        fake_bin = self.base / "wal-bin"
+        fake_bin.mkdir()
+        (fake_bin / "lsof").write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+        (fake_bin / "tmux").write_text(
+            "#!/bin/sh\necho 'no server running' >&2\nexit 1\n",
+            encoding="utf-8",
+        )
+        os.chmod(fake_bin / "lsof", 0o755)
+        os.chmod(fake_bin / "tmux", 0o755)
+        environment = os.environ.copy()
+        environment["PATH"] = f"{fake_bin}:{environment['PATH']}"
+
+        def command(codex_home: Path) -> list[str]:
+            return [
+                sys.executable,
+                str(CLEANER_PATH),
+                "--repo",
+                str(self.repo),
+                "--codex-home",
+                str(codex_home),
+                "--min-age-days",
+                "0",
+                "--trim-artifacts-age-days",
+                "0",
+                "--machine",
+            ]
+
+        plain_home = self.base / "plain-wal-codex"
+        plain_db = plain_home / "state.sqlite"
+        plain_writer = open_active_wal_state(plain_db, str(active))
+        try:
+            plain_before = snapshot_state_artifacts(plain_db)
+            subprocess.run(
+                command(plain_home),
+                env=environment,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            )
+            plain_after = snapshot_state_artifacts(plain_db)
+            self.assertEqual(
+                set(plain_before),
+                {"state.sqlite", "state.sqlite-shm", "state.sqlite-wal"},
+            )
+            self.assertEqual(plain_before["state.sqlite"], plain_after["state.sqlite"])
+            self.assertEqual(plain_before["state.sqlite-wal"], plain_after["state.sqlite-wal"])
+            self.assertNotEqual(
+                plain_before["state.sqlite-shm"],
+                plain_after["state.sqlite-shm"],
+            )
+            self.assertNotEqual(
+                plain_before,
+                plain_after,
+                "standalone SQLite mode=ro unexpectedly proved zero-touch on active WAL",
+            )
+        finally:
+            plain_writer.close()
+
+        sandbox_home = self.base / "sandbox-wal-codex"
+        sandbox_db = sandbox_home / "state.sqlite"
+        sandbox_writer = open_active_wal_state(sandbox_db, str(active))
+        try:
+            sandbox_before = snapshot_state_artifacts(sandbox_db)
+            physical_root = str(sandbox_home.resolve()).replace("\\", "\\\\").replace('"', '\\"')
+            policy = (
+                "(version 1)"
+                "(allow default)"
+                f'(deny file-write* (subpath "{physical_root}"))'
+            )
+            result = subprocess.run(
+                ["/usr/bin/sandbox-exec", "-p", policy, *command(sandbox_home)],
+                env=environment,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=True,
+            )
+            self.assertEqual(
+                set(sandbox_before),
+                {"state.sqlite", "state.sqlite-shm", "state.sqlite-wal"},
+            )
+            self.assertEqual(sandbox_before, snapshot_state_artifacts(sandbox_db))
+            payload = json.loads(result.stdout)
+            self.assertEqual(payload["kept_by_recent_sessions"], 1)
+            self.assertEqual(payload["removal_candidates"], 0)
+            self.assertEqual(result.stderr, "")
+        finally:
+            sandbox_writer.close()
+
     def test_live_ownership_probe_failures_are_fatal(self) -> None:
         worktree = CLEANER.Worktree("/tmp/example", "abc", "refs/heads/test", False, 10)
         failed = SimpleNamespace(returncode=2, stdout="", stderr="permission denied")
@@ -374,7 +871,11 @@ class WorktreeCleanerTests(unittest.TestCase):
         expected = CLEANER.build_inventory(str(self.repo), str(self.codex_home)).worktrees[0]
 
         with mock.patch.object(CLEANER, "collect_owned_worktree_paths", return_value=set()):
-            with mock.patch.object(CLEANER, "find_latest_state_db", return_value="/tmp/state.sqlite"):
+            with mock.patch.object(
+                CLEANER,
+                "discover_state_artifacts",
+                return_value=("/tmp/state.sqlite", ("/tmp/state.sqlite",)),
+            ):
                 with mock.patch.object(
                     CLEANER,
                     "read_recent_session_cwds",
@@ -421,6 +922,7 @@ class WorktreeCleanerTests(unittest.TestCase):
             quarantine_root=str(self.codex_home / "quarantine"),
             shared_node_modules_source=str(self.repo / "node_modules"),
             list_registered=False,
+            machine=False,
             scan_limit=200,
             limit=30,
             min_age_days=2,
@@ -437,7 +939,11 @@ class WorktreeCleanerTests(unittest.TestCase):
         )
         with mock.patch.object(CLEANER, "parse_args", return_value=args):
             with mock.patch.object(CLEANER, "build_inventory", return_value=inventory):
-                with mock.patch.object(CLEANER, "find_latest_state_db", return_value=None):
+                with mock.patch.object(
+                    CLEANER,
+                    "discover_state_artifacts",
+                    return_value=(str(self.state_db), (str(self.state_db),)),
+                ):
                     with mock.patch.object(CLEANER, "collect_owned_worktree_paths", return_value=set()):
                         with mock.patch.object(CLEANER, "print_summary"):
                             with mock.patch.object(CLEANER, "apply_trims", return_value=0):
@@ -492,6 +998,7 @@ class WorktreeCleanerTests(unittest.TestCase):
             quarantine_root=str(self.codex_home / "quarantine"),
             shared_node_modules_source=str(self.repo / "node_modules"),
             list_registered=False,
+            machine=False,
             scan_limit=200,
             limit=30,
             min_age_days=2,
@@ -508,7 +1015,11 @@ class WorktreeCleanerTests(unittest.TestCase):
         )
         with mock.patch.object(CLEANER, "parse_args", return_value=args):
             with mock.patch.object(CLEANER, "build_inventory", return_value=inventory):
-                with mock.patch.object(CLEANER, "find_latest_state_db", return_value=None):
+                with mock.patch.object(
+                    CLEANER,
+                    "discover_state_artifacts",
+                    return_value=(str(self.state_db), (str(self.state_db),)),
+                ):
                     with mock.patch.object(CLEANER, "collect_owned_worktree_paths", return_value=set()):
                         with mock.patch.object(CLEANER, "print_summary"):
                             with mock.patch.object(CLEANER, "apply_trims", return_value=1):

--- a/tests/gwt-cleanup-test.zsh
+++ b/tests/gwt-cleanup-test.zsh
@@ -15,10 +15,25 @@ gwt_source="$gwt_fixture_root/functions/gwt/gwt.zsh"
 mkdir -p "$home" "$runtime" "${gwt_source:h}"
 cp "$root/functions/gwt/gwt.zsh" "$gwt_source"
 cp "$root/bin/agent-worktree-ops/agent-worktree-clean" "$runtime/agent-worktree-clean"
-chmod +x "$runtime/agent-worktree-clean"
+cp "$root/bin/agent-worktree-ops/agent-worktree-maintain" "$runtime/agent-worktree-maintain"
+chmod +x "$runtime/agent-worktree-clean" "$runtime/agent-worktree-maintain"
 
 fake_bin="$temporary/bin"
 mkdir -p "$fake_bin"
+real_git="$(command -v git)"
+export TEST_REAL_GIT="$real_git"
+export TEST_PRUNE_LOG="$temporary/prune.log"
+cat >"$fake_bin/git" <<'EOF'
+#!/bin/sh
+previous=
+for argument in "$@"; do
+  if [ "$previous" = "worktree" ] && [ "$argument" = "prune" ]; then
+    printf '%s\n' "$*" >>"$TEST_PRUNE_LOG"
+  fi
+  previous="$argument"
+done
+exec "$TEST_REAL_GIT" "$@"
+EOF
 cat >"$fake_bin/lsof" <<'EOF'
 #!/bin/sh
 exit 1
@@ -28,7 +43,7 @@ cat >"$fake_bin/tmux" <<'EOF'
 echo 'no server running' >&2
 exit 1
 EOF
-chmod +x "$fake_bin/lsof" "$fake_bin/tmux"
+chmod +x "$fake_bin/git" "$fake_bin/lsof" "$fake_bin/tmux"
 
 audit_probe_bin="$temporary/audit-probe-bin"
 mkdir -p "$audit_probe_bin"
@@ -185,6 +200,18 @@ git -C "$repo" config remote.origin.url "git@example.test:owner/repo.git"
 print fixture >"$repo/README.md"
 git -C "$repo" add README.md
 git -C "$repo" commit -m fixture >/dev/null
+mkdir -p "$home/.codex"
+/usr/bin/python3 - "$home/.codex/state.sqlite" <<'PY'
+import sqlite3
+import sys
+
+connection = sqlite3.connect(sys.argv[1])
+connection.execute(
+    "CREATE TABLE threads (cwd TEXT, archived INTEGER, updated_at INTEGER)"
+)
+connection.commit()
+connection.close()
+PY
 
 remove_path="$temporary/remove-me"
 apply_path="$temporary/apply-me"
@@ -261,6 +288,46 @@ print(f"{index}\t{stat.S_IMODE(details.st_mode):04o}\t{details.st_mtime_ns}")
 PY
 )" ]]
 
+PATH="$fake_bin:$PATH" \
+HOME="$home" \
+DOTFILES_WORKTREES_ROOT="$worktrees_root" \
+zsh -f -c '
+  source "$1"
+  cd "$2"
+  gwt audit --machine --min-age-days 999 --trim-artifacts-age-days 999
+ ' zsh "$gwt_source" "$repo" >"$temporary/gwt-machine.out" 2>"$temporary/gwt-machine.err"
+[[ ! -s "$temporary/gwt-machine.err" ]]
+[[ "$(wc -l <"$temporary/gwt-machine.out" | tr -d ' ')" == "1" ]]
+if grep -Fq "$repo" "$temporary/gwt-machine.out"; then
+  print -u2 'machine audit leaked a repository path'
+  exit 1
+fi
+/usr/bin/python3 - "$temporary/gwt-machine.out" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+line = Path(sys.argv[1]).read_text(encoding="utf-8")
+payload = json.loads(line)
+expected_keys = [
+    "artifact_trim_candidates",
+    "kept_by_recent_sessions",
+    "kept_for_safety",
+    "mode",
+    "recent_sessions_scanned",
+    "registered_non_main_worktrees",
+    "removal_candidates",
+    "report_only_paths",
+    "schema_version",
+]
+assert list(payload) == sorted(expected_keys)
+assert line == json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n"
+assert payload["mode"] == "dry-run"
+assert payload["schema_version"] == 1
+for key, value in payload.items():
+    assert isinstance(value, str if key == "mode" else int)
+PY
+
 git -C "$repo" worktree lock "$remove_path"
 stale_before="$(tree_snapshot "$stale_admin")"
 PATH="$fake_bin:$PATH" \
@@ -278,7 +345,7 @@ grep -Fq "worktree ${stale_path:A}" <<< "$(
 [[ "$stale_before" == "$(tree_snapshot "$stale_admin")" ]]
 git -C "$repo" worktree unlock "$remove_path"
 
-HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
+PATH="$fake_bin:$PATH" HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
   source "$1"
   cd "$2"
   gwt rm remove-me
@@ -298,6 +365,33 @@ if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
   exit 1
 fi
 grep -Fq "audit is immutable" "$temporary/audit-apply.out"
+
+if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
+  source "$1"
+  cd "$2"
+  gwt audit --machine --apply
+ ' zsh "$gwt_source" "$repo" \
+  >"$temporary/audit-machine-apply.out" \
+  2>"$temporary/audit-machine-apply.err"; then
+  print -u2 'expected gwt audit --machine --apply to fail'
+  exit 1
+fi
+[[ ! -s "$temporary/audit-machine-apply.out" ]]
+grep -Fq "audit is immutable" "$temporary/audit-machine-apply.err"
+
+if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
+  source "$1"
+  cd "$2"
+  gwt audit --machine --list-registered
+ ' zsh "$gwt_source" "$repo" \
+  >"$temporary/audit-machine-list.out" \
+  2>"$temporary/audit-machine-list.err"; then
+  print -u2 'expected gwt audit --machine --list-registered to fail'
+  exit 1
+fi
+[[ ! -s "$temporary/audit-machine-list.out" ]]
+grep -Fq -- '--machine cannot be combined with --list-registered' \
+  "$temporary/audit-machine-list.err"
 
 metadata_before="$(git -C "$repo" worktree list --porcelain | shasum -a 256)"
 if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
@@ -378,6 +472,25 @@ if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" zsh -f -c '
 fi
 grep -Fq 'refusing existing path not registered to this repository' "$temporary/new.out"
 
+PATH="$fake_bin:$PATH" \
+HOME="$home" \
+DOTFILES_WORKTREES_ROOT="$worktrees_root" \
+zsh -f -c '
+  source "$1"
+  cd "$2"
+  gwt clean \
+    --no-log \
+    --skip-legacy-purge \
+    --min-age-days 999 \
+    --trim-artifacts-age-days 999
+ ' zsh "$gwt_source" "$repo" >"$temporary/clean-real-chain.out"
+grep -Fq 'agent-worktree-maintain: done' "$temporary/clean-real-chain.out"
+grep -Fq "worktree ${stale_path:A}" <<< "$(
+  GIT_OPTIONAL_LOCKS=0 git -C "$repo" worktree list --porcelain
+)"
+[[ "$stale_before" == "$(tree_snapshot "$stale_admin")" ]]
+[[ ! -e "$TEST_PRUNE_LOG" ]]
+
 cat >"$runtime/agent-worktree-maintain" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >"$TEST_MAINTAIN_ARGS"
@@ -386,6 +499,7 @@ chmod +x "$runtime/agent-worktree-maintain"
 
 HOME="$home" \
 DOTFILES_WORKTREES_ROOT="$worktrees_root" \
+PATH="$fake_bin:$PATH" \
 TEST_MAINTAIN_ARGS="$temporary/maintain.args" \
 zsh -f -c '
   source "$1"
@@ -396,6 +510,44 @@ zsh -f -c '
 grep -Fq 'running immediate forced maintenance' "$temporary/clean.out"
 grep -Fq -- '--force --min-age-days 7' "$temporary/maintain.args"
 grep -Fq -- "--repo ${repo:A}" "$temporary/maintain.args"
+maintain_args_before="$(shasum -a 256 "$temporary/maintain.args")"
+if HOME="$home" \
+  DOTFILES_WORKTREES_ROOT="$worktrees_root" \
+  PATH="$fake_bin:$PATH" \
+  TEST_MAINTAIN_ARGS="$temporary/maintain.args" \
+  zsh -f -c '
+    source "$1"
+    cd "$2"
+    gwt clean --machine
+  ' zsh "$gwt_source" "$repo" \
+    >"$temporary/clean-machine.out" \
+    2>"$temporary/clean-machine.err"; then
+  print -u2 'expected gwt clean --machine to fail'
+  exit 1
+fi
+[[ ! -s "$temporary/clean-machine.out" ]]
+grep -Fq 'clean does not support audit-only --machine output' \
+  "$temporary/clean-machine.err"
+[[ "$maintain_args_before" == "$(shasum -a 256 "$temporary/maintain.args")" ]]
+grep -Fq "worktree ${stale_path:A}" <<< "$(
+  GIT_OPTIONAL_LOCKS=0 git -C "$repo" worktree list --porcelain
+)"
+[[ ! -e "$TEST_PRUNE_LOG" ]]
+
+PATH="$fake_bin:$PATH" \
+HOME="$home" \
+DOTFILES_WORKTREES_ROOT="$worktrees_root" \
+zsh -f -c '
+  source "$1"
+  cd "$2"
+  gwt prune
+ ' zsh "$gwt_source" "$repo"
+grep -Fxq 'worktree prune' "$TEST_PRUNE_LOG"
+if GIT_OPTIONAL_LOCKS=0 git -C "$repo" worktree list --porcelain |
+  grep -Fq "worktree ${stale_path:A}"; then
+  print -u2 'explicit gwt prune left the stale registration behind'
+  exit 1
+fi
 
 authority_tool="authority-probe"
 


### PR DESCRIPTION
## Summary

- add audit-only `gwt audit --machine` output as one compact, sorted schema-v1 JSON line
- bind Codex SQLite reads to retained no-follow directory and artifact descriptors in an isolated read-only child
- preserve report-only stale registrations and keep pruning exclusive to explicit `gwt prune`

## Safety

- reject `--machine` with apply, path-listing, or `gwt clean`
- fail closed on missing, ambiguous, asymmetric, journaled, replaced, or unexpected state artifacts
- keep active-WAL zero-touch guarantees dependent on the private write-denial sandbox; there is no writable fallback

## Verification

- Apple Python 3.9.6: 24 tests passed
- Homebrew Python 3.14.6: 24 tests passed
- `zsh tests/gwt-cleanup-test.zsh`
- `bash tests/agent-worktree-maintain-test.sh`
- `git diff --check`
- two independent clean reviews, including pathname-swap and hostile-module regressions
