### PR TITLE
fix(codex): prevent worktree graph indexes

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -117,6 +117,8 @@
 - Before contributing, read `CONTRIBUTING.md` and relevant issue/PR templates. Match repo style. If an issue is linked, use closing refs like `Fixes #123`.
 - Use `ghx` for GitHub work. Prefer draft PRs first.
 - Never send a GitHub payload through `ghx` stdin (`--body-file -`, `-F -`, `--input -`, `--with-token`, or `/dev/stdin`). The proxy daemon does not forward stdin. Write the payload to a real temporary file and pass its path; after PR/issue body changes, read the live field back with `ghx --no-cache` and fail if it is empty or mismatched.
+- Before `codebase-memory-mcp` indexing, resolve the requested repository to its canonical owning checkout with the installed `codebase-memory-mcp` skill helper. Linked branch worktrees must reuse the owner graph; separate clones remain separate projects.
+- Never index `~/.codex/worktrees`, `~/GIT/_Worktrees`, repo-local `.worktrees`, `/tmp`, or `/private/tmp` paths as independent projects. If a path under one of those prefixes cannot resolve to an existing non-worktree owning checkout, skip indexing and report the missing canonical checkout.
 - Prefer worktrees and spawning subagents.
 - Create new worktrees with `gwt new <branch> [start-point]` or the repo-native wrapper.
 - Start in a branch/worktree early so commits can be made incrementally.

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo \"Code discovery: prefer codebase-memory-mcp (search_graph, trace_path, get_code_snippet, query_graph, search_code) over broad grep/file reads; run index_repository first if the project is not indexed.\""
+            "command": "echo \"Code discovery: prefer codebase-memory-mcp (search_graph, trace_path, get_code_snippet, query_graph, search_code) over broad grep/file reads. Before index_repository, resolve the requested path to its canonical owning checkout with the codebase-memory-mcp canonical helper. Never index a linked branch, GWT, Codex, repo-local, or temporary worktree as a separate project; if no non-worktree canonical checkout exists, skip indexing and report it.\""
           }
         ]
       }

--- a/tests/codebase-memory-policy-test.py
+++ b/tests/codebase-memory-policy-test.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+HOOKS = ROOT / ".codex" / "hooks.json"
+AGENTS = ROOT / ".codex" / "AGENTS.md"
+
+
+payload = json.loads(HOOKS.read_text())
+commands = [
+    hook["command"]
+    for group in payload["hooks"]["SessionStart"]
+    for hook in group["hooks"]
+    if hook.get("type") == "command"
+]
+message = next(command for command in commands if "codebase-memory-mcp" in command)
+for phrase in (
+    "Before index_repository",
+    "canonical owning checkout",
+    "Never index a linked branch",
+    "skip indexing and report it",
+):
+    if phrase not in message:
+        raise SystemExit(f"missing hook policy: {phrase}")
+
+agents = AGENTS.read_text()
+for phrase in (
+    "canonical owning checkout",
+    "Linked branch worktrees must reuse the owner graph",
+    "~/.codex/worktrees",
+    "~/GIT/_Worktrees",
+    "repo-local `.worktrees`",
+    "`/tmp`",
+    "`/private/tmp`",
+    "skip indexing and report the missing canonical checkout",
+):
+    if phrase not in agents:
+        raise SystemExit(f"missing agent policy: {phrase}")
+
+print("codebase_memory_policy_test=passed")


### PR DESCRIPTION
## What changed

- update the Codex session hook to require canonical checkout resolution before indexing
- prohibit independent codebase-memory indexes for Codex, GWT, repo-local, and temporary worktrees
- add a focused policy regression test

## Why

Linked branch worktrees were being treated as separate graph projects. Fleet agents should reuse the owning checkout graph and fail closed when no canonical checkout exists.

## Validation

- `python3 tests/codebase-memory-policy-test.py`
- `python3 -m json.tool .codex/hooks.json`
- `bash -n install.sh`
- `tests/terminal-sync-test.sh`
