### PR TITLE
fix(codex): use official standalone CLI on macOS

### DIFF
--- a/.natiliusrc
+++ b/.natiliusrc
@@ -303,7 +303,6 @@ BREWCASKS=(
     "android-platform-tools"
     "tfswitch"
     "tflint"
-    "codex"
     "claude"
     "ollama-app"
     "zed"

--- a/bin/codex
+++ b/bin/codex
@@ -2,23 +2,31 @@
 set -euo pipefail
 
 wrapper_dir="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+codex_home="${CODEX_HOME:-$HOME/.codex}"
+platform="$(uname -s)"
 
 real_codex=""
-case "$(uname -s)" in
+case "$platform" in
   Darwin)
-    # Homebrew owns the standalone CLI on macOS. Prefer its native binary even
-    # while old npm-backed Codex sessions are still draining.
-    for candidate in /opt/homebrew/bin/codex /usr/local/bin/codex; do
+    # The official installer owns macOS. Never fall through to Homebrew or npm:
+    # their binaries can block in dyld before Codex can report why.
+    for candidate in \
+      "$codex_home/packages/standalone/current/bin/codex" \
+      "$codex_home/packages/standalone/current/codex"; do
       if [[ -x "$candidate" ]]; then
         real_codex="$candidate"
         break
       fi
     done
+    if [[ -z "$real_codex" ]]; then
+      printf 'codex: official standalone CLI is missing; run codex-standalone-install\n' >&2
+      exit 127
+    fi
     ;;
   Linux)
     # The official standalone installer owns Linux/WSL and keeps this symlink
     # stable across releases.
-    candidate="$HOME/.codex/packages/standalone/current/bin/codex"
+    candidate="$codex_home/packages/standalone/current/bin/codex"
     if [[ -x "$candidate" ]]; then
       real_codex="$candidate"
     fi
@@ -47,10 +55,10 @@ while :; do
 done
 unset path_done path_entry path_remaining
 
-if [[ -z "$real_codex" ]]; then
+if [[ "$platform" != "Darwin" && -z "$real_codex" ]]; then
   real_codex="$(PATH="$lookup_path" command -v codex || true)"
 fi
-if [[ -z "$real_codex" && -x "/Applications/Codex.app/Contents/Resources/codex" ]]; then
+if [[ "$platform" != "Darwin" && -z "$real_codex" && -x "/Applications/Codex.app/Contents/Resources/codex" ]]; then
   real_codex="/Applications/Codex.app/Contents/Resources/codex"
 fi
 

--- a/bin/codex-standalone-install
+++ b/bin/codex-standalone-install
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly installer_url="https://chatgpt.com/codex/install.sh"
+codex_home="${CODEX_HOME:-$HOME/.codex}"
+standalone_root="$codex_home/packages/standalone"
+lock_file="$standalone_root/install.lock"
+lock_dir="$standalone_root/install.lock.d"
+
+fail() {
+  printf 'codex-standalone-install: %s\n' "$1" >&2
+  exit "${2:-1}"
+}
+
+platform="$(uname -s)"
+case "$platform" in
+  Darwin | Linux) ;;
+  *) fail "unsupported platform: $platform" ;;
+esac
+
+if [[ -d "$lock_dir" ]]; then
+  fail "installer lock is active at $lock_dir" 75
+fi
+
+if [[ -e "$lock_file" ]]; then
+  case "$platform" in
+    Darwin)
+      command -v lockf >/dev/null 2>&1 ||
+        fail "lockf is required to verify $lock_file"
+      if ! lockf -s -t 0 -k "$lock_file" /usr/bin/true; then
+        fail "installer lock is active at $lock_file" 75
+      fi
+      ;;
+    Linux)
+      if command -v flock >/dev/null 2>&1 &&
+        ! flock -n "$lock_file" /usr/bin/true; then
+        fail "installer lock is active at $lock_file" 75
+      fi
+      ;;
+  esac
+fi
+
+command -v curl >/dev/null 2>&1 || fail "curl is required"
+
+temporary="$(mktemp -d "${TMPDIR:-/tmp}/codex-standalone-install.XXXXXX")"
+cleanup() {
+  rm -rf "$temporary"
+}
+trap cleanup EXIT INT TERM
+
+installer="$temporary/install.sh"
+curl -fsSL --connect-timeout 10 --max-time 60 "$installer_url" -o "$installer"
+[[ -s "$installer" ]] || fail "downloaded installer is empty"
+
+first_line=""
+IFS= read -r first_line <"$installer" || true
+[[ "$first_line" == "#!/bin/sh" ]] ||
+  fail "downloaded installer has an unexpected header"
+grep -F 'RELEASES_BASE_URL="https://releases.openai.com/codex"' "$installer" >/dev/null ||
+  fail "downloaded installer does not declare the official release service"
+grep -F "STANDALONE_ROOT=\"\$CODEX_HOME_DIR/packages/standalone\"" "$installer" >/dev/null ||
+  fail "downloaded installer does not declare the standalone package root"
+/bin/sh -n "$installer" || fail "downloaded installer failed syntax validation"
+
+CODEX_NON_INTERACTIVE=1 /bin/sh "$installer" "$@"

