### PR TITLE
fix(signing): authorize fleet cleanup bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,37 @@ The installer bootstraps dependencies and links core shell dotfiles.
 Git uses the dedicated SSH signing-only key at
 `~/.ssh/git_signing_vincentkoc_ieee`. Keep a local `.ssh/allowed_signers` file
 in the dotfiles root. It is intentionally ignored from git, and the installer
-will stop if it is missing.
+will stop if it is missing or does not contain exactly one canonical entry for
+the signing identity. The entry authorizes Git signatures and signed fleet
+cleanup bundles:
 
-Create it with:
+```text
+vincentkoc@ieee.org namespaces="fleet-cleanup-bundle-v1,git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMYJHwFnesHbwtPLErQBRMffbET0Wrbzh+PjkndZRNyy
+```
+
+The expected fingerprint remains
+`SHA256:OIEOnMWCJeKhWpBNlB42wwPuUG5gsC8Crq1ibnt7ylQ`. Verify the public key,
+then create a new trust file. Fleet Git config must use the stable literal
+`~/GIT/_Perso/dotfiles/.ssh/allowed_signers`; resolve it only when accessing
+the filesystem:
 
 ```bash
-dotfiles_root="$HOME/.dotfiles"
-if [[ "$(uname)" == "Darwin" ]]; then
-  dotfiles_root="$HOME/Library/Mobile Documents/com~apple~CloudDocs/dotfiles"
-fi
-mkdir -p "$dotfiles_root/.ssh"
-printf '%s namespaces="git" %s\n' \
-  "$(git config --file "$dotfiles_root/.gitconfig" --get user.email)" \
-  "$(cat ~/.ssh/git_signing_vincentkoc_ieee.pub)" \
-  > "$dotfiles_root/.ssh/allowed_signers"
+allowed_signers="$HOME/GIT/_Perso/dotfiles/.ssh/allowed_signers"
+ssh-keygen -lf ~/.ssh/git_signing_vincentkoc_ieee.pub
+test ! -e "$allowed_signers" || {
+  printf 'refusing to overwrite existing signer entries: %s\n' "$allowed_signers" >&2
+  exit 1
+}
+mkdir -p "$(dirname "$allowed_signers")"
+umask 077
+printf '%s\n' \
+  'vincentkoc@ieee.org namespaces="fleet-cleanup-bundle-v1,git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMYJHwFnesHbwtPLErQBRMffbET0Wrbzh+PjkndZRNyy' \
+  > "$allowed_signers"
 ```
+
+If the file already contains unrelated signer entries, preserve them and
+replace only the entry for `vincentkoc@ieee.org` and the key above. The private
+fleet bootstrap performs that normalization atomically.
 
 Optional: restore additional app configs managed via Mackup.
 

--- a/bin/git-signing-mode
+++ b/bin/git-signing-mode
@@ -3,8 +3,13 @@
 set -euo pipefail
 
 git_config="${HOME}/.gitconfig"
-ssh_key="${HOME}/.ssh/id_ed25519"
-ssh_allowed_signers="${HOME}/Library/Mobile Documents/com~apple~CloudDocs/dotfiles/.ssh/allowed_signers"
+ssh_key="${HOME}/.ssh/git_signing_vincentkoc_ieee"
+ssh_key_config='~/.ssh/git_signing_vincentkoc_ieee'
+ssh_signing_principal='vincentkoc@ieee.org'
+ssh_signing_namespaces='fleet-cleanup-bundle-v1,git'
+ssh_signing_public_key='ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMYJHwFnesHbwtPLErQBRMffbET0Wrbzh+PjkndZRNyy'
+ssh_signing_fingerprint='SHA256:OIEOnMWCJeKhWpBNlB42wwPuUG5gsC8Crq1ibnt7ylQ'
+ssh_allowed_signers_config='~/GIT/_Perso/dotfiles/.ssh/allowed_signers'
 gpg_program="/opt/homebrew/bin/gpg"
 gpg_key_id="FB4C24AE87080A95"
 
