### PR TITLE
feat(linux): add user-only server refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ git clone https://github.com/vincentkoc/dotfiles.git ~/.dotfiles
 ~/.dotfiles/bin/linux-server-bootstrap plan
 ~/.dotfiles/bin/linux-server-bootstrap audit
 ~/.dotfiles/bin/linux-server-bootstrap prepare
+~/.dotfiles/bin/linux-server-bootstrap refresh-user
 ```
 
 `prepare` installs the Ubuntu shell baseline, checksum-pinned Node 24.19.0,
@@ -98,6 +99,15 @@ installs, Mosh, and firewall activation. Regular SSH is the safe default; add a
 separately reviewed tailnet UDP policy before opting into Mosh. `prepare` does
 not install, write, validate, or reload the SSH server; the Ubuntu host must
 already have a working `sshd`.
+
+`refresh-user` reruns only the user-owned portion: safe directory modes,
+public shell links, pinned prompt tooling, Node/pnpm, and the public Codex
+launcher. It never invokes sudo, package management, firewall, account, or SSH
+server mutations. PNPM globals live directly in `PNPM_HOME`, and the server
+profile adds `cx` as an argument-preserving `codex --no-alt-screen` shortcut.
+The empty private `~/.codex` surface remains host-local; no hooks, global
+instructions, model catalog, credentials, QuickSSH, Mosh, or OpenClaw launcher
+configuration is linked.
 
 Obtain the SHA256 fingerprint of the designated recovery public key through an
 independent trusted path, then explicitly enable the temporary proof phase:

--- a/bin/linux-server-bootstrap
+++ b/bin/linux-server-bootstrap
@@ -818,7 +818,7 @@ require_strict_home_descendant() {
 }
 
 preflight_home_directory() {
-  local canonical_home
+  local canonical_home home_mode
   canonical_home="$(canonical_absolute_path "$HOME")" || return 1
   [[ "$canonical_home" == "$HOME" && ! -L "$HOME" && -d "$HOME" ]] || {
     printf 'refusing unsafe HOME directory\n' >&2
@@ -828,11 +828,16 @@ preflight_home_directory() {
     printf 'refusing foreign-owned HOME directory\n' >&2
     return 1
   }
+  home_mode="$(owned_path_mode "$HOME")" || return 1
+  (( (8#$home_mode & 8#0100) != 0 )) || {
+    printf 'refusing non-traversable HOME directory\n' >&2
+    return 1
+  }
 }
 
 preflight_owned_directory() {
   local path="$1"
-  local relative component current="$HOME"
+  local relative component current="$HOME" current_mode
   local -a components=()
   require_strict_home_descendant "$path" || return 1
   relative="${path#"$HOME"/}"
@@ -852,9 +857,12 @@ preflight_owned_directory() {
         printf 'refusing foreign-owned user directory: %s\n' "$current" >&2
         return 1
       }
-      # Owned 0775 paths are normalized after the complete preflight; world-write is never safe.
-      local current_mode
       current_mode="$(owned_path_mode "$current")" || return 1
+      (( (8#$current_mode & 8#0100) != 0 )) || {
+        printf 'refusing non-traversable user directory: %s\n' "$current" >&2
+        return 1
+      }
+      # Owned 0775 paths are normalized after the complete preflight; world-write is never safe.
       (( (8#$current_mode & 8#0002) == 0 )) || {
         printf 'refusing world-writable user directory: %s\n' "$current" >&2
         return 1

--- a/bin/linux-server-bootstrap
+++ b/bin/linux-server-bootstrap
@@ -19,6 +19,7 @@ state_root="${XDG_STATE_HOME:-$HOME/.local/state}/dotfiles/linux-server"
 proof_file="$state_root/second-session-proof"
 auth_proof_state_file="$state_root/auth-proof-state"
 dry_run="${DOTFILES_SERVER_DRY_RUN:-0}"
+pnpm_home="${PNPM_HOME:-${XDG_DATA_HOME:-$HOME/.local/share}/pnpm}"
 
 node_version=24.19.0
 node_linux_x64_sha256=14b342e71204f811bde6153be8e04b62aef63c236fef92b55f9c83154b409647
@@ -36,11 +37,12 @@ gateway_port="${DOTFILES_SERVER_GATEWAY_PORT:-443}"
 
 usage() {
   printf '%s\n' \
-    'usage: linux-server-bootstrap <plan|audit|prepare|enable-auth-proof|prove-second-session|cleanup-auth-proof|lockdown>' \
+    'usage: linux-server-bootstrap <plan|audit|prepare|refresh-user|enable-auth-proof|prove-second-session|cleanup-auth-proof|lockdown>' \
     '' \
     '  plan                  Print the deterministic prepare and lockdown plan.' \
     '  audit                 Read-only shell, SSH, firewall, and tool audit.' \
     '  prepare               Install the Ubuntu CLI baseline and safe dotfiles.' \
+    '  refresh-user          Refresh only user-owned shell and CLI state.' \
     '  enable-auth-proof     Temporarily expose auth data for one administrator.' \
     '  prove-second-session  Prove a designated key on a fresh Tailscale session.' \
     '  cleanup-auth-proof    Remove an abandoned temporary auth-proof exposure.' \
@@ -148,6 +150,9 @@ plan() {
     'prepare.remote_shell=ssh' \
     'prepare.dotfiles=portable-aliases-functions-server-zsh-server-tmux' \
     'prepare.excludes=credentials-signing-gui-apps-global-openclaw-mosh' \
+    'refresh_user.privilege=user-only' \
+    'refresh_user.codex=public-wrapper-standalone-backend' \
+    'refresh_user.pnpm_home=direct-path-no-bin-suffix' \
     'enable_auth_proof.requires=admin-user,designated-key-sha256,unchanged-authorized_keys' \
     "enable_auth_proof.expires_seconds=$auth_proof_ttl" \
     'proof.requires=fresh-nonmultiplexed-transport,designated-public-key,tailscale-whois' \
@@ -239,6 +244,7 @@ install_pinned_checkout() {
     run git -C "$destination" fetch --depth 1 origin "$sha"
   fi
   run git -C "$destination" checkout --detach --force "$sha"
+  run chmod 0755 "$destination"
 }
 
 ssh_service_name() {
@@ -728,6 +734,214 @@ backup_and_link() {
   run ln -s "$source" "$destination"
 }
 
+owned_path_uid() {
+  stat -c %u "$1" 2>/dev/null || stat -f %u "$1"
+}
+
+preflight_owned_directory() {
+  local path="$1"
+  if [[ -L "$path" ]]; then
+    printf 'refusing symlinked user directory: %s\n' "$path" >&2
+    return 1
+  fi
+  if [[ -e "$path" ]]; then
+    [[ -d "$path" ]] || {
+      printf 'refusing non-directory user path: %s\n' "$path" >&2
+      return 1
+    }
+    [[ "$(owned_path_uid "$path")" == "$(id -u)" ]] || {
+      printf 'refusing foreign-owned user directory: %s\n' "$path" >&2
+      return 1
+    }
+  fi
+}
+
+preflight_link_destination() {
+  local source="$1"
+  local destination="$2"
+  if [[ -L "$destination" ]]; then
+    [[ "$(readlink "$destination")" == "$source" ]] || {
+      printf 'refusing unexpected user symlink: %s\n' "$destination" >&2
+      return 1
+    }
+    return
+  fi
+  if [[ -e "$destination" ]]; then
+    [[ -f "$destination" ]] || {
+      printf 'refusing unexpected user link destination type: %s\n' "$destination" >&2
+      return 1
+    }
+    [[ "$(owned_path_uid "$destination")" == "$(id -u)" ]] || {
+      printf 'refusing foreign-owned user file: %s\n' "$destination" >&2
+      return 1
+    }
+  fi
+}
+
+refresh_user_directory_manifest() {
+  local state_base="${XDG_STATE_HOME:-$HOME/.local/state}"
+  local data_base="${XDG_DATA_HOME:-$HOME/.local/share}"
+  printf '%s\t%s\n' \
+    "$HOME/.local" 0755 \
+    "$HOME/.local/bin" 0755 \
+    "$HOME/.local/share" 0755 \
+    "$data_base" 0755 \
+    "$(dirname "$pnpm_home")" 0755 \
+    "$pnpm_home" 0755 \
+    "$HOME/.local/opt" 0755 \
+    "$HOME/.ssh" 0700 \
+    "$HOME/.codex" 0700 \
+    "$state_base" 0700 \
+    "$(dirname "$state_root")" 0700 \
+    "$state_root" 0700 \
+    "$state_root/backups" 0700 \
+    "$HOME/.oh-my-zsh" 0755 \
+    "$HOME/.oh-my-zsh/custom" 0755 \
+    "$HOME/.oh-my-zsh/custom/plugins" 0755 \
+    "$HOME/.oh-my-zsh/custom/plugins/zsh-autosuggestions" 0755 \
+    "$HOME/.oh-my-zsh/custom/themes" 0755 \
+    "$HOME/.oh-my-zsh/custom/themes/spaceship-prompt" 0755
+}
+
+refresh_user_link_manifest() {
+  local source destination
+  while read -r source destination; do
+    printf '%s\t%s\n' "$repo_root/$source" "$HOME/$destination"
+  done <<'EOF'
+.aliases .aliases
+.functions .functions
+.ripgreprc .ripgreprc
+.tmux.conf .tmux.conf
+profiles/linux-server/profile .profile
+profiles/linux-server/zprofile .zprofile
+profiles/linux-server/zshenv .zshenv
+profiles/linux-server/zshrc .zshrc
+profiles/linux-server/tmux.conf.local .tmux.conf.local
+profiles/linux-server/gitconfig .gitconfig
+profiles/linux-server/ssh-config .ssh/config
+bin/dotfiles-audit .local/bin/dotfiles-audit
+bin/dotfiles-platform .local/bin/dotfiles-platform
+bin/gh .local/bin/gh
+bin/ghx .local/bin/ghx
+bin/linux-server-bootstrap .local/bin/linux-server-bootstrap
+bin/tt .local/bin/tt
+bin/codex .local/bin/codex
+EOF
+
+  printf '%s\t%s\n' \
+    "$HOME/.oh-my-zsh/custom/themes/spaceship-prompt/spaceship.zsh-theme" \
+    "$HOME/.oh-my-zsh/custom/themes/spaceship.zsh-theme"
+
+  if ! command -v fd >/dev/null 2>&1 && command -v fdfind >/dev/null 2>&1; then
+    printf '%s\t%s\n' "$(command -v fdfind)" "$HOME/.local/bin/fd"
+  fi
+  if ! command -v bat >/dev/null 2>&1 && command -v batcat >/dev/null 2>&1; then
+    printf '%s\t%s\n' "$(command -v batcat)" "$HOME/.local/bin/bat"
+  fi
+}
+
+preflight_corepack_pnpm() {
+  local destination="$pnpm_home/pnpm"
+  local install_root="$HOME/.local/opt/node-v$node_version"
+  local resolved
+  if [[ -L "$destination" ]]; then
+    resolved="$(readlink -f "$destination")" || return 1
+    case "$resolved" in
+      "$install_root"/*) return ;;
+      *)
+        printf 'refusing unexpected pnpm symlink: %s\n' "$destination" >&2
+        return 1
+        ;;
+    esac
+  fi
+  if [[ -e "$destination" ]]; then
+    [[ -f "$destination" && "$(owned_path_uid "$destination")" == "$(id -u)" ]] || {
+      printf 'refusing unexpected pnpm launcher: %s\n' "$destination" >&2
+      return 1
+    }
+  fi
+}
+
+preflight_refresh_user() {
+  local path mode source destination install_root
+  preflight_owned_directory "$HOME" || return 1
+  preflight_owned_directory "$repo_root" || return 1
+  case "$state_root" in
+    "$HOME"/*) ;;
+    *)
+      printf 'refusing state path outside HOME\n' >&2
+      return 1
+      ;;
+  esac
+  case "$pnpm_home" in
+    "$HOME"/*) ;;
+    *)
+      printf 'refusing PNPM_HOME outside HOME\n' >&2
+      return 1
+      ;;
+  esac
+  [[ "$state_root" != *"/../"* && "$pnpm_home" != *"/../"* ]] || {
+    printf 'refusing non-canonical user path\n' >&2
+    return 1
+  }
+  while IFS=$'\t' read -r path mode; do
+    [[ -n "$path" && -n "$mode" ]] || return 1
+    preflight_owned_directory "$path" || return 1
+  done < <(refresh_user_directory_manifest)
+
+  install_root="$HOME/.local/opt/node-v$node_version"
+  preflight_owned_directory "$install_root" || return 1
+  while IFS=$'\t' read -r source destination; do
+    [[ -n "$source" && -n "$destination" ]] || return 1
+    preflight_link_destination "$source" "$destination" || return 1
+  done < <(refresh_user_link_manifest)
+  for source in node npm npx corepack; do
+    preflight_link_destination \
+      "$install_root/bin/$source" \
+      "$HOME/.local/bin/$source" || return 1
+  done
+  preflight_corepack_pnpm || return 1
+}
+
+ensure_owned_directory() {
+  local path="$1"
+  local mode="$2"
+  if [[ ! -e "$path" ]]; then
+    run mkdir "$path"
+  fi
+  run chmod "$mode" "$path"
+}
+
+normalize_refresh_user_directories() {
+  local path mode
+  while IFS=$'\t' read -r path mode; do
+    ensure_owned_directory "$path" "$mode" || return 1
+  done < <(refresh_user_directory_manifest)
+}
+
+path_prepend_once() {
+  local target="$1"
+  local remaining="${PATH:-}"
+  local result="" entry done=""
+  while :; do
+    case "$remaining" in
+      *:*)
+        entry="${remaining%%:*}"
+        remaining="${remaining#*:}"
+        ;;
+      *)
+        entry="$remaining"
+        done=1
+        ;;
+    esac
+    if [[ -n "$entry" && "$entry" != "$target" ]]; then
+      result="${result:+$result:}$entry"
+    fi
+    [[ -z "$done" ]] || break
+  done
+  PATH="$target${result:+:$result}"
+}
+
 node_archive_metadata() {
   case "$(uname -m)" in
     x86_64 | amd64)
@@ -760,7 +974,9 @@ install_openclaw_toolchain() {
       printf '%s  %s\n' "$checksum" "$temporary/$archive" | sha256sum --check -
     fi
     run mkdir -p "$(dirname "$install_root")" "$staging"
+    run chmod 0755 "$staging"
     run tar -xJf "$temporary/$archive" --strip-components=1 -C "$staging"
+    run chmod 0755 "$staging"
     if [[ -e "$install_root" ]]; then
       run mkdir -p "$state_root/backups"
       run mv "$install_root" "$state_root/backups/node-v$node_version.$(date +%Y%m%d%H%M%S).bak"
@@ -775,46 +991,68 @@ install_openclaw_toolchain() {
   for executable in node npm npx corepack; do
     backup_and_link "$install_root/bin/$executable" "$local_bin/$executable"
   done
-  case ":$PATH:" in
-    *":$local_bin:"*) ;;
-    *) PATH="$local_bin${PATH:+:$PATH}" ;;
-  esac
+  path_prepend_once "$local_bin"
+  path_prepend_once "$pnpm_home"
   export PATH
-  run "$install_root/bin/corepack" enable --install-directory "$local_bin"
+  run chmod 0755 "$install_root"
+  run "$install_root/bin/corepack" enable --install-directory "$pnpm_home"
   run "$local_bin/corepack" install --global "$pnpm_spec"
 
   if [[ "$dry_run" != 1 ]]; then
     [[ "$("$local_bin/node" --version)" == "v$node_version" ]]
-    [[ "$("$local_bin/pnpm" --version)" == "$pnpm_version" ]]
+    [[ "$("$pnpm_home/pnpm" --version)" == "$pnpm_version" ]]
   fi
 }
 
 link_server_dotfiles() {
   local source destination
-  while read -r source destination; do
-    backup_and_link "$repo_root/$source" "$HOME/$destination"
-  done <<'EOF'
-.aliases .aliases
-.functions .functions
-.ripgreprc .ripgreprc
-.tmux.conf .tmux.conf
-profiles/linux-server/profile .profile
-profiles/linux-server/zprofile .zprofile
-profiles/linux-server/zshenv .zshenv
-profiles/linux-server/zshrc .zshrc
-profiles/linux-server/tmux.conf.local .tmux.conf.local
-profiles/linux-server/gitconfig .gitconfig
-profiles/linux-server/ssh-config .ssh/config
-EOF
-
-  run mkdir -p "$HOME/.local/bin"
-  for source in dotfiles-audit dotfiles-platform gh ghx linux-server-bootstrap tt; do
-    backup_and_link "$repo_root/bin/$source" "$HOME/.local/bin/$source"
-  done
+  while IFS=$'\t' read -r source destination; do
+    backup_and_link "$source" "$destination" || return 1
+  done < <(refresh_user_link_manifest)
 }
 
 ensure_sudo_access() {
   sudo -n true || sudo -v
+}
+
+refresh_user_content() {
+  export PNPM_HOME="$pnpm_home"
+  if ! preflight_refresh_user; then
+    return 1
+  fi
+  normalize_refresh_user_directories
+
+  install_pinned_checkout \
+    https://github.com/ohmyzsh/ohmyzsh.git \
+    "$HOME/.oh-my-zsh" \
+    "$oh_my_zsh_sha"
+  install_pinned_checkout \
+    https://github.com/zsh-users/zsh-autosuggestions.git \
+    "$HOME/.oh-my-zsh/custom/plugins/zsh-autosuggestions" \
+    "$autosuggestions_sha"
+  install_pinned_checkout \
+    https://github.com/spaceship-prompt/spaceship-prompt.git \
+    "$HOME/.oh-my-zsh/custom/themes/spaceship-prompt" \
+    "$spaceship_sha"
+  link_server_dotfiles
+  install_openclaw_toolchain
+}
+
+refresh_user() {
+  local refresh_status
+  if [[ "$dry_run" == 1 ]]; then
+    plan
+    return
+  fi
+  require_non_root
+  [[ "$(uname -s)" == Linux ]] || {
+    printf 'refresh-user requires Linux\n' >&2
+    exit 2
+  }
+  refresh_user_content
+  refresh_status=$?
+  ((refresh_status == 0)) || return "$refresh_status"
+  log "user-owned shell and CLI state refreshed"
 }
 
 prepare() {
@@ -839,29 +1077,7 @@ prepare() {
     build-essential pkg-config python3 python3-venv ufw unattended-upgrades \
     zsh-completions zsh-syntax-highlighting trash-cli
 
-  run mkdir -p "$HOME/.local/bin" "$state_root"
-  if ! command -v fd >/dev/null 2>&1 && command -v fdfind >/dev/null 2>&1; then
-    run ln -sfn "$(command -v fdfind)" "$HOME/.local/bin/fd"
-  fi
-  if ! command -v bat >/dev/null 2>&1 && command -v batcat >/dev/null 2>&1; then
-    run ln -sfn "$(command -v batcat)" "$HOME/.local/bin/bat"
-  fi
-
-  install_pinned_checkout https://github.com/ohmyzsh/ohmyzsh.git "$HOME/.oh-my-zsh" "$oh_my_zsh_sha"
-  install_pinned_checkout \
-    https://github.com/zsh-users/zsh-autosuggestions.git \
-    "$HOME/.oh-my-zsh/custom/plugins/zsh-autosuggestions" \
-    "$autosuggestions_sha"
-  install_pinned_checkout \
-    https://github.com/spaceship-prompt/spaceship-prompt.git \
-    "$HOME/.oh-my-zsh/custom/themes/spaceship-prompt" \
-    "$spaceship_sha"
-  run ln -sfn \
-    "$HOME/.oh-my-zsh/custom/themes/spaceship-prompt/spaceship.zsh-theme" \
-    "$HOME/.oh-my-zsh/custom/themes/spaceship.zsh-theme"
-
-  link_server_dotfiles
-  install_openclaw_toolchain
+  refresh_user_content
 
   if ! locale -a | tr '[:upper:]' '[:lower:]' | grep -qx 'en_us.utf8'; then
     run_root sed -i 's/^[#[:space:]]*en_US.UTF-8[[:space:]]\+UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen
@@ -1412,6 +1628,7 @@ if [[ "${DOTFILES_SERVER_SOURCE_ONLY:-0}" != 1 ]]; then
     plan) plan ;;
     audit) audit ;;
     prepare) prepare ;;
+    refresh-user) refresh_user ;;
     enable-auth-proof) enable_auth_proof ;;
     prove-second-session) prove_second_session ;;
     cleanup-auth-proof) cleanup_auth_proof ;;

--- a/bin/linux-server-bootstrap
+++ b/bin/linux-server-bootstrap
@@ -738,6 +738,10 @@ owned_path_uid() {
   stat -c %u "$1" 2>/dev/null || stat -f %u "$1"
 }
 
+owned_path_mode() {
+  stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1"
+}
+
 canonical_absolute_path() {
   local path="$1"
   local component
@@ -760,6 +764,32 @@ canonical_absolute_path() {
     local IFS=/
     printf '/%s\n' "${output[*]}"
   fi
+}
+
+relative_path_between() {
+  local from to component result="" index=0
+  local -a from_parts=() to_parts=()
+  from="$(canonical_absolute_path "$1")" || return 1
+  to="$(canonical_absolute_path "$2")" || return 1
+  IFS='/' read -r -a from_parts <<<"${from#/}"
+  IFS='/' read -r -a to_parts <<<"${to#/}"
+  while ((index < ${#from_parts[@]} && index < ${#to_parts[@]})) &&
+    [[ "${from_parts[index]}" == "${to_parts[index]}" ]]; do
+    index=$((index + 1))
+  done
+  for ((; index < ${#from_parts[@]}; index++)); do
+    result="${result:+$result/}.."
+  done
+  index=0
+  while ((index < ${#from_parts[@]} && index < ${#to_parts[@]})) &&
+    [[ "${from_parts[index]}" == "${to_parts[index]}" ]]; do
+    index=$((index + 1))
+  done
+  for ((; index < ${#to_parts[@]}; index++)); do
+    component="${to_parts[index]}"
+    result="${result:+$result/}$component"
+  done
+  printf '%s\n' "${result:-.}"
 }
 
 require_strict_home_descendant() {
@@ -822,6 +852,13 @@ preflight_owned_directory() {
         printf 'refusing foreign-owned user directory: %s\n' "$current" >&2
         return 1
       }
+      # Owned 0775 paths are normalized after the complete preflight; world-write is never safe.
+      local current_mode
+      current_mode="$(owned_path_mode "$current")" || return 1
+      (( (8#$current_mode & 8#0002) == 0 )) || {
+        printf 'refusing world-writable user directory: %s\n' "$current" >&2
+        return 1
+      }
     fi
   done
 }
@@ -854,21 +891,17 @@ preflight_link_destination() {
   fi
 }
 
-refresh_user_directory_manifest() {
+refresh_user_directory_targets() {
   local state_base="${XDG_STATE_HOME:-$HOME/.local/state}"
   local data_base="${XDG_DATA_HOME:-$HOME/.local/share}"
   printf '%s\t%s\n' \
     "$HOME/.local" 0755 \
     "$HOME/.local/bin" 0755 \
     "$HOME/.local/share" 0755 \
-    "$data_base" 0755 \
-    "$(dirname "$pnpm_home")" 0755 \
-    "$pnpm_home" 0755 \
     "$HOME/.local/opt" 0755 \
     "$HOME/.ssh" 0700 \
     "$HOME/.codex" 0700 \
     "$state_base" 0700 \
-    "$(dirname "$state_root")" 0700 \
     "$state_root" 0700 \
     "$state_root/backups" 0700 \
     "$HOME/.oh-my-zsh" 0755 \
@@ -876,7 +909,65 @@ refresh_user_directory_manifest() {
     "$HOME/.oh-my-zsh/custom/plugins" 0755 \
     "$HOME/.oh-my-zsh/custom/plugins/zsh-autosuggestions" 0755 \
     "$HOME/.oh-my-zsh/custom/themes" 0755 \
-    "$HOME/.oh-my-zsh/custom/themes/spaceship-prompt" 0755
+    "$HOME/.oh-my-zsh/custom/themes/spaceship-prompt" 0755 \
+    "$data_base" 0755 \
+    "$pnpm_home" 0755
+}
+
+refresh_user_directory_manifest() {
+  local path mode relative component current component_mode
+  local index lookup found
+  local -a paths=() modes=() components=() emitted=()
+  while IFS=$'\t' read -r path mode; do
+    [[ -n "$path" && -n "$mode" ]] || return 1
+    require_strict_home_descendant "$path" || return 1
+    found=0
+    for ((lookup = 0; lookup < ${#paths[@]}; lookup++)); do
+      if [[ "${paths[lookup]}" == "$path" ]]; then
+        [[ "${modes[lookup]}" == "$mode" ]] || {
+          printf 'refusing conflicting user directory mode: %s\n' "$path" >&2
+          return 1
+        }
+        found=1
+        break
+      fi
+    done
+    if ((found == 0)); then
+      paths+=("$path")
+      modes+=("$mode")
+    fi
+  done < <(refresh_user_directory_targets)
+
+  for ((index = 0; index < ${#paths[@]}; index++)); do
+    path="${paths[index]}"
+    mode="${modes[index]}"
+    relative="${path#"$HOME"/}"
+    current="$HOME"
+    IFS='/' read -r -a components <<<"$relative"
+    for component in "${components[@]}"; do
+      current="$current/$component"
+      component_mode="$mode"
+      for ((lookup = 0; lookup < ${#paths[@]}; lookup++)); do
+        if [[ "${paths[lookup]}" == "$current" ]]; then
+          component_mode="${modes[lookup]}"
+          break
+        fi
+      done
+      found=0
+      if ((${#emitted[@]} > 0)); then
+        for path in "${emitted[@]}"; do
+          if [[ "$path" == "$current" ]]; then
+            found=1
+            break
+          fi
+        done
+      fi
+      if ((found == 0)); then
+        printf '%s\t%s\n' "$current" "$component_mode"
+        emitted+=("$current")
+      fi
+    done
+  done
 }
 
 refresh_user_link_manifest() {
@@ -918,13 +1009,18 @@ EOF
 
 preflight_corepack_pnpm() {
   local install_root="$HOME/.local/opt/node-v$node_version"
-  local shim destination expected resolved resolved_expected
+  local shim destination expected expected_link resolved resolved_expected
   for shim in pnpm pnpx; do
     destination="$pnpm_home/$shim"
     expected="$install_root/lib/node_modules/corepack/dist/$shim.js"
     if [[ -L "$destination" ]]; then
       [[ "$(owned_path_uid "$destination")" == "$(id -u)" ]] || {
         printf 'refusing foreign-owned Corepack shim: %s\n' "$destination" >&2
+        return 1
+      }
+      expected_link="$(relative_path_between "$pnpm_home" "$expected")" || return 1
+      [[ "$(readlink "$destination")" == "$expected_link" ]] || {
+        printf 'refusing unexpected Corepack symlink: %s\n' "$destination" >&2
         return 1
       }
       resolved="$(readlink -f "$destination")" || {
@@ -953,6 +1049,7 @@ preflight_corepack_pnpm() {
 }
 
 preflight_refresh_user() {
+  local directory_manifest="$1"
   local path mode source destination install_root
   preflight_home_directory || return 1
   [[ ! -L "$repo_root" && -d "$repo_root" ]] || {
@@ -966,7 +1063,7 @@ preflight_refresh_user() {
   while IFS=$'\t' read -r path mode; do
     [[ -n "$path" && -n "$mode" ]] || return 1
     preflight_owned_directory "$path" || return 1
-  done < <(refresh_user_directory_manifest)
+  done <<<"$directory_manifest"
 
   install_root="$HOME/.local/opt/node-v$node_version"
   preflight_owned_directory "$install_root" || return 1
@@ -986,16 +1083,17 @@ ensure_owned_directory() {
   local path="$1"
   local mode="$2"
   if [[ ! -e "$path" ]]; then
-    run mkdir -p "$path"
+    run mkdir -m "$mode" "$path"
   fi
   run chmod "$mode" "$path"
 }
 
 normalize_refresh_user_directories() {
+  local directory_manifest="$1"
   local path mode
   while IFS=$'\t' read -r path mode; do
     ensure_owned_directory "$path" "$mode" || return 1
-  done < <(refresh_user_directory_manifest)
+  done <<<"$directory_manifest"
 }
 
 path_prepend_once() {
@@ -1095,11 +1193,13 @@ ensure_sudo_access() {
 }
 
 refresh_user_content() {
+  local directory_manifest
   export PNPM_HOME="$pnpm_home"
-  if ! preflight_refresh_user; then
+  directory_manifest="$(refresh_user_directory_manifest)" || return 1
+  if ! preflight_refresh_user "$directory_manifest"; then
     return 1
   fi
-  normalize_refresh_user_directories
+  normalize_refresh_user_directories "$directory_manifest"
 
   install_pinned_checkout \
     https://github.com/ohmyzsh/ohmyzsh.git \

--- a/bin/linux-server-bootstrap
+++ b/bin/linux-server-bootstrap
@@ -738,27 +738,103 @@ owned_path_uid() {
   stat -c %u "$1" 2>/dev/null || stat -f %u "$1"
 }
 
+canonical_absolute_path() {
+  local path="$1"
+  local component
+  local -a input=() output=()
+  [[ "$path" == /* && "$path" != *$'\n'* && "$path" != *$'\t'* ]] || return 1
+  IFS='/' read -r -a input <<<"${path#/}"
+  for component in "${input[@]}"; do
+    case "$component" in
+      '' | .) ;;
+      ..)
+        ((${#output[@]} > 0)) || return 1
+        unset "output[${#output[@]}-1]"
+        ;;
+      *) output+=("$component") ;;
+    esac
+  done
+  if ((${#output[@]} == 0)); then
+    printf '/\n'
+  else
+    local IFS=/
+    printf '/%s\n' "${output[*]}"
+  fi
+}
+
+require_strict_home_descendant() {
+  local path="$1"
+  local canonical_home canonical_path
+  canonical_home="$(canonical_absolute_path "$HOME")" || {
+    printf 'refusing non-canonical HOME\n' >&2
+    return 1
+  }
+  [[ "$canonical_home" == "$HOME" ]] || {
+    printf 'refusing non-canonical HOME\n' >&2
+    return 1
+  }
+  canonical_path="$(canonical_absolute_path "$path")" || {
+    printf 'refusing non-canonical user path: %s\n' "$path" >&2
+    return 1
+  }
+  [[ "$canonical_path" == "$path" ]] || {
+    printf 'refusing non-canonical user path: %s\n' "$path" >&2
+    return 1
+  }
+  [[ "$path" == "$HOME/"* ]] || {
+    printf 'refusing user path outside HOME: %s\n' "$path" >&2
+    return 1
+  }
+}
+
+preflight_home_directory() {
+  local canonical_home
+  canonical_home="$(canonical_absolute_path "$HOME")" || return 1
+  [[ "$canonical_home" == "$HOME" && ! -L "$HOME" && -d "$HOME" ]] || {
+    printf 'refusing unsafe HOME directory\n' >&2
+    return 1
+  }
+  [[ "$(owned_path_uid "$HOME")" == "$(id -u)" ]] || {
+    printf 'refusing foreign-owned HOME directory\n' >&2
+    return 1
+  }
+}
+
 preflight_owned_directory() {
   local path="$1"
-  if [[ -L "$path" ]]; then
-    printf 'refusing symlinked user directory: %s\n' "$path" >&2
-    return 1
-  fi
-  if [[ -e "$path" ]]; then
-    [[ -d "$path" ]] || {
-      printf 'refusing non-directory user path: %s\n' "$path" >&2
+  local relative component current="$HOME"
+  local -a components=()
+  require_strict_home_descendant "$path" || return 1
+  relative="${path#"$HOME"/}"
+  IFS='/' read -r -a components <<<"$relative"
+  for component in "${components[@]}"; do
+    current="$current/$component"
+    if [[ -L "$current" ]]; then
+      printf 'refusing symlinked user directory: %s\n' "$current" >&2
       return 1
-    }
-    [[ "$(owned_path_uid "$path")" == "$(id -u)" ]] || {
-      printf 'refusing foreign-owned user directory: %s\n' "$path" >&2
-      return 1
-    }
-  fi
+    fi
+    if [[ -e "$current" ]]; then
+      [[ -d "$current" ]] || {
+        printf 'refusing non-directory user path: %s\n' "$current" >&2
+        return 1
+      }
+      [[ "$(owned_path_uid "$current")" == "$(id -u)" ]] || {
+        printf 'refusing foreign-owned user directory: %s\n' "$current" >&2
+        return 1
+      }
+    fi
+  done
 }
 
 preflight_link_destination() {
   local source="$1"
   local destination="$2"
+  local parent
+  require_strict_home_descendant "$destination" || return 1
+  parent="$(dirname "$destination")"
+  if [[ "$parent" != "$HOME" ]]; then
+    preflight_owned_directory "$parent" || return 1
+  fi
   if [[ -L "$destination" ]]; then
     [[ "$(readlink "$destination")" == "$source" ]] || {
       printf 'refusing unexpected user symlink: %s\n' "$destination" >&2
@@ -841,47 +917,50 @@ EOF
 }
 
 preflight_corepack_pnpm() {
-  local destination="$pnpm_home/pnpm"
   local install_root="$HOME/.local/opt/node-v$node_version"
-  local resolved
-  if [[ -L "$destination" ]]; then
-    resolved="$(readlink -f "$destination")" || return 1
-    case "$resolved" in
-      "$install_root"/*) return ;;
-      *)
-        printf 'refusing unexpected pnpm symlink: %s\n' "$destination" >&2
+  local shim destination expected resolved resolved_expected
+  for shim in pnpm pnpx; do
+    destination="$pnpm_home/$shim"
+    expected="$install_root/lib/node_modules/corepack/dist/$shim.js"
+    if [[ -L "$destination" ]]; then
+      [[ "$(owned_path_uid "$destination")" == "$(id -u)" ]] || {
+        printf 'refusing foreign-owned Corepack shim: %s\n' "$destination" >&2
         return 1
-        ;;
-    esac
-  fi
-  if [[ -e "$destination" ]]; then
-    [[ -f "$destination" && "$(owned_path_uid "$destination")" == "$(id -u)" ]] || {
-      printf 'refusing unexpected pnpm launcher: %s\n' "$destination" >&2
+      }
+      resolved="$(readlink -f "$destination")" || {
+        printf 'refusing unexpected Corepack symlink: %s\n' "$destination" >&2
+        return 1
+      }
+      resolved_expected="$(readlink -f "$expected")" || {
+        printf 'refusing unexpected Corepack target: %s\n' "$destination" >&2
+        return 1
+      }
+      [[ "$resolved" == "$resolved_expected" && -f "$expected" && ! -L "$expected" ]] || {
+        printf 'refusing unexpected Corepack symlink: %s\n' "$destination" >&2
+        return 1
+      }
+      continue
+    fi
+    if [[ -e "$destination" ]]; then
+      [[ "$(owned_path_uid "$destination")" == "$(id -u)" ]] || {
+        printf 'refusing foreign-owned Corepack output: %s\n' "$destination" >&2
+        return 1
+      }
+      printf 'refusing unexpected Corepack output: %s\n' "$destination" >&2
       return 1
-    }
-  fi
+    fi
+  done
 }
 
 preflight_refresh_user() {
   local path mode source destination install_root
-  preflight_owned_directory "$HOME" || return 1
-  preflight_owned_directory "$repo_root" || return 1
-  case "$state_root" in
-    "$HOME"/*) ;;
-    *)
-      printf 'refusing state path outside HOME\n' >&2
-      return 1
-      ;;
-  esac
-  case "$pnpm_home" in
-    "$HOME"/*) ;;
-    *)
-      printf 'refusing PNPM_HOME outside HOME\n' >&2
-      return 1
-      ;;
-  esac
-  [[ "$state_root" != *"/../"* && "$pnpm_home" != *"/../"* ]] || {
-    printf 'refusing non-canonical user path\n' >&2
+  preflight_home_directory || return 1
+  [[ ! -L "$repo_root" && -d "$repo_root" ]] || {
+    printf 'refusing unsafe dotfiles source directory\n' >&2
+    return 1
+  }
+  [[ "$(owned_path_uid "$repo_root")" == "$(id -u)" ]] || {
+    printf 'refusing foreign-owned dotfiles source directory\n' >&2
     return 1
   }
   while IFS=$'\t' read -r path mode; do
@@ -907,7 +986,7 @@ ensure_owned_directory() {
   local path="$1"
   local mode="$2"
   if [[ ! -e "$path" ]]; then
-    run mkdir "$path"
+    run mkdir -p "$path"
   fi
   run chmod "$mode" "$path"
 }
@@ -995,7 +1074,7 @@ install_openclaw_toolchain() {
   path_prepend_once "$pnpm_home"
   export PATH
   run chmod 0755 "$install_root"
-  run "$install_root/bin/corepack" enable --install-directory "$pnpm_home"
+  run "$install_root/bin/corepack" enable pnpm --install-directory "$pnpm_home"
   run "$local_bin/corepack" install --global "$pnpm_spec"
 
   if [[ "$dry_run" != 1 ]]; then

--- a/profiles/linux-server/profile
+++ b/profiles/linux-server/profile
@@ -20,10 +20,27 @@ export DISABLE_TELEMETRY=1
 export DO_NOT_TRACK=1
 
 path_prepend() {
-  case ":$PATH:" in
-    *":$1:"*) ;;
-    *) PATH="$1${PATH:+:$PATH}" ;;
-  esac
+  local target="$1"
+  local remaining="${PATH:-}"
+  local result=""
+  local entry done=""
+  while :; do
+    case "$remaining" in
+      *:*)
+        entry="${remaining%%:*}"
+        remaining="${remaining#*:}"
+        ;;
+      *)
+        entry="$remaining"
+        done=1
+        ;;
+    esac
+    if [[ -n "$entry" && "$entry" != "$target" ]]; then
+      result="${result:+$result:}$entry"
+    fi
+    [[ -z "$done" ]] || break
+  done
+  PATH="$target${result:+:$result}"
 }
 
 path_prepend "$PNPM_HOME"

--- a/profiles/linux-server/zshrc
+++ b/profiles/linux-server/zshrc
@@ -36,11 +36,16 @@ SPACESHIP_PACKAGE_SHOW=false
 SPACESHIP_NODE_SHOW=false
 SPACESHIP_DIR_TRUNC=3
 SPACESHIP_CHAR_SYMBOL=">"
+SPACESHIP_CHAR_SUFFIX=" "
 [[ -r "$ZSH/custom/themes/spaceship.zsh-theme" ]] &&
   source "$ZSH/custom/themes/spaceship.zsh-theme"
 
 [[ -r "$HOME/.aliases" ]] && source "$HOME/.aliases"
 [[ -r "$HOME/.functions" ]] && source "$HOME/.functions"
+
+cx() {
+  codex --no-alt-screen "$@"
+}
 
 if [[ -r /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ]]; then
   source /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh

--- a/tests/codex-wrapper-test.sh
+++ b/tests/codex-wrapper-test.sh
@@ -61,6 +61,24 @@ output="$(env -u GITHUB_PAT_TOKEN PATH="$long_path" "$symlink_dir/codex" --versi
 [[ "$output" == *"version:--version"* ]]
 [[ "$output" == *"token:injected"* ]]
 
+linux_home="$temporary/linux-home"
+mkdir -p "$linux_home/.codex/packages/standalone/current/bin"
+cat >"$linux_home/.codex/packages/standalone/current/bin/codex" <<'EOF'
+#!/usr/bin/env bash
+printf 'standalone:%s\n' "$*"
+[[ "${GITHUB_PAT_TOKEN:-}" == "native-token" ]]
+EOF
+chmod +x "$linux_home/.codex/packages/standalone/current/bin/codex"
+cat >"$backend_dir/uname" <<'EOF'
+#!/usr/bin/env bash
+printf 'Linux\n'
+EOF
+linux_output="$(
+  env -u GITHUB_PAT_TOKEN HOME="$linux_home" PATH="$long_path" \
+    "$symlink_dir/codex" run "two words"
+)"
+[[ "$linux_output" == "standalone:run two words" ]]
+
 if grep -Fq 'gh auth token' "$repo_root/.zshrc"; then
   printf '.zshrc must not fetch GitHub credentials during startup\n' >&2
   exit 1

--- a/tests/linux-server-bootstrap-test.sh
+++ b/tests/linux-server-bootstrap-test.sh
@@ -162,14 +162,25 @@ NODE
 cat >"$install_root/bin/corepack" <<'COREPACK'
 #!/usr/bin/env node
 printf 'corepack|%s|%s\n' "$PATH" "$*" >>"$TOOLCHAIN_TEST_LOG"
-if [[ "${1:-}" == enable && "${2:-}" == --install-directory ]]; then
-  cat >"$3/pnpm" <<'PROXY'
+if [[ "${1:-}" == enable && "${2:-}" == pnpm && "${3:-}" == --install-directory ]]; then
+  for shim in pnpm pnpx; do
+    if [[ ! -L "$4/$shim" ]]; then
+      ln -s "$TOOLCHAIN_COREPACK_DIST_RELATIVE/$shim.js" "$4/$shim"
+    fi
+  done
+fi
+if [[ "${1:-}" == install && "${2:-}" == --global ]]; then
+  exit 0
+fi
+COREPACK
+mkdir -p "$install_root/lib/node_modules/corepack/dist"
+for shim in pnpm pnpx; do
+  cat >"$install_root/lib/node_modules/corepack/dist/$shim.js" <<'PROXY'
 #!/usr/bin/env bash
 printf '11.15.1\n'
 PROXY
-  chmod +x "$3/pnpm"
-fi
-COREPACK
+  chmod +x "$install_root/lib/node_modules/corepack/dist/$shim.js"
+done
 for executable in npm npx; do
   cat >"$install_root/bin/$executable" <<'TOOL'
 #!/usr/bin/env bash
@@ -177,6 +188,9 @@ exit 0
 TOOL
 done
 chmod +x "$install_root/bin/"*
+export TOOLCHAIN_COREPACK_DIST_RELATIVE="../../opt/node-v$node_version/lib/node_modules/corepack/dist"
+mkdir -p "$PNPM_HOME"
+printf 'keep-yarn\n' >"$PNPM_HOME/yarn"
 
   # shellcheck disable=SC2329
   validate_parameters() { :; }
@@ -204,6 +218,14 @@ awk -F'|' -v prefix="$HOME/.local/share/pnpm:$HOME/.local/bin:" '
 ' "$TOOLCHAIN_TEST_LOG"
 [[ "$("$HOME/.local/bin/node" --version)" == "v$node_version" ]]
 [[ "$("$HOME/.local/share/pnpm/pnpm" --version)" == "$pnpm_version" ]]
+[[ "$("$HOME/.local/share/pnpm/pnpx" --version)" == "$pnpm_version" ]]
+[[ "$(<"$PNPM_HOME/yarn")" == keep-yarn ]]
+[[ ! -e "$PNPM_HOME/yarnpkg" && ! -L "$PNPM_HOME/yarnpkg" ]]
+grep -Fq "enable pnpm --install-directory $PNPM_HOME" "$TOOLCHAIN_TEST_LOG"
+if grep -Eq 'enable .*yarn|enable --install-directory' "$TOOLCHAIN_TEST_LOG"; then
+  printf 'Corepack enabled an unscoped package manager surface\n' >&2
+  exit 1
+fi
 
 prepare >/dev/null
 [[ "$PATH" == "$first_prepare_path" ]]
@@ -213,6 +235,8 @@ prepare >/dev/null
 awk -F'|' -v prefix="$HOME/.local/share/pnpm:$HOME/.local/bin:" '
   $1 == "corepack" && index($2, prefix) != 1 { exit 1 }
 ' "$TOOLCHAIN_TEST_LOG"
+[[ "$(<"$PNPM_HOME/yarn")" == keep-yarn ]]
+[[ ! -e "$PNPM_HOME/yarnpkg" && ! -L "$PNPM_HOME/yarnpkg" ]]
 EOF
 chmod +x "$toolchain_test"
 : >"$temporary/toolchain.log"

--- a/tests/linux-server-bootstrap-test.sh
+++ b/tests/linux-server-bootstrap-test.sh
@@ -38,6 +38,9 @@ grep -Fxq 'prepare.node_source=nodejs.org-checksum-pinned-user-install' "$plan_o
 grep -Fxq 'prepare.pnpm=pnpm@11.15.1' "$plan_one"
 grep -Fxq 'prepare.remote_shell=ssh' "$plan_one"
 grep -Fxq 'prepare.excludes=credentials-signing-gui-apps-global-openclaw-mosh' "$plan_one"
+grep -Fxq 'refresh_user.privilege=user-only' "$plan_one"
+grep -Fxq 'refresh_user.codex=public-wrapper-standalone-backend' "$plan_one"
+grep -Fxq 'refresh_user.pnpm_home=direct-path-no-bin-suffix' "$plan_one"
 grep -Fxq 'enable_auth_proof.requires=admin-user,designated-key-sha256,unchanged-authorized_keys' "$plan_one"
 grep -Fxq 'enable_auth_proof.expires_seconds=900' "$plan_one"
 grep -Fxq 'proof.requires=fresh-nonmultiplexed-transport,designated-public-key,tailscale-whois' "$plan_one"
@@ -77,6 +80,7 @@ set -e
 grep -Fq "SCRIPT_DIR=$root/bin" "$temporary/tt-symlink.out"
 grep -Fq "DOTFILES_DIR=$root" "$temporary/tt-symlink.out"
 
+export SSH_CONNECTION=''
 # shellcheck disable=SC1090
 DOTFILES_SERVER_SOURCE_ONLY=1 source "$script"
 
@@ -125,6 +129,8 @@ prepare_commands="$temporary/prepare-commands"
   link_server_dotfiles() { :; }
   # shellcheck disable=SC2329
   install_openclaw_toolchain() { :; }
+  # shellcheck disable=SC2329
+  refresh_user_content() { :; }
   prepare
 ) >/dev/null
 if grep -Eq 'openssh-server|sshd|auth.proof|/etc/ssh|systemctl.*(ssh|sshd)' \
@@ -193,24 +199,27 @@ chmod +x "$install_root/bin/"*
 prepare >/dev/null
 first_prepare_path="$PATH"
 [[ "$(grep -c '^corepack|' "$TOOLCHAIN_TEST_LOG")" == 2 ]]
-awk -F'|' -v prefix="$HOME/.local/bin:" '
+awk -F'|' -v prefix="$HOME/.local/share/pnpm:$HOME/.local/bin:" '
   $1 == "corepack" && index($2, prefix) != 1 { exit 1 }
 ' "$TOOLCHAIN_TEST_LOG"
 [[ "$("$HOME/.local/bin/node" --version)" == "v$node_version" ]]
-[[ "$("$HOME/.local/bin/pnpm" --version)" == "$pnpm_version" ]]
+[[ "$("$HOME/.local/share/pnpm/pnpm" --version)" == "$pnpm_version" ]]
 
 prepare >/dev/null
 [[ "$PATH" == "$first_prepare_path" ]]
 [[ "$(tr ':' '\n' <<<"$PATH" | grep -Fxc "$HOME/.local/bin")" == 1 ]]
+[[ "$(tr ':' '\n' <<<"$PATH" | grep -Fxc "$HOME/.local/share/pnpm")" == 1 ]]
 [[ "$(grep -c '^corepack|' "$TOOLCHAIN_TEST_LOG")" == 4 ]]
-awk -F'|' -v prefix="$HOME/.local/bin:" '
+awk -F'|' -v prefix="$HOME/.local/share/pnpm:$HOME/.local/bin:" '
   $1 == "corepack" && index($2, prefix) != 1 { exit 1 }
 ' "$TOOLCHAIN_TEST_LOG"
 EOF
 chmod +x "$toolchain_test"
 : >"$temporary/toolchain.log"
 HOME="$temporary/toolchain-home" \
+  XDG_DATA_HOME="$temporary/toolchain-home/.local/share" \
   XDG_STATE_HOME="$temporary/toolchain-home/.local/state" \
+  PNPM_HOME="$temporary/toolchain-home/.local/share/pnpm" \
   PATH=/usr/bin:/bin \
   BOOTSTRAP_SCRIPT="$script" \
   TOOLCHAIN_TEST_LOG="$temporary/toolchain.log" \
@@ -426,6 +435,7 @@ grep -Fq 'AuthenticationMethods publickey' "$script"
 grep -Fq 'ExposeAuthInfo yes' "$script"
 grep -Fq 'ExposeAuthInfo no' "$script"
 grep -Fq 'cleanup-auth-proof) cleanup_auth_proof' "$script"
+grep -Fq 'refresh-user) refresh_user' "$script"
 # shellcheck disable=SC2016
 grep -Fq 'ufw allow in on "$tailscale_interface"' "$script"
 grep -Fq 'lockdown must run from a different SSH session' "$script"

--- a/tests/linux-server-refresh-user-test.sh
+++ b/tests/linux-server-refresh-user-test.sh
@@ -292,6 +292,11 @@ create_corepack_targets() {
   done
 }
 
+directory_metadata() {
+  stat -c '%f:%s:%Y:%Z' "$1" 2>/dev/null ||
+    stat -f '%p:%z:%m:%c' "$1"
+}
+
 case "$DRIFT_CASE" in
   symlink)
     mkdir "$HOME/redirect"
@@ -325,6 +330,12 @@ case "$DRIFT_CASE" in
     mkdir "$HOME/nested"
     chmod 0777 "$HOME/nested"
     ;;
+  non-traversable)
+    mkdir "$HOME/.local"
+    ln -s "$OUTSIDE_ROOT" "$HOME/.local/bin"
+    chmod 0600 "$HOME/.local"
+    NON_TRAVERSABLE_METADATA="$(directory_metadata "$HOME/.local")"
+    ;;
   pnpm-file)
     mkdir -p "$PNPM_HOME"
     printf 'keep-pnpm\n' >"$PNPM_HOME/pnpm"
@@ -346,6 +357,9 @@ if refresh_user >"$CASE_OUTPUT" 2>&1; then
   printf 'drift case unexpectedly succeeded: %s\n' "$DRIFT_CASE" >&2
   exit 1
 fi
+if [[ "$DRIFT_CASE" == non-traversable ]]; then
+  [[ "$(directory_metadata "$HOME/.local")" == "$NON_TRAVERSABLE_METADATA" ]]
+fi
 [[ ! -e "$HOME/.ssh" && ! -L "$HOME/.ssh" ]]
 [[ ! -e "$HOME/.local/state" && ! -L "$HOME/.local/state" ]]
 EOF
@@ -353,7 +367,7 @@ chmod +x "$drift_case"
 
 for case_name in \
   symlink type owner link home terminal-parent outside \
-  nested-symlink nested-type nested-owner world-mode \
+  nested-symlink nested-type nested-owner world-mode non-traversable \
   pnpm-file pnpx-symlink pnpm-owner; do
   case_home="$temporary/drift-$case_name"
   outside_root="$temporary/outside-$case_name"
@@ -388,7 +402,7 @@ for case_name in \
     CASE_OUTPUT="$temporary/drift-$case_name.out" \
     "$drift_case"
   [[ ! -s "$temporary/forbidden-$case_name.log" ]]
-  grep -Eq 'refusing (unsafe|non-canonical|symlinked|non-directory|foreign-owned|world-writable|unexpected|user path outside)' \
+  grep -Eq 'refusing (unsafe|non-canonical|symlinked|non-directory|non-traversable|foreign-owned|world-writable|unexpected|user path outside)' \
     "$temporary/drift-$case_name.out"
   [[ "$(mode "$case_home")" == "$home_mode_before" ]]
   [[ "$(mode "$outside_root")" == "$outside_mode_before" ]]
@@ -412,6 +426,10 @@ for case_name in \
       ;;
     world-mode)
       [[ "$(mode "$case_home/nested")" == 777 ]]
+      ;;
+    non-traversable)
+      [[ "$(mode "$case_home/.local")" == 600 ]]
+      chmod 0700 "$case_home/.local"
       ;;
     pnpm-file)
       [[ "$(<"$case_pnpm_home/pnpm")" == keep-pnpm ]]

--- a/tests/linux-server-refresh-user-test.sh
+++ b/tests/linux-server-refresh-user-test.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script="$root/bin/linux-server-bootstrap"
+temporary="$(mktemp -d)"
+trap 'rm -rf "$temporary"' EXIT
+
+mode() {
+  stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1"
+}
+
+fakebin="$temporary/fakebin"
+mkdir "$fakebin"
+for command_name in sudo apt apt-get apt-cache dpkg-query usermod chsh sshd ufw systemctl; do
+  cat >"$fakebin/$command_name" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$(basename "$0") $*" >>"$FORBIDDEN_LOG"
+exit 97
+EOF
+  chmod +x "$fakebin/$command_name"
+done
+
+refresh_case="$temporary/refresh-case.sh"
+cat >"$refresh_case" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+umask 0002
+
+# shellcheck disable=SC1090
+DOTFILES_SERVER_SOURCE_ONLY=1 source "$BOOTSTRAP_SCRIPT"
+
+uname() {
+  [[ "${1:-}" == -s ]] && {
+    printf 'Linux\n'
+    return
+  }
+  command uname "$@"
+}
+
+install_pinned_checkout() {
+  local destination="$2"
+  [[ -d "$destination" && ! -L "$destination" ]]
+  if [[ "$destination" == "$HOME/.oh-my-zsh/custom/themes/spaceship-prompt" ]]; then
+    cat >"$destination/spaceship.zsh-theme" <<'THEME'
+printf '[%s]\n' "$SPACESHIP_CHAR_SUFFIX" >"$PROMPT_CAPTURE"
+THEME
+    chmod 0644 "$destination/spaceship.zsh-theme"
+  fi
+}
+
+install_openclaw_toolchain() {
+  cat >"$PNPM_HOME/pnpm" <<'PNPM'
+#!/usr/bin/env bash
+printf '11.15.1\n'
+PNPM
+  chmod 0755 "$PNPM_HOME/pnpm"
+}
+
+mkdir -p \
+  "$HOME/.ssh" \
+  "$HOME/.local/bin" \
+  "$HOME/.local/share/pnpm" \
+  "$HOME/.local/state/dotfiles/linux-server/backups" \
+  "$HOME/.oh-my-zsh/custom/plugins/zsh-autosuggestions" \
+  "$HOME/.oh-my-zsh/custom/themes/spaceship-prompt"
+chmod 0775 \
+  "$HOME/.ssh" \
+  "$HOME/.local" \
+  "$HOME/.local/bin" \
+  "$HOME/.local/share" \
+  "$HOME/.local/share/pnpm" \
+  "$HOME/.local/state" \
+  "$HOME/.local/state/dotfiles" \
+  "$HOME/.local/state/dotfiles/linux-server" \
+  "$HOME/.local/state/dotfiles/linux-server/backups" \
+  "$HOME/.oh-my-zsh" \
+  "$HOME/.oh-my-zsh/custom" \
+  "$HOME/.oh-my-zsh/custom/plugins" \
+  "$HOME/.oh-my-zsh/custom/plugins/zsh-autosuggestions" \
+  "$HOME/.oh-my-zsh/custom/themes" \
+  "$HOME/.oh-my-zsh/custom/themes/spaceship-prompt"
+
+refresh_user
+first_links="$(
+  find "$HOME" -type l -print |
+    LC_ALL=C sort |
+    while IFS= read -r path; do printf '%s -> %s\n' "$path" "$(readlink "$path")"; done
+)"
+first_backups="$(find "$state_root/backups" -mindepth 1 -print)"
+refresh_user
+second_links="$(
+  find "$HOME" -type l -print |
+    LC_ALL=C sort |
+    while IFS= read -r path; do printf '%s -> %s\n' "$path" "$(readlink "$path")"; done
+)"
+[[ "$first_links" == "$second_links" ]]
+[[ -z "$first_backups" ]]
+[[ -z "$(find "$state_root/backups" -mindepth 1 -print)" ]]
+EOF
+chmod +x "$refresh_case"
+
+home="$temporary/home"
+mkdir "$home"
+: >"$temporary/forbidden.log"
+HOME="$home" \
+  XDG_DATA_HOME="$home/.local/share" \
+  XDG_STATE_HOME="$home/.local/state" \
+  PNPM_HOME="$home/.local/share/pnpm" \
+  PATH="$fakebin:/usr/bin:/bin" \
+  FORBIDDEN_LOG="$temporary/forbidden.log" \
+  BOOTSTRAP_SCRIPT="$script" \
+  "$refresh_case"
+[[ ! -s "$temporary/forbidden.log" ]]
+
+for secure_path in \
+  "$home/.ssh" \
+  "$home/.codex" \
+  "$home/.local/state" \
+  "$home/.local/state/dotfiles" \
+  "$home/.local/state/dotfiles/linux-server" \
+  "$home/.local/state/dotfiles/linux-server/backups"; do
+  [[ "$(mode "$secure_path")" == 700 ]]
+done
+for public_path in \
+  "$home/.local" \
+  "$home/.local/bin" \
+  "$home/.local/share" \
+  "$home/.local/share/pnpm" \
+  "$home/.local/opt" \
+  "$home/.oh-my-zsh" \
+  "$home/.oh-my-zsh/custom" \
+  "$home/.oh-my-zsh/custom/plugins" \
+  "$home/.oh-my-zsh/custom/plugins/zsh-autosuggestions" \
+  "$home/.oh-my-zsh/custom/themes" \
+  "$home/.oh-my-zsh/custom/themes/spaceship-prompt"; do
+  [[ "$(mode "$public_path")" == 755 ]]
+done
+[[ -x "$home/.local/share/pnpm/pnpm" ]]
+[[ ! -e "$home/.local/share/pnpm/bin" ]]
+[[ "$(readlink "$home/.local/bin/codex")" == "$root/bin/codex" ]]
+for absent in \
+  "$home/.local/bin/quickssh" \
+  "$home/.local/bin/op" \
+  "$home/.local/bin/openclaw" \
+  "$home/.local/bin/mttc" \
+  "$home/.codex/hooks.json" \
+  "$home/.codex/AGENTS.md" \
+  "$home/.codex/config.toml" \
+  "$home/.codex/models.json" \
+  "$home/.codex/auth.json"; do
+  [[ ! -e "$absent" && ! -L "$absent" ]]
+done
+[[ -z "$(find "$home/.codex" -mindepth 1 -print)" ]]
+
+profile_output="$(
+  HOME="$home" \
+    XDG_DATA_HOME="$home/.local/share" \
+    PNPM_HOME="$home/.local/share/pnpm" \
+    PATH="$home/.local/share/pnpm:/usr/bin:$home/.local/share/pnpm:/bin" \
+    zsh -dfc '
+      source "$HOME/.profile"
+      print -r -- "$PATH"
+    '
+)"
+[[ "$(tr ':' '\n' <<<"$profile_output" | grep -Fxc "$home/.local/share/pnpm")" == 1 ]]
+if grep -Fq "$home/.local/share/pnpm/bin" <<<"$profile_output"; then
+  printf 'server profile added PNPM_HOME/bin\n' >&2
+  exit 1
+fi
+
+prompt_capture="$temporary/prompt-suffix"
+cx_log="$temporary/cx-args"
+HOME="$home" \
+  PROMPT_CAPTURE="$prompt_capture" \
+  CX_LOG="$cx_log" \
+  zsh -dfc '
+    codex() {
+      print -r -- "$#" >"$CX_LOG"
+      local argument
+      for argument in "$@"; do
+        print -r -- "$argument" >>"$CX_LOG"
+      done
+    }
+    source "$HOME/.zshrc"
+    cx "two words" "*"
+  '
+[[ "$(<"$prompt_capture")" == "[ ]" ]]
+printf '%s\n' 3 --no-alt-screen "two words" '*' >"$temporary/cx-expected"
+cmp "$temporary/cx-expected" "$cx_log"
+
+drift_case="$temporary/drift-case.sh"
+cat >"$drift_case" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+# shellcheck disable=SC1090
+DOTFILES_SERVER_SOURCE_ONLY=1 source "$BOOTSTRAP_SCRIPT"
+uname() {
+  [[ "${1:-}" == -s ]] && {
+    printf 'Linux\n'
+    return
+  }
+  command uname "$@"
+}
+install_pinned_checkout() { :; }
+install_openclaw_toolchain() { :; }
+
+case "$DRIFT_CASE" in
+  symlink)
+    mkdir "$HOME/redirect"
+    ln -s "$HOME/redirect" "$HOME/.local"
+    ;;
+  type)
+    : >"$HOME/.codex"
+    ;;
+  owner)
+    mkdir -p "$HOME/.local/share/pnpm"
+    foreign="$HOME/.local/share/pnpm"
+    original_owned_path_uid="$(declare -f owned_path_uid)"
+    eval "${original_owned_path_uid/owned_path_uid/original_owned_path_uid}"
+    owned_path_uid() {
+      if [[ "$1" == "$foreign" ]]; then
+        printf '424242\n'
+      else
+        original_owned_path_uid "$1"
+      fi
+    }
+    ;;
+  link)
+    mkdir -p "$HOME/.local/bin"
+    ln -s "$HOME/wrong-codex" "$HOME/.local/bin/codex"
+    ;;
+esac
+
+if refresh_user >"$CASE_OUTPUT" 2>&1; then
+  printf 'drift case unexpectedly succeeded: %s\n' "$DRIFT_CASE" >&2
+  exit 1
+fi
+[[ ! -e "$HOME/.ssh" && ! -L "$HOME/.ssh" ]]
+[[ ! -e "$HOME/.local/state" && ! -L "$HOME/.local/state" ]]
+EOF
+chmod +x "$drift_case"
+
+for case_name in symlink type owner link; do
+  case_home="$temporary/drift-$case_name"
+  mkdir "$case_home"
+  : >"$temporary/forbidden-$case_name.log"
+  HOME="$case_home" \
+    XDG_DATA_HOME="$case_home/.local/share" \
+    XDG_STATE_HOME="$case_home/.local/state" \
+    PNPM_HOME="$case_home/.local/share/pnpm" \
+    PATH="$fakebin:/usr/bin:/bin" \
+    FORBIDDEN_LOG="$temporary/forbidden-$case_name.log" \
+    BOOTSTRAP_SCRIPT="$script" \
+    DRIFT_CASE="$case_name" \
+    CASE_OUTPUT="$temporary/drift-$case_name.out" \
+    "$drift_case"
+  [[ ! -s "$temporary/forbidden-$case_name.log" ]]
+  grep -Eq 'refusing (symlinked|non-directory|foreign-owned|unexpected)' \
+    "$temporary/drift-$case_name.out"
+done
+
+refresh_definitions="$(
+  # shellcheck disable=SC1090
+  DOTFILES_SERVER_SOURCE_ONLY=1 source "$script"
+  declare -f refresh_user refresh_user_content preflight_refresh_user
+)"
+if grep -Eq '(^|[[:space:]])(sudo|apt|apt-get|usermod|sshd|ufw|run_root)([[:space:]]|$)' \
+  <<<"$refresh_definitions"; then
+  printf 'refresh-user contains a privileged mutation route\n' >&2
+  exit 1
+fi
+
+printf 'linux_server_refresh_user_test=passed\n'

--- a/tests/linux-server-refresh-user-test.sh
+++ b/tests/linux-server-refresh-user-test.sh
@@ -50,11 +50,21 @@ THEME
 }
 
 install_openclaw_toolchain() {
-  cat >"$PNPM_HOME/pnpm" <<'PNPM'
+  local install_root="$HOME/.local/opt/node-v$node_version"
+  local dist="$install_root/lib/node_modules/corepack/dist"
+  local shim
+  mkdir -p "$dist"
+  for shim in pnpm pnpx; do
+    cat >"$dist/$shim.js" <<'PNPM'
 #!/usr/bin/env bash
 printf '11.15.1\n'
 PNPM
-  chmod 0755 "$PNPM_HOME/pnpm"
+    chmod 0755 "$dist/$shim.js"
+    if [[ ! -L "$PNPM_HOME/$shim" ]]; then
+      ln -s "../../opt/node-v$node_version/lib/node_modules/corepack/dist/$shim.js" \
+        "$PNPM_HOME/$shim"
+    fi
+  done
 }
 
 mkdir -p \
@@ -137,6 +147,7 @@ for public_path in \
   [[ "$(mode "$public_path")" == 755 ]]
 done
 [[ -x "$home/.local/share/pnpm/pnpm" ]]
+[[ -x "$home/.local/share/pnpm/pnpx" ]]
 [[ ! -e "$home/.local/share/pnpm/bin" ]]
 [[ "$(readlink "$home/.local/bin/codex")" == "$root/bin/codex" ]]
 for absent in \
@@ -144,6 +155,8 @@ for absent in \
   "$home/.local/bin/op" \
   "$home/.local/bin/openclaw" \
   "$home/.local/bin/mttc" \
+  "$home/.local/share/pnpm/yarn" \
+  "$home/.local/share/pnpm/yarnpkg" \
   "$home/.codex/hooks.json" \
   "$home/.codex/AGENTS.md" \
   "$home/.codex/config.toml" \
@@ -206,6 +219,30 @@ uname() {
 install_pinned_checkout() { :; }
 install_openclaw_toolchain() { :; }
 
+simulate_foreign_owner() {
+  foreign="$1"
+  original_owned_path_uid="$(declare -f owned_path_uid)"
+  eval "${original_owned_path_uid/owned_path_uid/original_owned_path_uid}"
+  owned_path_uid() {
+    if [[ "$1" == "$foreign" ]]; then
+      printf '424242\n'
+    else
+      original_owned_path_uid "$1"
+    fi
+  }
+}
+
+create_corepack_targets() {
+  local install_root="$HOME/.local/opt/node-v$node_version"
+  local dist="$install_root/lib/node_modules/corepack/dist"
+  local shim
+  mkdir -p "$dist"
+  for shim in pnpm pnpx; do
+    printf '#!/usr/bin/env bash\n' >"$dist/$shim.js"
+    chmod 0755 "$dist/$shim.js"
+  done
+}
+
 case "$DRIFT_CASE" in
   symlink)
     mkdir "$HOME/redirect"
@@ -216,20 +253,39 @@ case "$DRIFT_CASE" in
     ;;
   owner)
     mkdir -p "$HOME/.local/share/pnpm"
-    foreign="$HOME/.local/share/pnpm"
-    original_owned_path_uid="$(declare -f owned_path_uid)"
-    eval "${original_owned_path_uid/owned_path_uid/original_owned_path_uid}"
-    owned_path_uid() {
-      if [[ "$1" == "$foreign" ]]; then
-        printf '424242\n'
-      else
-        original_owned_path_uid "$1"
-      fi
-    }
+    simulate_foreign_owner "$HOME/.local/share/pnpm"
     ;;
   link)
     mkdir -p "$HOME/.local/bin"
     ln -s "$HOME/wrong-codex" "$HOME/.local/bin/codex"
+    ;;
+  home | terminal-parent | outside)
+    ;;
+  nested-symlink)
+    mkdir "$HOME/nested"
+    ln -s "$OUTSIDE_ROOT" "$HOME/nested/redirect"
+    ;;
+  nested-type)
+    : >"$HOME/nested"
+    ;;
+  nested-owner)
+    mkdir "$HOME/nested"
+    simulate_foreign_owner "$HOME/nested"
+    ;;
+  pnpm-file)
+    mkdir -p "$PNPM_HOME"
+    printf 'keep-pnpm\n' >"$PNPM_HOME/pnpm"
+    ;;
+  pnpx-symlink)
+    mkdir -p "$PNPM_HOME"
+    ln -s "$OUTSIDE_ROOT/wrong-pnpx" "$PNPM_HOME/pnpx"
+    ;;
+  pnpm-owner)
+    create_corepack_targets
+    mkdir -p "$PNPM_HOME"
+    ln -s "../../opt/node-v$node_version/lib/node_modules/corepack/dist/pnpm.js" \
+      "$PNPM_HOME/pnpm"
+    simulate_foreign_owner "$PNPM_HOME/pnpm"
     ;;
 esac
 
@@ -242,23 +298,74 @@ fi
 EOF
 chmod +x "$drift_case"
 
-for case_name in symlink type owner link; do
+for case_name in \
+  symlink type owner link home terminal-parent outside \
+  nested-symlink nested-type nested-owner \
+  pnpm-file pnpx-symlink pnpm-owner; do
   case_home="$temporary/drift-$case_name"
+  outside_root="$temporary/outside-$case_name"
   mkdir "$case_home"
+  mkdir "$outside_root"
+  chmod 0777 "$outside_root"
+  printf 'outside-marker\n' >"$outside_root/marker"
+  outside_mode_before="$(mode "$outside_root")"
+  outside_listing_before="$(find "$outside_root" -mindepth 1 -print | LC_ALL=C sort)"
+  home_mode_before="$(mode "$case_home")"
+  case_pnpm_home="$case_home/.local/share/pnpm"
+  case_state_home="$case_home/.local/state"
+  case "$case_name" in
+    home) case_pnpm_home="$case_home" ;;
+    terminal-parent) case_pnpm_home="$case_home/.." ;;
+    outside) case_pnpm_home="$case_home/../$(basename "$outside_root")/pnpm" ;;
+    nested-symlink) case_pnpm_home="$case_home/nested/redirect/pnpm" ;;
+    nested-type | nested-owner) case_pnpm_home="$case_home/nested/tools/pnpm" ;;
+  esac
   : >"$temporary/forbidden-$case_name.log"
   HOME="$case_home" \
     XDG_DATA_HOME="$case_home/.local/share" \
-    XDG_STATE_HOME="$case_home/.local/state" \
-    PNPM_HOME="$case_home/.local/share/pnpm" \
+    XDG_STATE_HOME="$case_state_home" \
+    PNPM_HOME="$case_pnpm_home" \
     PATH="$fakebin:/usr/bin:/bin" \
     FORBIDDEN_LOG="$temporary/forbidden-$case_name.log" \
     BOOTSTRAP_SCRIPT="$script" \
     DRIFT_CASE="$case_name" \
+    OUTSIDE_ROOT="$outside_root" \
     CASE_OUTPUT="$temporary/drift-$case_name.out" \
     "$drift_case"
   [[ ! -s "$temporary/forbidden-$case_name.log" ]]
-  grep -Eq 'refusing (symlinked|non-directory|foreign-owned|unexpected)' \
+  grep -Eq 'refusing (unsafe|non-canonical|symlinked|non-directory|foreign-owned|unexpected|user path outside)' \
     "$temporary/drift-$case_name.out"
+  [[ "$(mode "$case_home")" == "$home_mode_before" ]]
+  [[ "$(mode "$outside_root")" == "$outside_mode_before" ]]
+  [[ "$(<"$outside_root/marker")" == outside-marker ]]
+  [[ "$(find "$outside_root" -mindepth 1 -print | LC_ALL=C sort)" == "$outside_listing_before" ]]
+  case "$case_name" in
+    symlink)
+      [[ "$(readlink "$case_home/.local")" == "$case_home/redirect" ]]
+      ;;
+    type)
+      [[ -f "$case_home/.codex" && ! -L "$case_home/.codex" ]]
+      ;;
+    link)
+      [[ "$(readlink "$case_home/.local/bin/codex")" == "$case_home/wrong-codex" ]]
+      ;;
+    nested-symlink)
+      [[ "$(readlink "$case_home/nested/redirect")" == "$outside_root" ]]
+      ;;
+    nested-type)
+      [[ -f "$case_home/nested" && ! -L "$case_home/nested" ]]
+      ;;
+    pnpm-file)
+      [[ "$(<"$case_pnpm_home/pnpm")" == keep-pnpm ]]
+      ;;
+    pnpx-symlink)
+      [[ "$(readlink "$case_pnpm_home/pnpx")" == "$outside_root/wrong-pnpx" ]]
+      ;;
+    pnpm-owner)
+      [[ "$(readlink "$case_pnpm_home/pnpm")" == \
+        "../../opt/node-v24.19.0/lib/node_modules/corepack/dist/pnpm.js" ]]
+      ;;
+  esac
 done
 
 refresh_definitions="$(

--- a/tests/linux-server-refresh-user-test.sh
+++ b/tests/linux-server-refresh-user-test.sh
@@ -52,7 +52,7 @@ THEME
 install_openclaw_toolchain() {
   local install_root="$HOME/.local/opt/node-v$node_version"
   local dist="$install_root/lib/node_modules/corepack/dist"
-  local shim
+  local shim link_target
   mkdir -p "$dist"
   for shim in pnpm pnpx; do
     cat >"$dist/$shim.js" <<'PNPM'
@@ -61,8 +61,8 @@ printf '11.15.1\n'
 PNPM
     chmod 0755 "$dist/$shim.js"
     if [[ ! -L "$PNPM_HOME/$shim" ]]; then
-      ln -s "../../opt/node-v$node_version/lib/node_modules/corepack/dist/$shim.js" \
-        "$PNPM_HOME/$shim"
+      link_target="$(relative_path_between "$PNPM_HOME" "$dist/$shim.js")"
+      ln -s "$link_target" "$PNPM_HOME/$shim"
     fi
   done
 }
@@ -122,6 +122,55 @@ HOME="$home" \
   BOOTSTRAP_SCRIPT="$script" \
   "$refresh_case"
 [[ ! -s "$temporary/forbidden.log" ]]
+
+run_refresh_component_case() {
+  local name="$1"
+  local case_home="$2"
+  local case_pnpm_home="$3"
+  local forbidden="$temporary/forbidden-$name.log"
+  : >"$forbidden"
+  HOME="$case_home" \
+    XDG_DATA_HOME="$case_home/.local/share" \
+    XDG_STATE_HOME="$case_home/.local/state" \
+    PNPM_HOME="$case_pnpm_home" \
+    PATH="$fakebin:/usr/bin:/bin" \
+    FORBIDDEN_LOG="$forbidden" \
+    BOOTSTRAP_SCRIPT="$script" \
+    "$refresh_case"
+  [[ ! -s "$forbidden" ]]
+}
+
+direct_home="$temporary/direct-home"
+mkdir "$direct_home"
+run_refresh_component_case direct "$direct_home" "$direct_home/pnpm"
+[[ "$(mode "$direct_home/pnpm")" == 755 ]]
+
+deep_home="$temporary/deep-home"
+mkdir "$deep_home"
+deep_pnpm="$deep_home/tools/node/package-managers/pnpm"
+run_refresh_component_case deep "$deep_home" "$deep_pnpm"
+for path in \
+  "$deep_home/tools" \
+  "$deep_home/tools/node" \
+  "$deep_home/tools/node/package-managers" \
+  "$deep_pnpm"; do
+  [[ "$(mode "$path")" == 755 ]]
+done
+
+normalize_home="$temporary/normalize-home"
+normalize_pnpm="$normalize_home/existing/deep/pnpm"
+mkdir -p "$normalize_pnpm"
+chmod 0775 \
+  "$normalize_home/existing" \
+  "$normalize_home/existing/deep" \
+  "$normalize_pnpm"
+run_refresh_component_case normalize "$normalize_home" "$normalize_pnpm"
+for path in \
+  "$normalize_home/existing" \
+  "$normalize_home/existing/deep" \
+  "$normalize_pnpm"; do
+  [[ "$(mode "$path")" == 755 ]]
+done
 
 for secure_path in \
   "$home/.ssh" \
@@ -272,6 +321,10 @@ case "$DRIFT_CASE" in
     mkdir "$HOME/nested"
     simulate_foreign_owner "$HOME/nested"
     ;;
+  world-mode)
+    mkdir "$HOME/nested"
+    chmod 0777 "$HOME/nested"
+    ;;
   pnpm-file)
     mkdir -p "$PNPM_HOME"
     printf 'keep-pnpm\n' >"$PNPM_HOME/pnpm"
@@ -300,7 +353,7 @@ chmod +x "$drift_case"
 
 for case_name in \
   symlink type owner link home terminal-parent outside \
-  nested-symlink nested-type nested-owner \
+  nested-symlink nested-type nested-owner world-mode \
   pnpm-file pnpx-symlink pnpm-owner; do
   case_home="$temporary/drift-$case_name"
   outside_root="$temporary/outside-$case_name"
@@ -318,7 +371,9 @@ for case_name in \
     terminal-parent) case_pnpm_home="$case_home/.." ;;
     outside) case_pnpm_home="$case_home/../$(basename "$outside_root")/pnpm" ;;
     nested-symlink) case_pnpm_home="$case_home/nested/redirect/pnpm" ;;
-    nested-type | nested-owner) case_pnpm_home="$case_home/nested/tools/pnpm" ;;
+    nested-type | nested-owner | world-mode)
+      case_pnpm_home="$case_home/nested/tools/pnpm"
+      ;;
   esac
   : >"$temporary/forbidden-$case_name.log"
   HOME="$case_home" \
@@ -333,7 +388,7 @@ for case_name in \
     CASE_OUTPUT="$temporary/drift-$case_name.out" \
     "$drift_case"
   [[ ! -s "$temporary/forbidden-$case_name.log" ]]
-  grep -Eq 'refusing (unsafe|non-canonical|symlinked|non-directory|foreign-owned|unexpected|user path outside)' \
+  grep -Eq 'refusing (unsafe|non-canonical|symlinked|non-directory|foreign-owned|world-writable|unexpected|user path outside)' \
     "$temporary/drift-$case_name.out"
   [[ "$(mode "$case_home")" == "$home_mode_before" ]]
   [[ "$(mode "$outside_root")" == "$outside_mode_before" ]]
@@ -354,6 +409,9 @@ for case_name in \
       ;;
     nested-type)
       [[ -f "$case_home/nested" && ! -L "$case_home/nested" ]]
+      ;;
+    world-mode)
+      [[ "$(mode "$case_home/nested")" == 777 ]]
       ;;
     pnpm-file)
       [[ "$(<"$case_pnpm_home/pnpm")" == keep-pnpm ]]
@@ -376,6 +434,15 @@ refresh_definitions="$(
 if grep -Eq '(^|[[:space:]])(sudo|apt|apt-get|usermod|sshd|ufw|run_root)([[:space:]]|$)' \
   <<<"$refresh_definitions"; then
   printf 'refresh-user contains a privileged mutation route\n' >&2
+  exit 1
+fi
+ensure_directory_definition="$(
+  # shellcheck disable=SC1090
+  DOTFILES_SERVER_SOURCE_ONLY=1 source "$script"
+  declare -f ensure_owned_directory
+)"
+if grep -Eq 'mkdir[[:space:]]+-p' <<<"$ensure_directory_definition"; then
+  printf 'refresh-user uses mkdir -p for managed directory creation\n' >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- add a zero-sudo `refresh-user` phase for portable Linux shell and CLI state
- canonicalize every managed user path, require strict HOME descendants, and reject symlink, type, owner, world-write, or non-traversable drift before descending or writing
- render one parent-first managed-directory manifest so direct and arbitrarily deep safe `PNPM_HOME` paths are created one component at a time with exact modes
- install pnpm globals directly in `PNPM_HOME`; preflight only the authentic `pnpm` and `pnpx` Corepack outputs and never touch Yarn shims
- link the public Codex launcher, add the server-only `cx` shortcut, and set the Spaceship prompt suffix before theme loading
- keep private fleet, auth, QuickSSH, Mosh, and OpenClaw assets out

## Validation

- `bash tests/linux-server-bootstrap-test.sh`
- `bash tests/linux-server-refresh-user-test.sh`
- `bash tests/codex-wrapper-test.sh`
- `bash tests/linux-server-auth-proof-test.sh`
- Bash and Zsh syntax checks
- ShellCheck on changed shell scripts
- `git diff --check`
- privacy scan of the complete patch

Coverage includes direct-child and deep-missing PNPM paths, deep owned 0775 normalization and idempotence, `$HOME`, terminal `/..`, lexical outside-HOME bypasses, unsafe intermediate symlink/type/owner/world-write state, unchanged outside sentinels, unsafe `pnpm`/`pnpx` outputs, and untouched or absent `yarn`/`yarnpkg`.

The traversal regression creates owned mode-0600 `~/.local` containing a hidden `.local/bin` symlink to an outside target. Refresh rejects the parent before child inspection; HOME, directory metadata/mode, and outside content/mode remain unchanged.

Owned 0775 directories are intentionally accepted only through the complete read-only preflight and then normalized to their exact managed modes. World-writable or owner-non-executable directories fail closed without mutation.

## Dependency contract

The checksum-pinned Node 24.19.0 archive contains Corepack 0.35.0. Its bundled enable implementation maps the `pnpm` manager to the `pnpm` and `pnpx` binaries; bare enable selects additional package managers. The installer therefore uses `corepack enable pnpm`.

## Delta

- production: +480 / -54 lines, net +426
- tests: +527 / -8 lines, net +519
- docs: +10 / -0 lines

The production growth is the shared manifest, portable canonical ancestry and traversal preflight, exact-mode component installer, and exact Corepack output validator required to enforce the security and ownership invariants before mutation.