--- a/functions/system/update.zsh
+++ b/functions/system/update.zsh
@@ -1,39 +1,10 @@
-npm-global-update-all-nodenv() {
-    local package_name="$1"
-    local latest_version nodenv_root version version_dir
-    local update_failed=false
-
-    command -v nodenv >/dev/null 2>&1 || return 0
-    nodenv_root="${NODENV_ROOT:-$HOME/.nodenv}"
-    [[ -d "$nodenv_root/versions" ]] || return 0
-
-    latest_version=$(npm view "$package_name" version 2>/dev/null) || return 1
-
-    while IFS= read -r version_dir; do
-        version=${version_dir##*/}
-
-        if NODENV_VERSION="$version" npm ls -g "$package_name" --depth=0 >/dev/null 2>&1; then
-            echo "   $package_name@$latest_version for Node $version"
-            if ! NODENV_VERSION="$version" npm install -g "$package_name@$latest_version" --no-audit --no-fund; then
-                update_failed=true
-            fi
-        fi
-    done < <(find "$nodenv_root/versions" -mindepth 1 -maxdepth 1 -type d -print 2>/dev/null)
-
-    nodenv rehash
-    [[ "$update_failed" == false ]]
-}
-
 codex-update-all() {
-    local update_failed=false
-
-    if command -v brew >/dev/null 2>&1 && brew list --cask codex >/dev/null 2>&1; then
-        echo "   Homebrew cask codex"
-        brew upgrade --cask codex || update_failed=true
+    if ! command -v codex-standalone-install >/dev/null 2>&1; then
+        echo "codex-standalone-install is required" >&2
+        return 127
     fi
-
-    npm-global-update-all-nodenv @openai/codex || update_failed=true
-    [[ "$update_failed" == false ]]
+    echo "   OpenAI standalone Codex"
+    codex-standalone-install
 }
 
 up() {

--- a/tests/codex-standalone-install-test.sh
+++ b/tests/codex-standalone-install-test.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+helper="$repo_root/bin/codex-standalone-install"
+update_functions="$repo_root/functions/system/update.zsh"
+temporary="$(mktemp -d)"
+trap 'rm -rf "$temporary"' EXIT
+
+make_fake_tools() {
+  local directory="$1"
+  mkdir -p "$directory"
+
+  cat >"$directory/uname" <<'EOF'
+#!/usr/bin/env bash
+printf 'Darwin\n'
+EOF
+
+  cat >"$directory/lockf" <<'EOF'
+#!/usr/bin/env bash
+exit "${TEST_LOCK_STATUS:-0}"
+EOF
+
+  cat >"$directory/curl" <<'EOF'
+#!/usr/bin/env bash
+output=""
+url=""
+while (($#)); do
+  case "$1" in
+    -o)
+      output="$2"
+      shift 2
+      ;;
+    -*)
+      shift
+      ;;
+    *)
+      url="$1"
+      shift
+      ;;
+  esac
+done
+printf '%s\n' "$url" >"$TEST_CASE_DIR/url"
+touch "$TEST_CASE_DIR/curl-ran"
+cat >"$output" <<'INSTALLER'
+#!/bin/sh
+RELEASES_BASE_URL="https://releases.openai.com/codex"
+CODEX_HOME_DIR="${CODEX_HOME:-$HOME/.codex}"
+STANDALONE_ROOT="$CODEX_HOME_DIR/packages/standalone"
+[ "${CODEX_NON_INTERACTIVE:-}" = "1" ] || exit 81
+printf '%s\n' "$*" >"$TEST_CASE_DIR/installer-args"
+touch "$TEST_CASE_DIR/installer-ran"
+INSTALLER
+EOF
+
+  chmod +x "$directory/uname" "$directory/lockf" "$directory/curl"
+}
+
+case_dir="$temporary/success"
+tools="$case_dir/tools"
+mkdir -p "$case_dir/home/.codex/packages/standalone"
+touch "$case_dir/home/.codex/packages/standalone/install.lock"
+make_fake_tools "$tools"
+TEST_CASE_DIR="$case_dir" \
+  HOME="$case_dir/home" \
+  PATH="$tools:/usr/bin:/bin" \
+  "$helper" --release 1.2.3
+[[ -e "$case_dir/installer-ran" ]]
+[[ "$(<"$case_dir/url")" == "https://chatgpt.com/codex/install.sh" ]]
+[[ "$(<"$case_dir/installer-args")" == "--release 1.2.3" ]]
+
+case_dir="$temporary/locked-file"
+tools="$case_dir/tools"
+mkdir -p "$case_dir/home/.codex/packages/standalone"
+touch "$case_dir/home/.codex/packages/standalone/install.lock"
+make_fake_tools "$tools"
+set +e
+TEST_CASE_DIR="$case_dir" \
+  TEST_LOCK_STATUS=75 \
+  HOME="$case_dir/home" \
+  PATH="$tools:/usr/bin:/bin" \
+  "$helper" >"$case_dir/stdout" 2>"$case_dir/stderr"
+status=$?
+set -e
+[[ $status -eq 75 ]]
+[[ ! -e "$case_dir/curl-ran" ]]
+grep -F "installer lock is active" "$case_dir/stderr" >/dev/null
+
+case_dir="$temporary/locked-directory"
+tools="$case_dir/tools"
+mkdir -p "$case_dir/home/.codex/packages/standalone/install.lock.d"
+make_fake_tools "$tools"
+set +e
+TEST_CASE_DIR="$case_dir" \
+  HOME="$case_dir/home" \
+  PATH="$tools:/usr/bin:/bin" \
+  "$helper" >"$case_dir/stdout" 2>"$case_dir/stderr"
+status=$?
+set -e
+[[ $status -eq 75 ]]
+[[ ! -e "$case_dir/curl-ran" ]]
+grep -F "installer lock is active" "$case_dir/stderr" >/dev/null
+
+grep -F "codex-standalone-install" "$update_functions" >/dev/null
+if grep -E 'brew upgrade --cask codex|npm-global-update-all-nodenv|@openai/codex' \
+  "$update_functions" >/dev/null; then
+  printf 'legacy Codex updater remains in update.zsh\n' >&2
+  exit 1
+fi
+
+printf 'codex standalone installer tests passed\n'

--- a/tests/codex-wrapper-test.sh
+++ b/tests/codex-wrapper-test.sh
@@ -61,6 +61,37 @@ output="$(env -u GITHUB_PAT_TOKEN PATH="$long_path" "$symlink_dir/codex" --versi
 [[ "$output" == *"version:--version"* ]]
 [[ "$output" == *"token:injected"* ]]
 
+darwin_home="$temporary/darwin-home"
+mkdir -p "$darwin_home/.codex/packages/standalone/current/bin"
+cat >"$darwin_home/.codex/packages/standalone/current/bin/codex" <<'EOF'
+#!/usr/bin/env bash
+printf 'standalone:%s\n' "$*"
+EOF
+chmod +x "$darwin_home/.codex/packages/standalone/current/bin/codex"
+cat >"$backend_dir/uname" <<'EOF'
+#!/usr/bin/env bash
+printf 'Darwin\n'
+EOF
+darwin_output="$(
+  GITHUB_PAT_TOKEN=test HOME="$darwin_home" PATH="$long_path" \
+    "$symlink_dir/codex" run "two words"
+)"
+[[ "$darwin_output" == "standalone:run two words" ]]
+
+missing_home="$temporary/darwin-missing"
+mkdir -p "$missing_home"
+set +e
+GITHUB_PAT_TOKEN=test HOME="$missing_home" PATH="$long_path" \
+  "$symlink_dir/codex" --version \
+  >"$temporary/darwin-missing.stdout" 2>"$temporary/darwin-missing.stderr"
+missing_status=$?
+set -e
+[[ $missing_status -eq 127 ]]
+[[ ! -s "$temporary/darwin-missing.stdout" ]]
+grep -Fx \
+  "codex: official standalone CLI is missing; run codex-standalone-install" \
+  "$temporary/darwin-missing.stderr" >/dev/null
+
 linux_home="$temporary/linux-home"
 mkdir -p "$linux_home/.codex/packages/standalone/current/bin"
 cat >"$linux_home/.codex/packages/standalone/current/bin/codex" <<'EOF'


### PR DESCRIPTION
## Summary

- install and select the official standalone Codex CLI on macOS
- remove the Homebrew cask from the update path
- fail closed when the standalone launcher is unavailable

## Validation

- `tests/codex-wrapper-test.sh`
- `tests/codex-standalone-install-test.sh`
- `git diff --check origin/master...HEAD`