@@ -12,7 +17,7 @@ usage() {
   cat <<'EOF'
 usage: git-signing-mode <ssh|gpg|status>
 
-  ssh    use SSH commit/tag signing with ~/.ssh/id_ed25519
+  ssh    use SSH commit/tag signing with ~/.ssh/git_signing_vincentkoc_ieee
   gpg    switch Git back to OpenPGP signing with the saved key id
   status show the active signing-related Git config
 EOF
@@ -29,20 +34,85 @@ show_status() {
   git config --global --show-origin --get-regexp '^(user.signingkey|commit.gpgsign|tag.gpgsign|gpg\.format|gpg\.program|gpg\.ssh\.allowedSignersFile)$' || true
 }
 
+canonical_ssh_allowed_signer() {
+  printf '%s namespaces="%s" %s\n' \
+    "$ssh_signing_principal" \
+    "$ssh_signing_namespaces" \
+    "$ssh_signing_public_key"
+}
+
+ssh_allowed_signer_ready() {
+  local path="$1" expected canonical_count matching_count
+  expected="$(canonical_ssh_allowed_signer)"
+  canonical_count="$(grep -Fxc "$expected" "$path" || true)"
+  matching_count="$(
+    awk \
+      -v principal="$ssh_signing_principal" \
+      -v key_type="${ssh_signing_public_key%% *}" \
+      -v key_blob="${ssh_signing_public_key#* }" \
+      '
+      $1 == principal {
+        for (field = 2; field < NF; field++) {
+          if ($field == key_type && $(field + 1) == key_blob) {
+            count++
+          }
+        }
+      }
+      END { print count + 0 }
+      ' \
+      "$path"
+  )"
+  [[ "$canonical_count" == 1 && "$matching_count" == 1 ]]
+}
+
 set_ssh_mode() {
+  local configured_allowed_signers derived_public_key observed_fingerprint observed_public_key
+  local ssh_allowed_signers="$HOME/GIT/_Perso/dotfiles/.ssh/allowed_signers"
+  configured_allowed_signers="$(
+    git config --global --get gpg.ssh.allowedSignersFile 2>/dev/null || true
+  )"
+  if [[ -n "$configured_allowed_signers" &&
+    "$configured_allowed_signers" != "$ssh_allowed_signers_config" ]]; then
+    echo "git-signing-mode: allowed signers config drift; expected ${ssh_allowed_signers_config}" >&2
+    exit 1
+  fi
   if [[ ! -f "${ssh_key}" ]]; then
     echo "git-signing-mode: missing SSH private key at ${ssh_key}" >&2
+    exit 1
+  fi
+  if [[ ! -f "${ssh_key}.pub" ]]; then
+    echo "git-signing-mode: missing SSH public key at ${ssh_key}.pub" >&2
+    exit 1
+  fi
+  observed_public_key="$(awk 'NF >= 2 { print $1 " " $2; exit }' "${ssh_key}.pub")"
+  observed_fingerprint="$(
+    ssh-keygen -lf "${ssh_key}.pub" 2>/dev/null |
+      awk '{print $2}' || true
+  )"
+  derived_public_key="$(
+    ssh-keygen -y -f "$ssh_key" </dev/null 2>/dev/null |
+      awk 'NF >= 2 { print $1 " " $2; exit }' || true
+  )"
+  if [[ "$observed_public_key" != "$ssh_signing_public_key" ||
+    "$derived_public_key" != "$ssh_signing_public_key" ||
+    "$observed_fingerprint" != "$ssh_signing_fingerprint" ]]; then
+    echo "git-signing-mode: signing key drift; expected ${ssh_signing_fingerprint}" >&2
     exit 1
   fi
   if [[ ! -f "${ssh_allowed_signers}" ]]; then
     echo "git-signing-mode: missing allowed signers file at ${ssh_allowed_signers}" >&2
     exit 1
   fi
