### PR TITLE
fix(gwt): make help side effect free

### DIFF
--- a/functions/gwt/README.md
+++ b/functions/gwt/README.md
@@ -19,6 +19,7 @@ Key responsibilities:
 - sparse-checkout profile application
 - shared `node_modules` bootstrap for pnpm repos
 - pretty/default worktree listing with `--raw`, `--plain`, `--color`, and `--no-color`
+- metadata-immutable `-h`/`--help` handling before repository probes or command dispatch
 - unified worktree discovery across:
   - the current repository's registered Git worktrees
 - agent worktree cleanup front doors

--- a/functions/gwt/gwt.zsh
+++ b/functions/gwt/gwt.zsh
@@ -980,18 +980,8 @@ _gwt_tmux_sync_context() {
     tt sync >/dev/null 2>&1 || true
 }
 
-_gwt_sparse_register_shell_hook
-
-# gwt: opinionated wrapper around `git worktree`.
-# oh-my-zsh git plugin defines `gwt` alias; remove it so the function can load cleanly.
-unalias gwt 2>/dev/null
-gwt() {
-    local subcommand="$1"
-    shift || true
-
-    case "$subcommand" in
-        ""|help|-h|--help)
-            cat <<'EOF'
+_gwt_print_help() {
+    cat <<'EOF'
 Usage: gwt <command> [args]
 
 Commands:
@@ -1014,7 +1004,35 @@ Commands:
 Env:
   DOTFILES_GWT_LINK_DEEP_NODE_MODULES=1  Also link nested workspace node_modules trees
 EOF
+}
+
+_gwt_sparse_register_shell_hook
+
+# gwt: opinionated wrapper around `git worktree`.
+# oh-my-zsh git plugin defines `gwt` alias; remove it so the function can load cleanly.
+unalias gwt 2>/dev/null
+gwt() {
+    local subcommand="${1:-}"
+    local help_arg
+    (( $# > 0 )) && shift
+
+    case "$subcommand" in
+        ""|help|-h|--help)
+            _gwt_print_help
+            return 0
             ;;
+    esac
+
+    for help_arg in "$@"; do
+        case "$help_arg" in
+            -h|--help)
+                _gwt_print_help
+                return 0
+                ;;
+        esac
+    done
+
+    case "$subcommand" in
         root)
             printf '%s\n' "${DOTFILES_WORKTREES_ROOT:-$HOME/.codex/worktrees}"
             ;;

