### PR TITLE
fix(git): normalize SSH signing config

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -30,6 +30,7 @@
 [core]
 	# Sets editor to sublime
 	editor = true
+	hooksPath = /dev/null
 	# Sets global excludes
 	excludesfile = ~/.gitignore_global
 	# Improves diff used by git in CLI
@@ -136,3 +137,4 @@
 	gpgsign = true
 [gpg "ssh"]
 	allowedSignersFile = ~/GIT/_Perso/dotfiles/.ssh/allowed_signers
+	program = /usr/bin/ssh-keygen


### PR DESCRIPTION
## Summary

- disable repository hooks in the canonical global Git config
- pin SSH signing to the system `ssh-keygen`
- preserve the canonical allowed-signers path

## Validation

- `bash tests/git-signing-trust-test.sh`
- parsed `.gitconfig` and verified each signing value occurs exactly once
- `git diff --check`
