### PR TITLE
fix(tmux): make timer stat checks portable

### DIFF
--- a/bin/tt
+++ b/bin/tt
@@ -2285,12 +2285,31 @@ count_snapshot_history() {
   find "$dir" -maxdepth 1 -type f -name '*.tsv' 2>/dev/null | wc -l | tr -d ' '
 }
 
+portable_stat_value() {
+  local bsd_format="$1"
+  local gnu_format="$2"
+  local path="$3"
+  local value
+
+  if value="$(stat -f "$bsd_format" -- "$path" 2>/dev/null)" &&
+    [[ "$value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  if value="$(stat -c "$gnu_format" -- "$path" 2>/dev/null)" &&
+    [[ "$value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  return 1
+}
+
 file_age_seconds() {
   local file="$1"
   local now mtime
   [[ -f "$file" ]] || return 1
   now="$(date +%s)"
-  mtime="$(stat -f %m "$file" 2>/dev/null || stat -c %Y "$file" 2>/dev/null || true)"
+  mtime="$(portable_stat_value %m %Y "$file" 2>/dev/null || true)"
   [[ "$mtime" =~ ^[0-9]+$ ]] || return 1
   printf '%s\n' "$((now - mtime))"
 }
@@ -3284,11 +3303,11 @@ clear_agent_autosave_hooks() {
 }
 
 codex_snapshot_timer_file_uid() {
-  stat -f %u "$1" 2>/dev/null || stat -c %u "$1" 2>/dev/null
+  portable_stat_value %u %u "$1"
 }
 
 codex_snapshot_timer_file_size() {
-  stat -f %z "$1" 2>/dev/null || stat -c %s "$1" 2>/dev/null
+  portable_stat_value %z %s "$1"
 }
 
 codex_snapshot_timer_log() {

--- a/tests/tt-autosave-timer-test.sh
+++ b/tests/tt-autosave-timer-test.sh
@@ -51,6 +51,25 @@ wait_until() {
   return 1
 }
 
+portable_stat_value() {
+  local bsd_format="$1"
+  local gnu_format="$2"
+  local path="$3"
+  local value
+
+  if value="$(stat -f "$bsd_format" -- "$path" 2>/dev/null)" &&
+    [[ "$value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  if value="$(stat -c "$gnu_format" -- "$path" 2>/dev/null)" &&
+    [[ "$value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  return 1
+}
+
 start_case() {
   local name="$1"
   CASE_DIR="$temporary/$name"
@@ -228,7 +247,7 @@ token="$(timer_token)"
 server_pid="$("$tmux_bin" -L "$CASE_SOCKET" display-message -p '#{pid}')"
 [[ "$(awk -F '\t' '{print $1, $3, $4}' "$state_file")" == "v1 $server_pid $(id -u)" ]]
 [[ "$(timer_max_age)" == "7" ]]
-[[ "$(stat -f %Lp "$state_file" 2>/dev/null || stat -c %a "$state_file")" == "600" ]]
+[[ "$(portable_stat_value %Lp %a "$state_file")" == "600" ]]
 kill -0 "$pid"
 timer_process_matches "$pid" "$token"
 timer_has_server_ancestor "$pid" "$server_pid"
@@ -346,8 +365,7 @@ export TT_CODEX_SNAPSHOT_TIMER_LOG_MAX_BYTES=220
 touch "$CASE_FAIL"
 sleep 5
 rm -f "$CASE_FAIL"
-log_size="$(stat -f %z "$CASE_STATE/tt/codex-cockpit.timer.log" 2>/dev/null ||
-  stat -c %s "$CASE_STATE/tt/codex-cockpit.timer.log")"
+log_size="$(portable_stat_value %z %s "$CASE_STATE/tt/codex-cockpit.timer.log")"
 (( log_size <= 1024 ))
 
 case_tt autosave off


### PR DESCRIPTION
## Summary

- isolate BSD and GNU `stat` probes so failed BSD output cannot contaminate the GNU fallback
- require numeric stat values before accepting them
- use the same portable helper for timer-test mode and log-size assertions

## Validation

- `bash -n bin/tt tests/tt-autosave-timer-test.sh` under Bash 3.2 and Bash 5.3
- `git diff --check`
- helper smoke against BSD `stat`, GNU `gstat`, and native Linux/WSL `stat`
- `tests/tt-autosave-timer-test.sh` on macOS, macOS system Bash 3.2, and isolated WSL
- `tests/tt-codex-snapshot-test.sh`
- `tests/tt-codex-snapshot-live-test.sh`
- `tests/tt-recovery-test.sh`
- `tests/tt-lifecycle-test.sh`
- `tests/tt-wsl-bridge-test.sh`

## Regression proof

Current `master` fails autosave timer health checks on WSL because the failed BSD probe writes filesystem details before the GNU fallback value. With only the product patch, the timer is healthy but the old test has the same contaminated-output bug. The complete product-and-test patch passes.