--- a/tests/gwt-help-test.zsh
+++ b/tests/gwt-help-test.zsh
@@ -1,0 +1,170 @@
+#!/usr/bin/env zsh
+set -euo pipefail
+
+root="${0:A:h:h}"
+temporary="$(mktemp -d)"
+trap 'rm -rf "$temporary"' EXIT
+
+home="$temporary/home"
+repo="$temporary/repo"
+fixture="$temporary/gwt-fixture"
+gwt_source="$fixture/functions/gwt/gwt.zsh"
+maintainer="$fixture/bin/agent-worktree-ops/agent-worktree-maintain"
+fake_bin="$temporary/bin"
+mkdir -p "$home" "$repo" "${gwt_source:h}" "${maintainer:h}" "$fake_bin"
+cp "$root/functions/gwt/gwt.zsh" "$gwt_source"
+
+cat >"$maintainer" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >>"$TEST_MAINTAIN_LOG"
+EOF
+chmod +x "$maintainer"
+
+real_git="$(command -v git)"
+export TEST_REAL_GIT="$real_git"
+export TEST_GIT_LOG="$temporary/git.log"
+export TEST_MAINTAIN_LOG="$temporary/maintain.log"
+export TEST_TT_LOG="$temporary/tt.log"
+cat >"$fake_bin/git" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >>"$TEST_GIT_LOG"
+exec "$TEST_REAL_GIT" "$@"
+EOF
+cat >"$fake_bin/tt" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >>"$TEST_TT_LOG"
+EOF
+chmod +x "$fake_bin/git" "$fake_bin/tt"
+
+git init -b main "$repo" >/dev/null
+git -C "$repo" config user.name "GWT Help Test"
+git -C "$repo" config user.email "gwt-help@example.test"
+print fixture >"$repo/README.md"
+git -C "$repo" add README.md
+git -C "$repo" commit -m fixture >/dev/null
+
+tree_snapshot() {
+  python3 - "$1" <<'PY'
+import hashlib
+import json
+import os
+import stat
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+snapshot = {}
+for path in [root, *sorted(root.rglob("*"))]:
+    details = path.lstat()
+    if path.is_symlink():
+        kind = "symlink"
+        content = os.readlink(path).encode()
+    elif path.is_dir():
+        kind = "directory"
+        content = b""
+    else:
+        kind = "file"
+        content = path.read_bytes()
+    relative = "." if path == root else str(path.relative_to(root))
+    snapshot[relative] = {
+        "type": kind,
+        "mode": stat.S_IMODE(details.st_mode),
+        "size": details.st_size,
+        "mtime_ns": details.st_mtime_ns,
+        "sha256": hashlib.sha256(content).hexdigest(),
+    }
+print(json.dumps(snapshot, sort_keys=True, separators=(",", ":")))
+PY
+}
+
+typeset -a cases
+cases=(
+  'empty|'
+  'help|help'
+  'top-short|-h'
+  'top-long|--help'
+  'help-short|help -h'
+  'help-long|help --help'
+  'help-help|help help'
+  'root|root --help'
+  'clone|clone https://example.invalid/repo.git clone-dest --help'
+  'ls|ls --help'
+  'list-alias|list -h'
+  'audit|audit --help'
+  'clean|clean -h'
+  'new|new help-branch --help'
+  'add-alias|add help-branch -h'
+  'cd|cd remove-me --help'
+  'rm|rm remove-me -h'
+  'remove-alias|remove remove-me --help'
+  'prune|prune -h'
+  'sparse|sparse --help'
+  'sparse-status|sparse status --help'
+  'sparse-show-alias|sparse show -h'
+  'sparse-list|sparse list --help'
+  'sparse-profiles-alias|sparse profiles -h'
+  'sparse-set|sparse set profile --help'
+  'sparse-add|sparse add path -h'
+  'sparse-expand-alias|sparse expand path --help'
+  'sparse-full|sparse full --help'
+  'sparse-disable-alias|sparse disable -h'
+)
+
+repo_before="$(tree_snapshot "$repo")"
+home_before="$(tree_snapshot "$home")"
+reference_output="$temporary/reference.out"
+for test_case in "${cases[@]}"; do
+  label="${test_case%%|*}"
+  invocation="${test_case#*|}"
+  output="$temporary/$label.out"
+
+  PATH="$fake_bin:$PATH" \
+  HOME="$home" \
+  TMUX=test \
+  zsh -f -c '
+    source "$1"
+    cd "$2"
+    before="$PWD"
+    gwt ${(z)3}
+    [[ "$PWD" == "$before" ]]
+  ' zsh "$gwt_source" "$repo" "$invocation" >"$output"
+
+  grep -Fq 'Usage: gwt <command> [args]' "$output"
+  if [[ -e "$reference_output" ]]; then
+    cmp -s "$reference_output" "$output"
+  else
+    cp "$output" "$reference_output"
+  fi
+  [[ "$repo_before" == "$(tree_snapshot "$repo")" ]]
+  [[ "$home_before" == "$(tree_snapshot "$home")" ]]
+  [[ ! -e "$TEST_GIT_LOG" ]]
+  [[ ! -e "$TEST_MAINTAIN_LOG" ]]
+  [[ ! -e "$TEST_TT_LOG" ]]
+done
+
+if PATH="$fake_bin:$PATH" \
+  HOME="$home" \
+  TMUX=test \
+  zsh -f -c '
+    source "$1"
+    cd "$2"
+    before="$PWD"
+    if gwt unknown-command; then
+      exit 1
+    fi
+    [[ "$PWD" == "$before" ]]
+  ' zsh "$gwt_source" "$repo" >"$temporary/unknown.out" 2>&1; then
+  :
+else
+  print -u2 'unknown command compatibility check failed'
+  exit 1
+fi
+grep -Fxq "gwt: unknown command 'unknown-command' (run 'gwt help')" \
+  "$temporary/unknown.out"
+grep -Fxq 'rev-parse --is-inside-work-tree' "$TEST_GIT_LOG"
+[[ "$repo_before" == "$(tree_snapshot "$repo")" ]]
+[[ "$home_before" == "$(tree_snapshot "$home")" ]]
+[[ ! -e "$TEST_MAINTAIN_LOG" ]]
+[[ ! -e "$TEST_TT_LOG" ]]
+
+print 'gwt help tests passed'


### PR DESCRIPTION
## Summary

- intercept `-h` and `--help` before any GWT command dispatch
- keep bare and top-level help compatible while preventing accidental worktree, maintenance, prune, or sparse mutations
- add table-driven purity coverage for commands, aliases, and nested sparse operations

## Validation

- `zsh -n functions/gwt/gwt.zsh tests/gwt-help-test.zsh tests/gwt-cleanup-test.zsh tests/functions-authority-test.zsh`
- `zsh tests/gwt-help-test.zsh`
- `zsh tests/gwt-cleanup-test.zsh`
- `zsh tests/functions-authority-test.zsh`
- `git diff --check`
- independent exact-head review
