### PR TITLE
fix(codex): guard worktree maintenance ownership

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -168,6 +168,8 @@ Recovery mode rules:
 - If `node_modules` is not a symlink in a Codex worktree, stop and report it.
 - Prefer shared worktrees created with `gwt new`.
 - Prefer scoped tests and targeted verification; do not run repo-wide heavy gates unless explicitly asked or clearly required.
-- If disk is low, worktree count is high, or local state looks stale, run `agent-worktree-maintain --force` before continuing.
+- Worktree maintenance is a broad destructive mutation, never an automatic recovery step. Do not run `agent-worktree-maintain` because disk is low, the worktree count is high, state looks stale, or another cleanup command such as `gwt rm` just ran.
+- Before invoking worktree maintenance, resolve the exact host, canonical repository set, target worktree paths, owner session or PIDs, lock owner, and stop condition. A live maintainer/cleaner process or lock is contention: do not start a second process, kill it, or clear its lock; wait for the owner to finish unless the user gives current-turn permission naming that exact process or lock.
+- Run worktree maintenance only with current-turn user authorization naming the exact host, repository/worktree scope, and destructive mode. Restrict cleanup to paths owned by the current task or exact paths explicitly authorized; age, merged branches, missing panes, and low disk never prove ownership.
 - If the current worktree was cleaned up or no longer exists, stop and ask whether to recreate it.
 - Do not start duplicate heavy checks if another session is likely already running them.

--- a/tests/worktree-maintenance-policy-test.py
+++ b/tests/worktree-maintenance-policy-test.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+AGENTS = ROOT / ".codex" / "AGENTS.md"
+
+
+policy = AGENTS.read_text(encoding="utf-8")
+
+for obsolete in (
+    "If disk is low, worktree count is high, or local state looks stale, run "
+    "`agent-worktree-maintain --force` before continuing.",
+):
+    if obsolete in policy:
+        raise SystemExit(f"obsolete automatic maintenance policy remains: {obsolete}")
+
+for required in (
+    "never an automatic recovery step",
+    "another cleanup command such as `gwt rm` just ran",
+    "canonical repository set",
+    "owner session or PIDs",
+    "lock owner",
+    "A live maintainer/cleaner process or lock is contention",
+    "do not start a second process, kill it, or clear its lock",
+    "current-turn permission naming that exact process or lock",
+    "current-turn user authorization naming the exact host",
+    "repository/worktree scope",
+    "paths owned by the current task or exact paths explicitly authorized",
+    "missing panes, and low disk never prove ownership",
+):
+    if required not in policy:
+        raise SystemExit(f"missing worktree maintenance policy: {required}")
+
+print("worktree_maintenance_policy_test=passed")


### PR DESCRIPTION
## Summary

- remove the implicit low-disk/stale-state trigger for broad worktree maintenance
- require exact current-turn authorization, ownership resolution, and lock/contention handling
- add an executable regression test for the maintenance policy

## Validation

- `./tests/worktree-maintenance-policy-test.py`
- `python3 -m py_compile tests/worktree-maintenance-policy-test.py`
- `python3 tests/codebase-memory-policy-test.py`
- `git diff --check`
