### PR TITLE
fix(codex): route memory indexing through canonical helper

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo \"Code discovery: use codebase-memory-mcp search/query tools (search_graph, trace_path, get_code_snippet, query_graph, search_code). The MCP index_repository tool is intentionally disabled. All indexing/reindexing must use the installed codebase-memory-graph.sh index|init canonical helper; direct codebase-memory-mcp cli index_repository is forbidden. Linked worktrees rewrite to their owning checkout; reserved and temporary paths are denied as independent clones.\""
+            "command": "echo \"Code discovery: use codebase-memory-mcp search/query tools (search_graph, trace_path, get_code_snippet, query_graph, search_code). Direct index_repository use is policy-forbidden; all indexing/reindexing must use the installed codebase-memory-graph.sh index|init canonical helper, and direct codebase-memory-mcp cli index_repository is forbidden. Linked worktrees rewrite to their owning checkout. Independent indexing is denied for ~/.codex/worktrees, ~/GIT/_Worktrees, any repo-local .worktrees path, /tmp, and /private/tmp.\""
           }
         ]
       }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo \"Code discovery: prefer codebase-memory-mcp (search_graph, trace_path, get_code_snippet, query_graph, search_code) over broad grep/file reads. Before index_repository, resolve the requested path to its canonical owning checkout with the codebase-memory-mcp canonical helper. Never index a linked branch, GWT, Codex, repo-local, or temporary worktree as a separate project; if no non-worktree canonical checkout exists, skip indexing and report it.\""
+            "command": "echo \"Code discovery: use codebase-memory-mcp search/query tools (search_graph, trace_path, get_code_snippet, query_graph, search_code). The MCP index_repository tool is intentionally disabled. All indexing/reindexing must use the installed codebase-memory-graph.sh index|init canonical helper; direct codebase-memory-mcp cli index_repository is forbidden. Linked worktrees rewrite to their owning checkout; reserved and temporary paths are denied as independent clones.\""
           }
         ]
       }

--- a/tests/codebase-memory-policy-test.py
+++ b/tests/codebase-memory-policy-test.py
@@ -25,14 +25,20 @@ rendered = subprocess.run(
 ).stdout
 for phrase in (
     "search/query tools",
-    "index_repository tool is intentionally disabled",
+    "Direct index_repository use is policy-forbidden",
     "codebase-memory-graph.sh index|init canonical helper",
     "direct codebase-memory-mcp cli index_repository is forbidden",
     "Linked worktrees rewrite to their owning checkout",
-    "reserved and temporary paths are denied as independent clones",
+    (
+        "Independent indexing is denied for ~/.codex/worktrees, "
+        "~/GIT/_Worktrees, any repo-local .worktrees path, /tmp, "
+        "and /private/tmp."
+    ),
 ):
     if phrase not in rendered:
         raise SystemExit(f"missing hook policy: {phrase}")
+if "intentionally disabled" in rendered:
+    raise SystemExit("hook must describe policy rather than tool capability")
 
 agents = AGENTS.read_text()
 for phrase in (

--- a/tests/codebase-memory-policy-test.py
+++ b/tests/codebase-memory-policy-test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import json
 import pathlib
+import subprocess
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -16,13 +17,21 @@ commands = [
     if hook.get("type") == "command"
 ]
 message = next(command for command in commands if "codebase-memory-mcp" in command)
+rendered = subprocess.run(
+    ["/bin/sh", "-c", message],
+    check=True,
+    capture_output=True,
+    text=True,
+).stdout
 for phrase in (
-    "Before index_repository",
-    "canonical owning checkout",
-    "Never index a linked branch",
-    "skip indexing and report it",
+    "search/query tools",
+    "index_repository tool is intentionally disabled",
+    "codebase-memory-graph.sh index|init canonical helper",
+    "direct codebase-memory-mcp cli index_repository is forbidden",
+    "Linked worktrees rewrite to their owning checkout",
+    "reserved and temporary paths are denied as independent clones",
 ):
-    if phrase not in message:
+    if phrase not in rendered:
         raise SystemExit(f"missing hook policy: {phrase}")
 
 agents = AGENTS.read_text()


### PR DESCRIPTION
## Summary

- clarify that code discovery uses codebase-memory search and query tools
- state that direct `index_repository` use is policy-forbidden
- require the installed canonical helper for all indexing and reindexing
- forbid direct CLI indexing and enumerate every denied worktree or temporary root

## Testing

- `PYTHONDONTWRITEBYTECODE=1 python3 tests/codebase-memory-policy-test.py`
- JSON parse and Python AST/compile checks
- `git diff --check`