+  if ! ssh_allowed_signer_ready "${ssh_allowed_signers}"; then
+    echo "git-signing-mode: allowed signers drift at ${ssh_allowed_signers}" >&2
+    echo "expected exactly one entry: $(canonical_ssh_allowed_signer)" >&2
+    exit 1
+  fi
 
   git config --global gpg.format ssh
   git config --global gpg.program "${gpg_program}"
-  git config --global gpg.ssh.allowedSignersFile "${ssh_allowed_signers}"
-  git config --global user.signingkey "${ssh_key}"
+  git config --global gpg.ssh.allowedSignersFile "${ssh_allowed_signers_config}"
+  git config --global user.signingkey "${ssh_key_config}"
   git config --global commit.gpgsign true
   git config --global tag.gpgsign true
 
@@ -89,4 +159,6 @@ main() {
   esac
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,12 @@ YELLOW='\033[0;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+SSH_SIGNING_PRINCIPAL='vincentkoc@ieee.org'
+SSH_SIGNING_NAMESPACES='fleet-cleanup-bundle-v1,git'
+SSH_SIGNING_PUBLIC_KEY='ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMYJHwFnesHbwtPLErQBRMffbET0Wrbzh+PjkndZRNyy'
+SSH_SIGNING_FINGERPRINT='SHA256:OIEOnMWCJeKhWpBNlB42wwPuUG5gsC8Crq1ibnt7ylQ'
+SSH_ALLOWED_SIGNERS_CONFIG='~/GIT/_Perso/dotfiles/.ssh/allowed_signers'
+
 info() { echo -e "${BLUE}[INFO]${NC} $1"; }
 success() { echo -e "${GREEN}[OK]${NC} $1"; }
 warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
@@ -498,8 +504,16 @@ setup_spec_symlink() {
     success "Symlinked ~/.spec to $sync_dir"
 }
 
+canonical_ssh_allowed_signer() {
+    printf '%s namespaces="%s" %s\n' \
+        "$SSH_SIGNING_PRINCIPAL" \
+        "$SSH_SIGNING_NAMESPACES" \
+        "$SSH_SIGNING_PUBLIC_KEY"
+}
+
 ensure_ssh_signing_trust_file() {
     local df_dir signing_format allowed_signers ssh_pub_key user_email
+    local configured_allowed_signers public_key fingerprint expected canonical_count matching_count
     df_dir="$(dotfiles_dir)"
     signing_format="$(git config --file "$df_dir/.gitconfig" --get gpg.format 2>/dev/null || true)"
 
@@ -507,35 +521,73 @@ ensure_ssh_signing_trust_file() {
         return
     fi
 
-    allowed_signers="$df_dir/.ssh/allowed_signers"
-    if [[ -f "$allowed_signers" ]]; then
-        success "SSH signing trust file present"
-        return
+    configured_allowed_signers="$(
+        git config --file "$df_dir/.gitconfig" --get gpg.ssh.allowedSignersFile 2>/dev/null || true
+    )"
+    if [[ "$configured_allowed_signers" != "$SSH_ALLOWED_SIGNERS_CONFIG" ]]; then
+        warn "Git allowed signers config drift: expected $SSH_ALLOWED_SIGNERS_CONFIG"
+        return 1
     fi
-
+    allowed_signers="$HOME/GIT/_Perso/dotfiles/.ssh/allowed_signers"
     ssh_pub_key="$HOME/.ssh/git_signing_vincentkoc_ieee.pub"
     user_email="$(git config --file "$df_dir/.gitconfig" --get user.email 2>/dev/null || true)"
     if [[ -z "$user_email" ]]; then
         user_email="$(git config --global --get user.email 2>/dev/null || true)"
     fi
+    expected="$(canonical_ssh_allowed_signer)"
 
-    warn "Missing SSH signing trust file: $allowed_signers"
-    if [[ -f "$ssh_pub_key" && -n "$user_email" ]]; then
-        cat <<EOF
-Create it with:
-  mkdir -p "$df_dir/.ssh"
-  printf '%s namespaces=\"git\" %s\n' "$user_email" "\$(cat \"$ssh_pub_key\")" > "$allowed_signers"
-
-Then rerun:
-  "$df_dir/install.sh"
-EOF
-    else
+    if [[ "$user_email" != "$SSH_SIGNING_PRINCIPAL" ]]; then
+        warn "Git signing principal drift: expected $SSH_SIGNING_PRINCIPAL"
+        return 1
+    fi
+    if [[ ! -f "$ssh_pub_key" ]]; then
         warn "Expected SSH public key not found at $ssh_pub_key"
-        warn "Expected Git email not found in $df_dir/.gitconfig or global git config"
-        info "Create $allowed_signers manually once your SSH key and Git email are set"
+        return 1
+    fi
+    public_key="$(awk 'NF >= 2 { print $1 " " $2; exit }' "$ssh_pub_key")"
+    fingerprint="$(ssh-keygen -lf "$ssh_pub_key" 2>/dev/null | awk '{print $2}')"
+    if [[ "$public_key" != "$SSH_SIGNING_PUBLIC_KEY" || "$fingerprint" != "$SSH_SIGNING_FINGERPRINT" ]]; then
+        warn "SSH signing public key drift: expected $SSH_SIGNING_FINGERPRINT"
+        return 1
     fi
 
-    return 0
+    if [[ -f "$allowed_signers" ]]; then
+        canonical_count="$(grep -Fxc "$expected" "$allowed_signers" || true)"
+        matching_count="$(
+            awk \
+                -v principal="$SSH_SIGNING_PRINCIPAL" \
+                -v key_type="${SSH_SIGNING_PUBLIC_KEY%% *}" \
+                -v key_blob="${SSH_SIGNING_PUBLIC_KEY#* }" \
+                '
+                $1 == principal {
+                    for (field = 2; field < NF; field++) {
+                        if ($field == key_type && $(field + 1) == key_blob) {
+                            count++
+                        }
+                    }
+                }
+                END { print count + 0 }
+                ' \
+                "$allowed_signers"
+        )"
+        if [[ "$canonical_count" == 1 && "$matching_count" == 1 ]]; then
+            success "SSH signing trust file authorizes Git and fleet cleanup bundles"
+            return 0
+        fi
+        warn "SSH signing trust file drift: $allowed_signers"
+    else
+        warn "Missing SSH signing trust file: $allowed_signers"
+    fi
+
+    cat <<EOF
+Expected exactly one canonical entry:
+  $expected
+
+Preserve unrelated entries, replace any entry for this principal and key,
+then rerun:
+  "$df_dir/install.sh"
+EOF
+    return 1
 }
 
 setup_codex_dotfiles() {

--- a/tests/git-signing-trust-test.sh
+++ b/tests/git-signing-trust-test.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$repo_root/install.sh"
+
+fixture_root="$(mktemp -d)"
+fixture="$fixture_root/fixture with spaces"
+mkdir -p "$fixture"
+trap 'rm -rf "$fixture_root"' EXIT
+export HOME="$fixture/home"
+dotfiles="$HOME/GIT/_Perso/dotfiles"
+mkdir -p "$dotfiles/.ssh" "$HOME/.ssh"
+printf '[user]\n\temail = %s\n[gpg]\n\tformat = ssh\n' \
+  "$SSH_SIGNING_PRINCIPAL" > "$dotfiles/.gitconfig"
+printf '[gpg "ssh"]\n\tallowedSignersFile = ~/GIT/_Perso/dotfiles/.ssh/allowed_signers\n' \
+  >> "$dotfiles/.gitconfig"
+printf '%s test-fixture\n' "$SSH_SIGNING_PUBLIC_KEY" \
+  > "$HOME/.ssh/git_signing_vincentkoc_ieee.pub"
+
+run_check() {
+  local output status
+  set +e
+  output="$(ensure_ssh_signing_trust_file 2>&1)"
+  status=$?
+  set -e
+  printf '%s\n' "$status"
+  printf '%s\n' "$output"
+}
+
+expected="$(canonical_ssh_allowed_signer)"
+unrelated='other@example.com namespaces="git" ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+
+printf '%s\n%s\n' "$unrelated" "$expected" > "$dotfiles/.ssh/allowed_signers"
+result="$(run_check)"
+[[ "${result%%$'\n'*}" == 0 ]]
+grep -Fq 'authorizes Git and fleet cleanup bundles' <<<"$result"
+
+git config --file "$dotfiles/.gitconfig" \
+  gpg.ssh.allowedSignersFile "$HOME/custom trust/allowed_signers"
+result="$(run_check)"
+[[ "${result%%$'\n'*}" == 1 ]]
+grep -Fq 'Git allowed signers config drift' <<<"$result"
+git config --file "$dotfiles/.gitconfig" \
+  gpg.ssh.allowedSignersFile '~/GIT/_Perso/dotfiles/.ssh/allowed_signers'
+
+printf '%s\n%s namespaces="git" %s\n' \
+  "$unrelated" \
+  "$SSH_SIGNING_PRINCIPAL" \
+  "$SSH_SIGNING_PUBLIC_KEY" \
+  > "$dotfiles/.ssh/allowed_signers"
+result="$(run_check)"
+[[ "${result%%$'\n'*}" == 1 ]]
+grep -Fq 'SSH signing trust file drift' <<<"$result"
+grep -Fq "$expected" <<<"$result"
+if grep -Fq '[OK]' <<<"$result"; then
+  echo 'stale signer trust was incorrectly reported ready' >&2
+  exit 1
+fi
+
+printf '%s\n%s\n%s\n' "$unrelated" "$expected" "$expected" \
+  > "$dotfiles/.ssh/allowed_signers"
+result="$(run_check)"
+[[ "${result%%$'\n'*}" == 1 ]]
+grep -Fq 'SSH signing trust file drift' <<<"$result"
+
+rm "$dotfiles/.ssh/allowed_signers"
+result="$(run_check)"
+[[ "${result%%$'\n'*}" == 1 ]]
+grep -Fq 'Missing SSH signing trust file' <<<"$result"
+grep -Fq "$expected" <<<"$result"
+
+printf '%s wrong-key\n' \
+  'ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' \
+  > "$HOME/.ssh/git_signing_vincentkoc_ieee.pub"
+result="$(run_check)"
+[[ "${result%%$'\n'*}" == 1 ]]
+grep -Fq "expected $SSH_SIGNING_FINGERPRINT" <<<"$result"
+
+signing_fixture="$fixture/signing"
+fixture_key="$signing_fixture/key"
+fixture_other_key="$signing_fixture/other-key"
+fixture_allowed_signers="$signing_fixture/allowed_signers"
+fixture_repo="$signing_fixture/repo"
+fixture_payload="$signing_fixture/fleet-cleanup-bundle"
+mkdir -p "$signing_fixture"
+ssh-keygen -q -t ed25519 -N '' -C signing-fixture -f "$fixture_key"
+ssh-keygen -q -t ed25519 -N '' -C other-signing-fixture -f "$fixture_other_key"
+fixture_public_key="$(awk 'NF >= 2 { print $1 " " $2; exit }' "$fixture_key.pub")"
+printf '%s namespaces="%s" %s\n' \
+  "$SSH_SIGNING_PRINCIPAL" \
+  "$SSH_SIGNING_NAMESPACES" \
+  "$fixture_public_key" \
+  > "$fixture_allowed_signers"
+
+git -C "$signing_fixture" init -q repo
+git -C "$fixture_repo" config user.name 'Signing Fixture'
+git -C "$fixture_repo" config user.email "$SSH_SIGNING_PRINCIPAL"
+git -C "$fixture_repo" config user.signingkey "$fixture_key"
+git -C "$fixture_repo" config gpg.format ssh
+git -C "$fixture_repo" config gpg.ssh.allowedSignersFile "$fixture_allowed_signers"
+git -C "$fixture_repo" config commit.gpgsign true
+git -C "$fixture_repo" commit --allow-empty -qm 'test: verify git namespace'
+git -C "$fixture_repo" verify-commit HEAD >/dev/null
+
+printf 'fleet-cleanup-bundle-v1\n' > "$fixture_payload"
+ssh-keygen -Y sign \
+  -f "$fixture_key" \
+  -n fleet-cleanup-bundle-v1 \
+  "$fixture_payload" >/dev/null 2>&1
+ssh-keygen -Y verify \
+  -f "$fixture_allowed_signers" \
+  -I "$SSH_SIGNING_PRINCIPAL" \
+  -n fleet-cleanup-bundle-v1 \
+  -s "$fixture_payload.sig" \
+  < "$fixture_payload" >/dev/null
+
+printf '%s namespaces="git" %s\n' \
+  "$SSH_SIGNING_PRINCIPAL" \
+  "$fixture_public_key" \
+  > "$fixture_allowed_signers"
+if ssh-keygen -Y verify \
+  -f "$fixture_allowed_signers" \
+  -I "$SSH_SIGNING_PRINCIPAL" \
+  -n fleet-cleanup-bundle-v1 \
+  -s "$fixture_payload.sig" \
+  < "$fixture_payload" >/dev/null 2>&1; then
+  echo 'git-only namespace incorrectly verified a fleet cleanup bundle' >&2
+  exit 1
+fi
+
+mode_home="$fixture/mode-home"
+mode_allowed_signers="$mode_home/GIT/_Perso/dotfiles/.ssh/allowed_signers"
+mkdir -p "$(dirname "$mode_allowed_signers")" "$mode_home/.ssh"
+cp "$fixture_key" "$mode_home/.ssh/git_signing_vincentkoc_ieee"
+cp "$fixture_key.pub" "$mode_home/.ssh/git_signing_vincentkoc_ieee.pub"
+fixture_fingerprint="$(ssh-keygen -lf "$fixture_key.pub" | awk '{print $2}')"
+mode_expected="$SSH_SIGNING_PRINCIPAL namespaces=\"$SSH_SIGNING_NAMESPACES\" $fixture_public_key"
+printf '%s\n' "$mode_expected" > "$mode_allowed_signers"
+(
+  export HOME="$mode_home"
+  export GIT_CONFIG_GLOBAL="$mode_home/.gitconfig"
+  source "$repo_root/bin/git-signing-mode"
+  ssh_signing_public_key="$fixture_public_key"
+  ssh_signing_fingerprint="$fixture_fingerprint"
+  main ssh
+) >/dev/null
+[[ "$(
+  HOME="$mode_home" GIT_CONFIG_GLOBAL="$mode_home/.gitconfig" \
+    git config --global --get user.signingkey
+)" == '~/.ssh/git_signing_vincentkoc_ieee' ]]
+[[ "$(
+  HOME="$mode_home" GIT_CONFIG_GLOBAL="$mode_home/.gitconfig" \
+    git config --global --get gpg.ssh.allowedSignersFile
+)" == '~/GIT/_Perso/dotfiles/.ssh/allowed_signers' ]]
+if grep -Fq "$mode_home" "$mode_home/.gitconfig"; then
+  echo 'git-signing-mode wrote a machine-specific home path' >&2
+  exit 1
+fi
+
+printf '%s namespaces="git" %s\n' \
+  "$SSH_SIGNING_PRINCIPAL" \
+  "$fixture_public_key" \
+  > "$mode_allowed_signers"
+mode_config_before="$(shasum -a 256 "$mode_home/.gitconfig" | awk '{print $1}')"
+if (
+  export HOME="$mode_home"
+  export GIT_CONFIG_GLOBAL="$mode_home/.gitconfig"
+  source "$repo_root/bin/git-signing-mode"
+  ssh_signing_public_key="$fixture_public_key"
+  ssh_signing_fingerprint="$fixture_fingerprint"
+  main ssh
+) >"$fixture/mode.out" 2>&1; then
+  echo 'git-signing-mode incorrectly accepted git-only trust' >&2
+  exit 1
+fi
+mode_config_after="$(shasum -a 256 "$mode_home/.gitconfig" | awk '{print $1}')"
+[[ "$mode_config_before" == "$mode_config_after" ]]
+grep -Fq 'allowed signers drift' "$fixture/mode.out"
+grep -Fq "$mode_expected" "$fixture/mode.out"
+
+cp "$fixture_other_key" "$mode_home/.ssh/git_signing_vincentkoc_ieee"
+printf '%s\n' "$mode_expected" > "$mode_allowed_signers"
+mode_config_before="$(shasum -a 256 "$mode_home/.gitconfig" | awk '{print $1}')"
+if (
+  export HOME="$mode_home"
+  export GIT_CONFIG_GLOBAL="$mode_home/.gitconfig"
+  source "$repo_root/bin/git-signing-mode"
+  ssh_signing_public_key="$fixture_public_key"
+  ssh_signing_fingerprint="$fixture_fingerprint"
+  main ssh
+) >"$fixture/mode-private-mismatch.out" 2>&1; then
+  echo 'git-signing-mode accepted a private/public key mismatch' >&2
+  exit 1
+fi
+mode_config_after="$(shasum -a 256 "$mode_home/.gitconfig" | awk '{print $1}')"
+[[ "$mode_config_before" == "$mode_config_after" ]]
+grep -Fq 'signing key drift' "$fixture/mode-private-mismatch.out"
+cp "$fixture_key" "$mode_home/.ssh/git_signing_vincentkoc_ieee"
+
+mode_missing="$mode_home/configured missing/allowed_signers"
+HOME="$mode_home" GIT_CONFIG_GLOBAL="$mode_home/.gitconfig" \
+  git config --global gpg.ssh.allowedSignersFile "$mode_missing"
+if (
+  export HOME="$mode_home"
+  export GIT_CONFIG_GLOBAL="$mode_home/.gitconfig"
+  source "$repo_root/bin/git-signing-mode"
+  ssh_signing_public_key="$fixture_public_key"
+  ssh_signing_fingerprint="$fixture_fingerprint"
+  main ssh
+) >"$fixture/mode-missing.out" 2>&1; then
+  echo 'git-signing-mode silently accepted a noncanonical configured path' >&2
+  exit 1
+fi
+grep -Fq 'allowed signers config drift' "$fixture/mode-missing.out"
+
+echo git_signing_trust_test=passed


### PR DESCRIPTION
## Summary

- require the canonical signer entry to authorize both `git` and `fleet-cleanup-bundle-v1`
- keep Git config on stable `~` literals and reject stale paths, keys, duplicates, and Git-only trust
- make `git-signing-mode ssh` use the dedicated signing-only key and validate its exact private/public identity
- document the canonical fleet trust path and safe creation flow

Companion: https://github.com/vincentkoc/dotfiles-private/pull/12

## Verification

- `/bin/bash tests/git-signing-trust-test.sh`
- `/opt/homebrew/bin/bash tests/git-signing-trust-test.sh`
- `shellcheck --severity=error install.sh bin/git-signing-mode tests/git-signing-trust-test.sh`
- `git diff --check`
- signed commit verified with fingerprint `SHA256:OIEOnMWCJeKhWpBNlB42wwPuUG5gsC8Crq1ibnt7ylQ`
