### PR TITLE
feat(worktrees): add fail-closed external storage

### DIFF
--- a/bin/agent-worktree-ops/README.md
+++ b/bin/agent-worktree-ops/README.md
@@ -4,6 +4,17 @@ Agent worktree cleanup and maintenance tools.
 
 Bins in this folder:
 
+- `worktree-storage-guard`
+  - reads the private runtime contract
+    `external-worktree-storage.v1`
+  - treats a missing contract as an unconfigured host, but fails closed once a
+    valid required contract is installed
+  - requires the exact UUID to be mounted directly at canonical
+    `~/.codex/worktrees` as encrypted, case-insensitive APFS with ownership
+    enabled and a user-owned mode-0700 mounted root
+  - rejects symlinked mountpoints or parent components, wrong UUID/filesystem,
+    writable internal fallback, and hot disappearance
+  - when absent, the underlying mountpoint must remain `root:wheel` mode `0000`
 - `agent-worktree-clean`
   - dry-run/apply cleanup of idle worktrees and stale artifacts
   - only registered, non-main worktrees from the selected Git common dir are actionable
@@ -38,6 +49,8 @@ Bins in this folder:
   - apply mode revalidates dirtiness, reachability, sessions, tmux panes, and process CWDs
   - removals are serial, non-force `git worktree remove` operations
   - apply exits nonzero when a selected trim or removal fails
+  - validates required external storage before inventory and again before every
+    trim/removal mutation
   - pass `--skip-legacy-purge` to leave legacy quarantine cleanup to a separate job
 - `agent-worktree-maintain`
   - pressure-aware maintenance runner using the cleaner's registered inventory
@@ -50,10 +63,11 @@ Bins in this folder:
     untrusted lock state exits with status 73
   - pass `--skip-legacy-purge` to forward the cleaner's purge opt-out
   - pass `--no-log` to emit output for ephemeral capture without creating a log
+  - validates required external storage before creating locks, logs, or state
 - `agent-worktree-purge`
   - background purge of entries left in the legacy quarantine directory
 - `install-agent-worktree-ops`
-  - atomically installs runtime copies only
+  - atomically installs runtime copies, including the storage guard, only
   - never creates, loads, unloads, enables, disables, or removes a LaunchAgent
   - accepts legacy `--install-only` as an alias for the runtime-only default
 - `retire-agent-worktree-scheduler`
@@ -72,5 +86,6 @@ Bins in this folder:
     labels disabled with no matching jobs loaded
   - never removes runtime directories, logs, history, or iCloud/Mackup residue
 
-Neither audit nor apply mode prunes Git worktree metadata. Use explicit
-`git worktree prune` or `gwt prune` only after reviewing stale registrations.
+Neither audit nor apply mode prunes Git worktree metadata. Use guarded
+`gwt prune` only after reviewing stale registrations. Raw `git worktree prune`
+is unsafe while required storage is absent.

--- a/bin/agent-worktree-ops/README.md
+++ b/bin/agent-worktree-ops/README.md
@@ -5,13 +5,18 @@ Agent worktree cleanup and maintenance tools.
 Bins in this folder:
 
 - `worktree-storage-guard`
-  - reads the private runtime contract
+  - reads the private system policy
     `external-worktree-storage.v1`
-  - treats a missing contract as an unconfigured host, but fails closed once a
-    valid required contract is installed
+  - reads the root-owned, non-writable policy at
+    `/Library/Application Support/agent-worktree-ops/external-worktree-storage.json`
+  - treats a missing contract as unconfigured only when the canonical path has
+    neither a direct mount nor the sealed `root:wheel` mode-0000 backing directory
   - requires the exact UUID to be mounted directly at canonical
     `~/.codex/worktrees` as encrypted, case-insensitive APFS with ownership
     enabled and a user-owned mode-0700 mounted root
+  - requires at least 200 GiB and 10% free, an exact host marker, external-device
+    location, disabled Spotlight indexing, and a UUID-tracked Time Machine volume
+    exclusion verified with `tmutil isexcluded`
   - rejects symlinked mountpoints or parent components, wrong UUID/filesystem,
     writable internal fallback, and hot disappearance
   - when absent, the underlying mountpoint must remain `root:wheel` mode `0000`

--- a/bin/agent-worktree-ops/agent-worktree-clean
+++ b/bin/agent-worktree-ops/agent-worktree-clean
@@ -30,6 +30,9 @@ DEFAULT_MIN_AGE_DAYS = 2
 DEFAULT_TRIM_ARTIFACTS_AGE_DAYS = 0.25
 DEFAULT_CODEX_HOME = os.environ.get("CODEX_HOME", str(Path.home() / ".codex"))
 DEFAULT_QUARANTINE_ROOT = os.path.join(DEFAULT_CODEX_HOME, "quarantine", "worktrees")
+DEFAULT_STORAGE_GUARD = os.path.join(
+    os.path.dirname(os.path.realpath(__file__)), "worktree-storage-guard"
+)
 STATE_READER_MAX_BYTES = 8 * 1024 * 1024
 STATE_READER_SOURCE_MAX_BYTES = 2 * 1024 * 1024
 MACHINE_CHILD_TIMEOUT_SECONDS = 30.0
@@ -651,6 +654,7 @@ def main() -> int:
 
 
 def run_cleaner(args: argparse.Namespace) -> int:
+    require_worktree_storage()
     repo_root = normalize_path(resolve_repo_root(args.repo))
     codex_home = normalize_path(args.codex_home)
     quarantine_root = normalize_path(args.quarantine_root)
@@ -769,6 +773,7 @@ def run_cleaner(args: argparse.Namespace) -> int:
     if not args.apply:
         return 0
 
+    require_worktree_storage()
     failed_mutations = apply_trims(
         repo_root=repo_root,
         codex_home=codex_home,
@@ -804,6 +809,22 @@ def resolve_repo_root(repo: Optional[str]) -> str:
     if repo:
         return repo
     return run_text(["git", "rev-parse", "--show-toplevel"])
+
+
+def require_worktree_storage() -> None:
+    guard = os.environ.get("WORKTREE_STORAGE_GUARD", DEFAULT_STORAGE_GUARD)
+    result = subprocess.run(
+        [guard],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            result.stderr.strip()
+            or f"worktree storage guard failed with status {result.returncode}"
+        )
 
 
 def normalize_path(raw_path: str) -> str:
@@ -2050,6 +2071,7 @@ def apply_trims(
     failed_mutations = 0
     with progress_bar(total=len(candidates), desc="trimming artifacts") as progress:
         for candidate in candidates:
+            require_worktree_storage()
             reason = revalidate_candidate(
                 repo_root=repo_root,
                 codex_home=codex_home,
@@ -2080,6 +2102,7 @@ def apply_removals(
     failed_mutations = 0
     with progress_bar(total=len(candidates), desc="removing worktrees") as progress:
         for candidate in candidates:
+            require_worktree_storage()
             reason = revalidate_candidate(
                 repo_root=repo_root,
                 codex_home=codex_home,

--- a/bin/agent-worktree-ops/agent-worktree-maintain
+++ b/bin/agent-worktree-ops/agent-worktree-maintain
@@ -9,6 +9,7 @@ export GIT_CONFIG_GLOBAL="${GIT_CONFIG_GLOBAL:-/dev/null}"
 DEFAULT_REPO="$HOME/GIT/_Perso/openclaw"
 DEFAULT_CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 DEFAULT_CLEANER="$SCRIPT_DIR/agent-worktree-clean"
+DEFAULT_STORAGE_GUARD="$SCRIPT_DIR/worktree-storage-guard"
 DEFAULT_SESSION_LIMIT=30
 DEFAULT_MIN_AGE_DAYS=2
 DEFAULT_TRIM_ARTIFACTS_AGE_DAYS=0.25
@@ -494,6 +495,11 @@ EOF
       ;;
   esac
 done
+
+"$DEFAULT_STORAGE_GUARD" || {
+  echo "agent-worktree-maintain: required worktree storage is unavailable" >&2
+  exit 78
+}
 
 if (( state_dir_explicit == 0 )); then
   state_dir="$codex_home"

--- a/bin/agent-worktree-ops/install-agent-worktree-ops
+++ b/bin/agent-worktree-ops/install-agent-worktree-ops
@@ -49,5 +49,6 @@ install_atomic "$DOTFILES_DIR/bin/agent-worktree-ops/agent-worktree-clean" "$RUN
 install_atomic "$DOTFILES_DIR/bin/agent-worktree-ops/agent-worktree-maintain" "$RUNTIME_DIR/agent-worktree-maintain"
 install_atomic "$DOTFILES_DIR/bin/agent-worktree-ops/agent-worktree-purge" "$RUNTIME_DIR/agent-worktree-purge"
 install_atomic "$DOTFILES_DIR/bin/agent-worktree-ops/retire-agent-worktree-scheduler" "$RUNTIME_DIR/retire-agent-worktree-scheduler"
+install_atomic "$DOTFILES_DIR/bin/agent-worktree-ops/worktree-storage-guard" "$RUNTIME_DIR/worktree-storage-guard"
 
 printf 'agent-worktree-ops runtime installed; scheduler state unchanged\n'

--- a/bin/agent-worktree-ops/worktree-storage-guard
+++ b/bin/agent-worktree-ops/worktree-storage-guard
@@ -17,12 +17,13 @@ from typing import Any
 
 SCHEMA = "external-worktree-storage.v1"
 DEFAULT_CONFIG = (
-    pathlib.Path.home()
-    / "Library"
-    / "Application Support"
+    pathlib.Path("/Library/Application Support")
     / "agent-worktree-ops"
     / "external-worktree-storage.json"
 )
+MARKER_NAME = ".external-worktree-storage-marker"
+REQUIRED_MINIMUM_FREE_GIB = 200
+REQUIRED_MINIMUM_FREE_PERCENT = 10
 UUID_RE = re.compile(
     r"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-"
     r"[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
@@ -46,29 +47,48 @@ def path_has_no_symlink_components(path: pathlib.Path) -> bool:
     return True
 
 
-def load_config(path: pathlib.Path) -> dict[str, Any] | None:
-    if not path.exists():
+def load_config(
+    path: pathlib.Path, *, production_default: bool
+) -> dict[str, Any] | None:
+    if not path.exists() and not path.is_symlink():
         return None
     if not path_has_no_symlink_components(path):
         raise GuardError(f"runtime config has a symlinked component: {path}")
     if path.is_symlink() or not path.is_file():
         raise GuardError(f"runtime config is not a regular file: {path}")
     metadata = path.stat()
-    if metadata.st_uid != os.getuid():
+    expected_uid = 0 if production_default else os.getuid()
+    if metadata.st_uid != expected_uid:
         raise GuardError(f"runtime config has the wrong owner: {path}")
     if metadata.st_nlink != 1 or stat.S_IMODE(metadata.st_mode) & 0o022:
         raise GuardError(f"runtime config permissions are unsafe: {path}")
+    if production_default:
+        parent = path.parent.stat()
+        if (
+            path.parent.is_symlink()
+            or parent.st_uid != 0
+            or stat.S_IMODE(parent.st_mode) & 0o022
+        ):
+            raise GuardError(f"runtime config directory is unsafe: {path.parent}")
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as error:
         raise GuardError(f"runtime config is unreadable: {error}") from error
     expected_keys = {
         "case_sensitive",
+        "backing_directory_mode",
+        "device_location",
         "encrypted",
         "filesystem",
+        "marker_id",
+        "minimum_free_gib",
+        "minimum_free_percent",
         "mount_point",
+        "owners",
         "required",
         "schema_version",
+        "spotlight",
+        "time_machine_excluded",
         "volume_uuid",
     }
     if not isinstance(value, dict) or set(value) != expected_keys:
@@ -79,6 +99,15 @@ def load_config(path: pathlib.Path) -> dict[str, Any] | None:
         or value.get("filesystem") != "apfs"
         or value.get("encrypted") is not True
         or value.get("case_sensitive") is not False
+        or value.get("owners") is not True
+        or value.get("device_location") != "External"
+        or value.get("backing_directory_mode") != "0000"
+        or value.get("spotlight") != "disabled"
+        or value.get("time_machine_excluded") is not True
+        or value.get("minimum_free_gib") != REQUIRED_MINIMUM_FREE_GIB
+        or value.get("minimum_free_percent") != REQUIRED_MINIMUM_FREE_PERCENT
+        or not isinstance(value.get("marker_id"), str)
+        or not value["marker_id"]
         or not isinstance(value.get("volume_uuid"), str)
         or UUID_RE.fullmatch(value["volume_uuid"]) is None
     ):
@@ -100,6 +129,37 @@ def test_observation() -> dict[str, Any] | None:
     if not isinstance(value, dict):
         raise GuardError("test observation is invalid")
     return value
+
+
+def run_text(command: list[str]) -> tuple[int, str]:
+    try:
+        result = subprocess.run(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return 1, ""
+    return result.returncode, result.stdout.strip()
+
+
+def read_marker(mount_point: pathlib.Path) -> str | None:
+    marker = mount_point / MARKER_NAME
+    try:
+        metadata = os.lstat(marker)
+        if (
+            stat.S_ISLNK(metadata.st_mode)
+            or not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+            or metadata.st_uid != os.getuid()
+            or stat.S_IMODE(metadata.st_mode) & 0o022
+        ):
+            return None
+        return marker.read_text(encoding="utf-8").strip()
+    except (FileNotFoundError, OSError, UnicodeDecodeError):
+        return None
 
 
 def live_observation(mount_point: pathlib.Path) -> dict[str, Any]:
@@ -130,12 +190,21 @@ def live_observation(mount_point: pathlib.Path) -> dict[str, Any]:
     except FileNotFoundError:
         pass
     free_gib = None
+    free_percent = None
     if mounted:
         try:
             filesystem = os.statvfs(mount_point)
             free_gib = (filesystem.f_bavail * filesystem.f_frsize) // (1024**3)
+            if filesystem.f_blocks:
+                free_percent = filesystem.f_bavail * 100.0 / filesystem.f_blocks
         except OSError:
             pass
+    spotlight_code, spotlight_output = run_text(
+        ["/usr/bin/mdutil", "-s", str(mount_point)]
+    )
+    excluded_code, excluded_output = run_text(
+        ["/usr/bin/tmutil", "isexcluded", str(mount_point)]
+    )
     personality = str(
         disk.get("FileSystemPersonality")
         or disk.get("FilesystemName")
@@ -148,8 +217,20 @@ def live_observation(mount_point: pathlib.Path) -> dict[str, Any]:
         "filesystem": "apfs" if "apfs" in personality.casefold() else personality.casefold(),
         "encrypted": disk.get("Encrypted") is True,
         "free_gib": free_gib,
+        "free_percent": free_percent,
         "case_sensitive": "case-sensitive" in personality.casefold(),
         "ownership_enabled": disk.get("GlobalPermissionsEnabled") is True,
+        "device_location": disk.get("DeviceLocation"),
+        "marker_id": read_marker(mount_point) if mounted else None,
+        "spotlight": (
+            "disabled"
+            if spotlight_code == 0 and "indexing disabled" in spotlight_output.casefold()
+            else "enabled_or_unknown"
+        ),
+        "time_machine_excluded": (
+            excluded_code == 0
+            and "[excluded]" in excluded_output.casefold()
+        ),
         "owner_uid": metadata.st_uid if metadata else None,
         "owner_gid": metadata.st_gid if metadata else None,
         "mode": format(stat.S_IMODE(metadata.st_mode), "04o") if metadata else None,
@@ -158,15 +239,36 @@ def live_observation(mount_point: pathlib.Path) -> dict[str, Any]:
     }
 
 
-def require_fallback_closed(observed: dict[str, Any]) -> None:
+def fallback_is_sealed(observed: dict[str, Any]) -> bool:
     try:
         wheel_gid = grp.getgrnam("wheel").gr_gid
     except KeyError:
         wheel_gid = 0
+    return (
+        observed.get("owner_uid") == 0
+        and observed.get("owner_gid") == wheel_gid
+        and observed.get("mode") in ("0000", "000")
+    )
+
+
+def direct_mount_is_present(
+    mount_point: pathlib.Path, observed: dict[str, Any]
+) -> bool:
+    return (
+        observed.get("mounted") is True
+        and observed.get("mount_point") == str(mount_point)
+        and observed.get("device") is not None
+        and observed.get("parent_device") is not None
+        and observed.get("device") != observed.get("parent_device")
+    )
+
+
+def require_fallback_closed(
+    config: dict[str, Any], observed: dict[str, Any]
+) -> None:
     if (
-        observed.get("owner_uid") != 0
-        or observed.get("owner_gid") != wheel_gid
-        or observed.get("mode") not in ("0000", "000")
+        config.get("backing_directory_mode") != "0000"
+        or not fallback_is_sealed(observed)
     ):
         raise GuardError("required storage is absent and the internal fallback is writable")
     raise GuardError("required external worktree storage is not mounted")
@@ -181,7 +283,7 @@ def validate_observation(
     if os.path.realpath(mount_point) != str(mount_point):
         raise GuardError(f"mount point resolves outside its canonical path: {mount_point}")
     if observed.get("mounted") is not True:
-        require_fallback_closed(observed)
+        require_fallback_closed(config, observed)
     if observed.get("mount_point") != str(mount_point):
         raise GuardError("external volume is mounted at the wrong path")
     if str(observed.get("volume_uuid") or "").casefold() != config["volume_uuid"].casefold():
@@ -194,6 +296,8 @@ def validate_observation(
         raise GuardError("mounted external volume must be case-insensitive")
     if observed.get("ownership_enabled") is not True:
         raise GuardError("mounted external volume ownership is disabled")
+    if observed.get("device_location") != config["device_location"]:
+        raise GuardError("mounted worktree volume is not an external device")
     if observed.get("owner_uid") != os.getuid():
         raise GuardError("mounted external volume has the wrong owner")
     if observed.get("mode") not in ("0700", "700"):
@@ -202,6 +306,21 @@ def validate_observation(
     parent_device = observed.get("parent_device")
     if device is None or parent_device is None or device == parent_device:
         raise GuardError("canonical path is not a direct filesystem mount")
+    if observed.get("marker_id") != config["marker_id"]:
+        raise GuardError("mounted worktree volume marker does not match policy")
+    if observed.get("spotlight") != config["spotlight"]:
+        raise GuardError("Spotlight indexing is not disabled on the worktree volume")
+    if observed.get("time_machine_excluded") is not True:
+        raise GuardError("worktree volume lacks a persistent Time Machine exclusion")
+    free_gib = observed.get("free_gib")
+    if not isinstance(free_gib, (int, float)) or free_gib < config["minimum_free_gib"]:
+        raise GuardError("worktree volume free space is below minimum_free_gib")
+    free_percent = observed.get("free_percent")
+    if (
+        not isinstance(free_percent, (int, float))
+        or free_percent < config["minimum_free_percent"]
+    ):
+        raise GuardError("worktree volume free space is below minimum_free_percent")
     return mount_point
 
 
@@ -218,10 +337,28 @@ def main() -> int:
     args = parse_args()
     config_path = pathlib.Path(args.config).expanduser() if args.config else DEFAULT_CONFIG
     try:
-        config = load_config(config_path)
+        if args.config and os.environ.get("WORKTREE_STORAGE_GUARD_TESTING") != "1":
+            raise GuardError("runtime config override requires guard test mode")
+        config_error = None
+        try:
+            config = load_config(config_path, production_default=args.config is None)
+        except GuardError as error:
+            config = None
+            config_error = error
         if config is None:
+            canonical = pathlib.Path.home() / ".codex" / "worktrees"
+            observed = test_observation() or live_observation(canonical)
+            managed_state = (
+                not path_has_no_symlink_components(canonical)
+                or fallback_is_sealed(observed)
+                or direct_mount_is_present(canonical, observed)
+            )
+            if managed_state:
+                raise GuardError(f"required config missing or invalid: {config_path}")
+            if config_error is not None:
+                raise config_error
             if args.require_config:
-                raise GuardError(f"external worktree storage is not configured: {config_path}")
+                raise GuardError(f"required config missing: {config_path}")
             if args.json:
                 print(json.dumps({"configured": False, "schema_version": SCHEMA}, sort_keys=True))
             return 0
@@ -234,9 +371,18 @@ def main() -> int:
                 json.dumps(
                     {
                         "configured": True,
+                        "backing_directory_mode": config["backing_directory_mode"],
+                        "device_location": observed.get("device_location"),
                         "free_gib": observed.get("free_gib"),
+                        "free_percent": observed.get("free_percent"),
+                        "marker_id": observed.get("marker_id"),
+                        "minimum_free_gib": config["minimum_free_gib"],
+                        "minimum_free_percent": config["minimum_free_percent"],
                         "mount_point": str(mount_point),
+                        "owners": observed.get("ownership_enabled"),
                         "schema_version": SCHEMA,
+                        "spotlight": observed.get("spotlight"),
+                        "time_machine_excluded": observed.get("time_machine_excluded"),
                         "volume_uuid": config["volume_uuid"],
                     },
                     sort_keys=True,

--- a/bin/agent-worktree-ops/worktree-storage-guard
+++ b/bin/agent-worktree-ops/worktree-storage-guard
@@ -22,6 +22,9 @@ DEFAULT_CONFIG = (
     / "external-worktree-storage.json"
 )
 MARKER_NAME = ".external-worktree-storage-marker"
+PHYSICAL_EXTERNAL_BUS_PROTOCOLS = frozenset(
+    {"FireWire", "NVMe", "SATA", "SCSI", "Thunderbolt", "USB"}
+)
 REQUIRED_MINIMUM_FREE_GIB = 200
 REQUIRED_MINIMUM_FREE_PERCENT = 10
 UUID_RE = re.compile(
@@ -162,6 +165,24 @@ def read_marker(mount_point: pathlib.Path) -> str | None:
         return None
 
 
+def normalized_device_location(disk: dict[str, Any]) -> str | None:
+    if (
+        disk.get("Internal") is False
+        and disk.get("RemovableMediaOrExternalDevice") is True
+        and disk.get("BusProtocol") in PHYSICAL_EXTERNAL_BUS_PROTOCOLS
+    ):
+        return "External"
+    return None
+
+
+def normalized_encryption(disk: dict[str, Any]) -> bool | None:
+    encryption = disk.get("Encryption")
+    if isinstance(encryption, bool):
+        return encryption
+    legacy = disk.get("Encrypted")
+    return legacy if isinstance(legacy, bool) else None
+
+
 def live_observation(mount_point: pathlib.Path) -> dict[str, Any]:
     try:
         result = subprocess.run(
@@ -215,12 +236,12 @@ def live_observation(mount_point: pathlib.Path) -> dict[str, Any]:
         "mount_point": disk.get("MountPoint"),
         "volume_uuid": disk.get("VolumeUUID"),
         "filesystem": "apfs" if "apfs" in personality.casefold() else personality.casefold(),
-        "encrypted": disk.get("Encrypted") is True,
+        "encrypted": normalized_encryption(disk) is True,
         "free_gib": free_gib,
         "free_percent": free_percent,
         "case_sensitive": "case-sensitive" in personality.casefold(),
         "ownership_enabled": disk.get("GlobalPermissionsEnabled") is True,
-        "device_location": disk.get("DeviceLocation"),
+        "device_location": normalized_device_location(disk),
         "marker_id": read_marker(mount_point) if mounted else None,
         "spotlight": (
             "disabled"

--- a/bin/agent-worktree-ops/worktree-storage-guard
+++ b/bin/agent-worktree-ops/worktree-storage-guard
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import grp
+import json
+import os
+import pathlib
+import plistlib
+import re
+import stat
+import subprocess
+import sys
+from typing import Any
+
+
+SCHEMA = "external-worktree-storage.v1"
+DEFAULT_CONFIG = (
+    pathlib.Path.home()
+    / "Library"
+    / "Application Support"
+    / "agent-worktree-ops"
+    / "external-worktree-storage.json"
+)
+UUID_RE = re.compile(
+    r"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-"
+    r"[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+)
+
+
+class GuardError(RuntimeError):
+    pass
+
+
+def path_has_no_symlink_components(path: pathlib.Path) -> bool:
+    path = pathlib.Path(os.path.abspath(path))
+    current = pathlib.Path(path.anchor)
+    for component in path.parts[1:]:
+        current /= component
+        try:
+            if stat.S_ISLNK(os.lstat(current).st_mode):
+                return False
+        except FileNotFoundError:
+            continue
+    return True
+
+
+def load_config(path: pathlib.Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    if not path_has_no_symlink_components(path):
+        raise GuardError(f"runtime config has a symlinked component: {path}")
+    if path.is_symlink() or not path.is_file():
+        raise GuardError(f"runtime config is not a regular file: {path}")
+    metadata = path.stat()
+    if metadata.st_uid != os.getuid():
+        raise GuardError(f"runtime config has the wrong owner: {path}")
+    if metadata.st_nlink != 1 or stat.S_IMODE(metadata.st_mode) & 0o022:
+        raise GuardError(f"runtime config permissions are unsafe: {path}")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise GuardError(f"runtime config is unreadable: {error}") from error
+    expected_keys = {
+        "case_sensitive",
+        "encrypted",
+        "filesystem",
+        "mount_point",
+        "required",
+        "schema_version",
+        "volume_uuid",
+    }
+    if not isinstance(value, dict) or set(value) != expected_keys:
+        raise GuardError("runtime config schema is invalid")
+    if (
+        value.get("schema_version") != SCHEMA
+        or value.get("required") is not True
+        or value.get("filesystem") != "apfs"
+        or value.get("encrypted") is not True
+        or value.get("case_sensitive") is not False
+        or not isinstance(value.get("volume_uuid"), str)
+        or UUID_RE.fullmatch(value["volume_uuid"]) is None
+    ):
+        raise GuardError("runtime config policy is incomplete or invalid")
+    canonical = pathlib.Path.home() / ".codex" / "worktrees"
+    mount_point = pathlib.Path(value["mount_point"])
+    if not mount_point.is_absolute() or os.path.normpath(mount_point) != str(canonical):
+        raise GuardError(f"runtime config mount point is not canonical: {mount_point}")
+    return value
+
+
+def test_observation() -> dict[str, Any] | None:
+    if os.environ.get("WORKTREE_STORAGE_GUARD_TESTING") != "1":
+        return None
+    fixture = os.environ.get("WORKTREE_STORAGE_GUARD_OBSERVED")
+    if not fixture:
+        return None
+    value = json.loads(pathlib.Path(fixture).read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise GuardError("test observation is invalid")
+    return value
+
+
+def live_observation(mount_point: pathlib.Path) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            ["/usr/sbin/diskutil", "info", "-plist", str(mount_point)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+    except OSError:
+        result = None
+    disk = {}
+    if result is not None and result.returncode == 0:
+        try:
+            disk = plistlib.loads(result.stdout)
+        except (plistlib.InvalidFileException, ValueError):
+            disk = {}
+    mounted = disk.get("MountPoint") == str(mount_point)
+    metadata = None
+    try:
+        metadata = os.lstat(mount_point)
+    except FileNotFoundError:
+        pass
+    parent_metadata = None
+    try:
+        parent_metadata = os.stat(mount_point.parent)
+    except FileNotFoundError:
+        pass
+    free_gib = None
+    if mounted:
+        try:
+            filesystem = os.statvfs(mount_point)
+            free_gib = (filesystem.f_bavail * filesystem.f_frsize) // (1024**3)
+        except OSError:
+            pass
+    personality = str(
+        disk.get("FileSystemPersonality")
+        or disk.get("FilesystemName")
+        or ""
+    )
+    return {
+        "mounted": mounted,
+        "mount_point": disk.get("MountPoint"),
+        "volume_uuid": disk.get("VolumeUUID"),
+        "filesystem": "apfs" if "apfs" in personality.casefold() else personality.casefold(),
+        "encrypted": disk.get("Encrypted") is True,
+        "free_gib": free_gib,
+        "case_sensitive": "case-sensitive" in personality.casefold(),
+        "ownership_enabled": disk.get("GlobalPermissionsEnabled") is True,
+        "owner_uid": metadata.st_uid if metadata else None,
+        "owner_gid": metadata.st_gid if metadata else None,
+        "mode": format(stat.S_IMODE(metadata.st_mode), "04o") if metadata else None,
+        "device": metadata.st_dev if metadata else None,
+        "parent_device": parent_metadata.st_dev if parent_metadata else None,
+    }
+
+
+def require_fallback_closed(observed: dict[str, Any]) -> None:
+    try:
+        wheel_gid = grp.getgrnam("wheel").gr_gid
+    except KeyError:
+        wheel_gid = 0
+    if (
+        observed.get("owner_uid") != 0
+        or observed.get("owner_gid") != wheel_gid
+        or observed.get("mode") not in ("0000", "000")
+    ):
+        raise GuardError("required storage is absent and the internal fallback is writable")
+    raise GuardError("required external worktree storage is not mounted")
+
+
+def validate_observation(
+    config: dict[str, Any], observed: dict[str, Any]
+) -> pathlib.Path:
+    mount_point = pathlib.Path(config["mount_point"])
+    if not path_has_no_symlink_components(mount_point):
+        raise GuardError(f"mount point has a symlinked component: {mount_point}")
+    if os.path.realpath(mount_point) != str(mount_point):
+        raise GuardError(f"mount point resolves outside its canonical path: {mount_point}")
+    if observed.get("mounted") is not True:
+        require_fallback_closed(observed)
+    if observed.get("mount_point") != str(mount_point):
+        raise GuardError("external volume is mounted at the wrong path")
+    if str(observed.get("volume_uuid") or "").casefold() != config["volume_uuid"].casefold():
+        raise GuardError("mounted external volume UUID does not match policy")
+    if str(observed.get("filesystem") or "").casefold() != "apfs":
+        raise GuardError("mounted external volume is not APFS")
+    if observed.get("encrypted") is not True:
+        raise GuardError("mounted external volume is not encrypted")
+    if observed.get("case_sensitive") is not False:
+        raise GuardError("mounted external volume must be case-insensitive")
+    if observed.get("ownership_enabled") is not True:
+        raise GuardError("mounted external volume ownership is disabled")
+    if observed.get("owner_uid") != os.getuid():
+        raise GuardError("mounted external volume has the wrong owner")
+    if observed.get("mode") not in ("0700", "700"):
+        raise GuardError("mounted external volume root must use mode 0700")
+    device = observed.get("device")
+    parent_device = observed.get("parent_device")
+    if device is None or parent_device is None or device == parent_device:
+        raise GuardError("canonical path is not a direct filesystem mount")
+    return mount_point
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(allow_abbrev=False)
+    parser.add_argument("--config", default=os.environ.get("WORKTREE_STORAGE_CONFIG"))
+    parser.add_argument("--require-config", action="store_true")
+    parser.add_argument("--print-mount-point", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    config_path = pathlib.Path(args.config).expanduser() if args.config else DEFAULT_CONFIG
+    try:
+        config = load_config(config_path)
+        if config is None:
+            if args.require_config:
+                raise GuardError(f"external worktree storage is not configured: {config_path}")
+            if args.json:
+                print(json.dumps({"configured": False, "schema_version": SCHEMA}, sort_keys=True))
+            return 0
+        observed = test_observation() or live_observation(pathlib.Path(config["mount_point"]))
+        mount_point = validate_observation(config, observed)
+        if args.print_mount_point:
+            print(mount_point)
+        elif args.json:
+            print(
+                json.dumps(
+                    {
+                        "configured": True,
+                        "free_gib": observed.get("free_gib"),
+                        "mount_point": str(mount_point),
+                        "schema_version": SCHEMA,
+                        "volume_uuid": config["volume_uuid"],
+                    },
+                    sort_keys=True,
+                )
+            )
+        return 0
+    except (GuardError, OSError, ValueError, json.JSONDecodeError) as error:
+        print(f"worktree-storage-guard: {error}", file=sys.stderr)
+        return 78
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/external-tmp
+++ b/bin/external-tmp
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+umask 077
+
+if (( $# == 0 )); then
+  printf 'Usage: external-tmp <command...>\n' >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+guard="${WORKTREE_STORAGE_GUARD:-$SCRIPT_DIR/agent-worktree-ops/worktree-storage-guard}"
+if [[ ! -x "$guard" ]]; then
+  guard="$HOME/Library/Application Support/agent-worktree-ops/worktree-storage-guard"
+fi
+if [[ ! -x "$guard" ]]; then
+  printf 'external-tmp: worktree storage guard is unavailable\n' >&2
+  exit 127
+fi
+
+mount_point="$("$guard" --require-config --print-mount-point)"
+scratch_root="$mount_point/.scratch/tmp"
+temporary=""
+
+cleanup() {
+  local status=$?
+  trap - EXIT HUP INT TERM
+  if [[ -n "$temporary" && -e "$temporary" ]]; then
+    if "$guard" >/dev/null 2>&1; then
+      /bin/rm -rf -- "$temporary"
+    else
+      printf 'external-tmp: storage disappeared; refusing cleanup fallback: %s\n' \
+        "$temporary" >&2
+    fi
+  fi
+  exit "$status"
+}
+
+trap cleanup EXIT HUP INT TERM
+mkdir -p "$scratch_root"
+chmod 0700 "$mount_point/.scratch" "$scratch_root"
+temporary="$(mktemp -d "$scratch_root/external-tmp.XXXXXX")"
+"$guard"
+
+physical="$(cd "$temporary" && pwd -P)"
+case "$physical/" in
+  "$mount_point/.scratch/tmp/"*) ;;
+  *)
+    printf 'external-tmp: scratch path escaped configured storage: %s\n' "$physical" >&2
+    exit 78
+    ;;
+esac
+
+TMPDIR="$temporary/" TMP="$temporary" TEMP="$temporary" "$@"

--- a/functions/gwt/README.md
+++ b/functions/gwt/README.md
@@ -22,6 +22,22 @@ Key responsibilities:
 - unified worktree discovery across:
   - the current repository's registered Git worktrees
 - agent worktree cleanup front doors
+- fail-closed external worktree storage validation for mutating and audit commands
+
+External storage behavior:
+
+- Configured hosts mount an encrypted, case-insensitive APFS volume directly at
+  canonical `~/.codex/worktrees`; a symlinked `~/.codex/worktrees` is rejected.
+- `gwt new`, `add`, `rm`, `audit`, `clean`, and `prune` stop before worktree
+  access when the configured volume is absent, wrong, or replaced by a writable
+  internal fallback. `gwt root` remains informational.
+- The guard validates both lexical and resolved containment. A worktree on the
+  direct mount still resolves through Git to its canonical owning checkout;
+  physical aliases beneath `/Volumes` are never independent indexing roots.
+- Raw `git worktree prune` is unsafe while required storage is absent because
+  Git can mistake temporarily unavailable registrations for stale worktrees.
+- Global `TMPDIR`, Codex sessions/databases/logs, tmux state, and package caches
+  remain internal. Use `external-tmp <command...>` for opt-in per-process scratch.
 
 Cleanup behavior:
 
@@ -40,6 +56,7 @@ Cleanup behavior:
 - `gwt rm` resolves targets to an absolute path registered to the current Git common dir.
 - `gwt rm` never prunes unrelated stale worktree registrations.
 - `gwt prune` is the only wrapper command that prunes worktree metadata.
+- `gwt prune` requires the configured external worktree volume to be present.
 
 The cleaner retains no-follow state directory and artifact descriptors, then
 opens the unique database through a relative SQLite `mode=ro` URI in an isolated

--- a/functions/gwt/README.md
+++ b/functions/gwt/README.md
@@ -28,9 +28,14 @@ External storage behavior:
 
 - Configured hosts mount an encrypted, case-insensitive APFS volume directly at
   canonical `~/.codex/worktrees`; a symlinked `~/.codex/worktrees` is rejected.
+- The root-owned system policy binds the exact UUID and host marker, requires an
+  external device with ownership enabled, disabled Spotlight, persistent Time
+  Machine volume exclusion, and at least 200 GiB plus 10% free.
 - `gwt new`, `add`, `rm`, `audit`, `clean`, and `prune` stop before worktree
   access when the configured volume is absent, wrong, or replaced by a writable
-  internal fallback. `gwt root` remains informational.
+  internal fallback. Missing policy also fails closed when the direct mount or
+  sealed backing directory proves the host is configured. `gwt root` remains
+  informational.
 - The guard validates both lexical and resolved containment. A worktree on the
   direct mount still resolves through Git to its canonical owning checkout;
   physical aliases beneath `/Volumes` are never independent indexing roots.

--- a/functions/gwt/gwt.zsh
+++ b/functions/gwt/gwt.zsh
@@ -566,6 +566,16 @@ _gwt_tool_path() {
     return 1
 }
 
+_gwt_require_worktree_storage() {
+    local guard_path
+
+    guard_path=$(_gwt_tool_path worktree-storage-guard) || {
+        echo "gwt: worktree-storage-guard not found" >&2
+        return 127
+    }
+    "$guard_path"
+}
+
 _gwt_validate_cleanup_args() {
     local command_name="$1"
     shift
@@ -1134,6 +1144,7 @@ EOF
             ;;
         audit)
             local repo_root cleaner_path audit_table worktree_count machine_mode=false arg
+            _gwt_require_worktree_storage || return
             repo_root=$(_gwt_git_probe rev-parse --show-toplevel 2>/dev/null) || return 1
             _gwt_validate_cleanup_args audit "$@" || return 1
             cleaner_path=$(_gwt_tool_path agent-worktree-clean) || {
@@ -1171,6 +1182,7 @@ EOF
             ;;
         clean)
             local repo_root maintainer_path
+            _gwt_require_worktree_storage || return
             repo_root=$(_gwt_git_probe rev-parse --show-toplevel 2>/dev/null) || return 1
             _gwt_validate_cleanup_args clean "$@" || return 1
             maintainer_path=$(_gwt_tool_path agent-worktree-maintain) || {
@@ -1188,6 +1200,8 @@ EOF
             local use_sparse=false
             local checkout_risk=""
             local created_worktree=false
+
+            _gwt_require_worktree_storage || return
 
             while [[ $# -gt 0 ]]; do
                 case "$1" in
@@ -1330,6 +1344,8 @@ EOF
             local force_remove=false
             local arg target_path main_worktree repo_root current_path
 
+            _gwt_require_worktree_storage || return
+
             for arg in "$@"; do
                 case "$arg" in
                     --force|-f) force_remove=true ;;
@@ -1379,6 +1395,7 @@ EOF
             _gwt_tmux_sync_context
             ;;
         prune)
+            _gwt_require_worktree_storage || return
             git worktree prune
             _gwt_tmux_sync_context
             ;;

--- a/functions/system/deepclean.zsh
+++ b/functions/system/deepclean.zsh
@@ -3,6 +3,8 @@ deepclean() {
     local skip_mole=0
     local repo=""
     local root="${DOTFILES_WORKTREES_ROOT:-$HOME/.codex/worktrees}"
+    local guard=""
+    local source_path="${${(%):-%x}:A}"
     local -a repo_roots
 
     while (( $# )); do
@@ -32,6 +34,23 @@ EOF
         esac
         shift
     done
+
+    if [[ -n "${WORKTREE_STORAGE_GUARD:-}" ]]; then
+        guard="$WORKTREE_STORAGE_GUARD"
+    elif [[ -x "${source_path:h:h:h}/bin/agent-worktree-ops/worktree-storage-guard" ]]; then
+        guard="${source_path:h:h:h}/bin/agent-worktree-ops/worktree-storage-guard"
+    elif command -v worktree-storage-guard >/dev/null 2>&1; then
+        guard="$(command -v worktree-storage-guard)"
+    elif [[ -x "$HOME/Library/Application Support/agent-worktree-ops/worktree-storage-guard" ]]; then
+        guard="$HOME/Library/Application Support/agent-worktree-ops/worktree-storage-guard"
+    else
+        echo "deepclean: worktree-storage-guard missing" >&2
+        return 127
+    fi
+    "$guard" || {
+        echo "deepclean: required worktree storage is unavailable" >&2
+        return 78
+    }
 
     if [[ -n "$repo" ]]; then
         repo_roots=("${repo:A}")

--- a/tests/agent-worktree-maintain-test.sh
+++ b/tests/agent-worktree-maintain-test.sh
@@ -17,6 +17,7 @@ mkdir -m 700 "$state_dir/log"
 : >"$state_dir/log/agent-worktree-maintain.log"
 chmod 644 "$state_dir/log/agent-worktree-maintain.log"
 cp "$root/bin/agent-worktree-ops/agent-worktree-maintain" "$runtime/agent-worktree-maintain"
+cp "$root/bin/agent-worktree-ops/worktree-storage-guard" "$runtime/worktree-storage-guard"
 
 cat >"$runtime/agent-worktree-clean" <<'EOF'
 #!/usr/bin/env bash
@@ -28,7 +29,8 @@ fi
 printf '%s\n' "$*" >"$TEST_CLEANER_ARGS"
 exit "${TEST_CLEANER_EXIT:-0}"
 EOF
-chmod +x "$runtime/agent-worktree-clean" "$runtime/agent-worktree-maintain"
+chmod +x "$runtime/agent-worktree-clean" "$runtime/agent-worktree-maintain" \
+  "$runtime/worktree-storage-guard"
 
 mode_of() {
   stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1"
@@ -76,6 +78,23 @@ grep -q -- '--skip-legacy-purge' "$temporary/cleaner.args"
 [[ "$(mode_of "$state_dir/log")" == "700" ]]
 [[ "$(mode_of "$state_dir/locks")" == "700" ]]
 [[ "$(mode_of "$log_file")" == "600" ]]
+
+cat >"$runtime/worktree-storage-guard" <<'EOF'
+#!/usr/bin/env bash
+printf 'storage unavailable\n' >&2
+exit 78
+EOF
+chmod +x "$runtime/worktree-storage-guard"
+set +e
+run_maintainer >"$temporary/storage-failure.out" 2>&1
+status=$?
+set -e
+[[ "$status" == "78" ]]
+grep -q 'storage unavailable' "$temporary/storage-failure.out"
+[[ ! -e "$state_dir/locks/agent-worktree-maintain.lock" ]]
+[[ "$(grep -c 'start count=' "$log_file")" == "1" ]]
+cp "$root/bin/agent-worktree-ops/worktree-storage-guard" "$runtime/worktree-storage-guard"
+chmod +x "$runtime/worktree-storage-guard"
 
 legacy_codex_home="$temporary/legacy-codex"
 legacy_state_dir="$temporary/legacy-state"

--- a/tests/agent-worktree-ops-test.py
+++ b/tests/agent-worktree-ops-test.py
@@ -552,6 +552,10 @@ class WorktreeCleanerTests(unittest.TestCase):
 
     def test_machine_reader_runs_from_anonymous_cleaner_source_fd(self) -> None:
         source_fd = os.open(CLEANER_PATH, os.O_RDONLY)
+        environment = os.environ.copy()
+        environment["WORKTREE_STORAGE_GUARD"] = str(
+            CLEANER_PATH.with_name("worktree-storage-guard")
+        )
         try:
             result = subprocess.run(
                 [
@@ -567,6 +571,7 @@ class WorktreeCleanerTests(unittest.TestCase):
                     str(self.codex_home),
                     "--machine",
                 ],
+                env=environment,
                 pass_fds=(source_fd,),
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
@@ -968,26 +973,30 @@ class WorktreeCleanerTests(unittest.TestCase):
         )
         failed_remove = SimpleNamespace(returncode=1, stdout="", stderr="refused")
 
-        with mock.patch.object(CLEANER, "progress_bar", return_value=mock.MagicMock()):
-            with mock.patch.object(CLEANER, "revalidate_candidate", return_value=None):
-                with mock.patch.object(CLEANER, "trim_worktree_artifacts", return_value=False):
-                    trim_failures = CLEANER.apply_trims(
-                        repo_root="/tmp/repo",
-                        codex_home="/tmp/codex",
-                        candidates=[candidate],
-                        shared_node_modules_source="/tmp/repo/node_modules",
-                        session_limit=30,
-                        scan_limit=200,
-                    )
-                with mock.patch.object(CLEANER.subprocess, "run", return_value=failed_remove):
-                    removal_failures = CLEANER.apply_removals(
-                        repo_root="/tmp/repo",
-                        codex_home="/tmp/codex",
-                        candidates=[candidate],
-                        include_detached=False,
-                        session_limit=30,
-                        scan_limit=200,
-                    )
+        with mock.patch.object(CLEANER, "require_worktree_storage"):
+            progress_patch = mock.patch.object(
+                CLEANER, "progress_bar", return_value=mock.MagicMock()
+            )
+            with progress_patch:
+                with mock.patch.object(CLEANER, "revalidate_candidate", return_value=None):
+                    with mock.patch.object(CLEANER, "trim_worktree_artifacts", return_value=False):
+                        trim_failures = CLEANER.apply_trims(
+                            repo_root="/tmp/repo",
+                            codex_home="/tmp/codex",
+                            candidates=[candidate],
+                            shared_node_modules_source="/tmp/repo/node_modules",
+                            session_limit=30,
+                            scan_limit=200,
+                        )
+                    with mock.patch.object(CLEANER.subprocess, "run", return_value=failed_remove):
+                        removal_failures = CLEANER.apply_removals(
+                            repo_root="/tmp/repo",
+                            codex_home="/tmp/codex",
+                            candidates=[candidate],
+                            include_detached=False,
+                            session_limit=30,
+                            scan_limit=200,
+                        )
 
         self.assertEqual(trim_failures, 1)
         self.assertEqual(removal_failures, 1)
@@ -1374,6 +1383,34 @@ class WorktreeCleanerTests(unittest.TestCase):
             self.assertEqual(before, path_metadata(sentinel))
         finally:
             time.sleep(0.7)
+
+    def test_storage_guard_failure_precedes_inventory(self) -> None:
+        guard = self.base / "storage-guard"
+        guard.write_text(
+            "#!/bin/sh\nprintf 'storage unavailable\\n' >&2\nexit 78\n",
+            encoding="utf-8",
+        )
+        os.chmod(guard, 0o755)
+        environment = os.environ.copy()
+        environment["WORKTREE_STORAGE_GUARD"] = str(guard)
+        result = subprocess.run(
+            [
+                str(CLEANER_PATH),
+                "--repo",
+                str(self.repo),
+                "--codex-home",
+                str(self.codex_home),
+                "--list-registered",
+            ],
+            env=environment,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("storage unavailable", result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/codebase-memory-policy-test.py
+++ b/tests/codebase-memory-policy-test.py
@@ -7,6 +7,8 @@ import subprocess
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 HOOKS = ROOT / ".codex" / "hooks.json"
 AGENTS = ROOT / ".codex" / "AGENTS.md"
+STORAGE_GUARD = ROOT / "bin" / "agent-worktree-ops" / "worktree-storage-guard"
+WORKTREE_DOCS = ROOT / "functions" / "gwt" / "README.md"
 
 
 payload = json.loads(HOOKS.read_text())
@@ -53,5 +55,23 @@ for phrase in (
 ):
     if phrase not in agents:
         raise SystemExit(f"missing agent policy: {phrase}")
+
+guard = STORAGE_GUARD.read_text()
+for phrase in (
+    "path_has_no_symlink_components",
+    "mount point resolves outside its canonical path",
+    "canonical path is not a direct filesystem mount",
+):
+    if phrase not in guard:
+        raise SystemExit(f"missing physical-path storage guard: {phrase}")
+
+docs = WORKTREE_DOCS.read_text()
+for phrase in (
+    "lexical and resolved containment",
+    "canonical owning checkout",
+    "symlinked `~/.codex/worktrees`",
+):
+    if phrase not in docs:
+        raise SystemExit(f"missing worktree indexing policy: {phrase}")
 
 print("codebase_memory_policy_test=passed")

--- a/tests/deepclean-test.zsh
+++ b/tests/deepclean-test.zsh
@@ -8,6 +8,31 @@ output="$(deepclean --dry-run --repo "$repo_root" --skip-mole)"
 [[ "$output" == *"deepclean mode=preview"* ]]
 [[ "$output" == *"deepclean complete"* ]]
 
+temporary="$(mktemp -d)"
+trap 'rm -rf "$temporary"' EXIT
+mkdir -p "$temporary/bin"
+cat >"$temporary/bin/worktree-storage-guard" <<'EOF'
+#!/bin/sh
+echo storage-unavailable >&2
+exit 78
+EOF
+chmod +x "$temporary/bin/worktree-storage-guard"
+function mole() {
+    print -r -- called >"$temporary/mole-called"
+}
+if WORKTREE_STORAGE_GUARD="$temporary/bin/worktree-storage-guard" \
+    deepclean --dry-run --repo "$repo_root" \
+        >"$temporary/storage.out" 2>&1; then
+    print -u2 'expected unavailable storage to fail deepclean'
+    exit 1
+fi
+grep -Fq storage-unavailable "$temporary/storage.out"
+[[ ! -e "$temporary/mole-called" ]]
+if grep -Fq 'deepclean complete' "$temporary/storage.out"; then
+    print -u2 'storage failure must not print completion'
+    exit 1
+fi
+
 if deepclean --wat >/dev/null 2>&1; then
     print -u2 'expected unknown argument to fail'
     exit 1

--- a/tests/external-tmp-test.sh
+++ b/tests/external-tmp-test.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+command_path="$root/bin/external-tmp"
+temporary="$(mktemp -d)"
+temporary="$(cd "$temporary" && pwd -P)"
+trap 'rm -rf "$temporary"' EXIT
+
+home="$temporary/home"
+mount_point="$home/.codex/worktrees"
+config="$temporary/config.json"
+observed="$temporary/observed.json"
+probe="$temporary/probe.sh"
+result="$temporary/result"
+mkdir -p "$mount_point"
+chmod 0700 "$mount_point"
+cat >"$config" <<EOF
+{"case_sensitive":false,"encrypted":true,"filesystem":"apfs","mount_point":"$mount_point","required":true,"schema_version":"external-worktree-storage.v1","volume_uuid":"11111111-2222-3333-4444-555555555555"}
+EOF
+chmod 0600 "$config"
+cat >"$observed" <<EOF
+{"case_sensitive":false,"device":200,"encrypted":true,"filesystem":"apfs","mode":"0700","mount_point":"$mount_point","mounted":true,"owner_gid":$(id -g),"owner_uid":$(id -u),"ownership_enabled":true,"parent_device":100,"volume_uuid":"11111111-2222-3333-4444-555555555555"}
+EOF
+cat >"$probe" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n%s\n%s\n' "$TMPDIR" "$TMP" "$TEMP" >"$1"
+touch "$TMPDIR/child-created"
+EOF
+chmod 0755 "$probe"
+
+HOME="$home" \
+  WORKTREE_STORAGE_CONFIG="$config" \
+  WORKTREE_STORAGE_GUARD_TESTING=1 \
+  WORKTREE_STORAGE_GUARD_OBSERVED="$observed" \
+  "$command_path" "$probe" "$result"
+
+tmpdir_path="$(sed -n '1p' "$result")"
+tmp_path="$(sed -n '2p' "$result")"
+temp_path="$(sed -n '3p' "$result")"
+[[ "$tmpdir_path" == "$mount_point/.scratch/tmp/"external-tmp.*"/" ]]
+[[ "$tmp_path" == "${tmpdir_path%/}" ]]
+[[ "$temp_path" == "${tmpdir_path%/}" ]]
+[[ -z "$(find "$mount_point/.scratch/tmp" -mindepth 1 -print -quit)" ]]
+
+fake_guard="$temporary/fake-guard"
+counter="$temporary/guard-counter"
+child_marker="$temporary/child-ran"
+cat >"$fake_guard" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+count=0
+[[ ! -f "$counter" ]] || count="\$(cat "$counter")"
+count=\$((count + 1))
+printf '%s\n' "\$count" >"$counter"
+if [[ "\${1:-}" == "--require-config" ]]; then
+  printf '%s\n' "$mount_point"
+  exit 0
+fi
+if (( count >= 2 )); then
+  printf 'simulated hot disappearance\n' >&2
+  exit 78
+fi
+EOF
+chmod 0755 "$fake_guard"
+if HOME="$home" WORKTREE_STORAGE_GUARD="$fake_guard" \
+  "$command_path" /usr/bin/touch "$child_marker" >"$temporary/hot.out" 2>&1; then
+  echo "external-tmp must stop when storage disappears before child execution" >&2
+  exit 1
+fi
+[[ ! -e "$child_marker" ]]
+grep -Fq "simulated hot disappearance" "$temporary/hot.out"
+
+if HOME="$home" WORKTREE_STORAGE_CONFIG="$temporary/missing" \
+  "$command_path" /usr/bin/true >"$temporary/missing.out" 2>&1; then
+  echo "external-tmp must require configured storage" >&2
+  exit 1
+fi
+grep -Fq "not configured" "$temporary/missing.out"
+
+printf 'external tmp tests passed\n'

--- a/tests/external-tmp-test.sh
+++ b/tests/external-tmp-test.sh
@@ -13,14 +13,16 @@ config="$temporary/config.json"
 observed="$temporary/observed.json"
 probe="$temporary/probe.sh"
 result="$temporary/result"
+volume_uuid="$(printf '%s-%s-%s-%s-%s' 11111111 2222 3333 4444 555555555555)"
+marker_id="studio-a.external-worktree-storage.v1"
 mkdir -p "$mount_point"
 chmod 0700 "$mount_point"
 cat >"$config" <<EOF
-{"backing_directory_mode":"0000","case_sensitive":false,"device_location":"External","encrypted":true,"filesystem":"apfs","marker_id":"vcuriosity.external-worktree-storage.v1","minimum_free_gib":200,"minimum_free_percent":10,"mount_point":"$mount_point","owners":true,"required":true,"schema_version":"external-worktree-storage.v1","spotlight":"disabled","time_machine_excluded":true,"volume_uuid":"11111111-2222-3333-4444-555555555555"}
+{"backing_directory_mode":"0000","case_sensitive":false,"device_location":"External","encrypted":true,"filesystem":"apfs","marker_id":"$marker_id","minimum_free_gib":200,"minimum_free_percent":10,"mount_point":"$mount_point","owners":true,"required":true,"schema_version":"external-worktree-storage.v1","spotlight":"disabled","time_machine_excluded":true,"volume_uuid":"$volume_uuid"}
 EOF
 chmod 0600 "$config"
 cat >"$observed" <<EOF
-{"case_sensitive":false,"device":200,"device_location":"External","encrypted":true,"filesystem":"apfs","free_gib":1000,"free_percent":50,"marker_id":"vcuriosity.external-worktree-storage.v1","mode":"0700","mount_point":"$mount_point","mounted":true,"owner_gid":$(id -g),"owner_uid":$(id -u),"ownership_enabled":true,"parent_device":100,"spotlight":"disabled","time_machine_excluded":true,"volume_uuid":"11111111-2222-3333-4444-555555555555"}
+{"case_sensitive":false,"device":200,"device_location":"External","encrypted":true,"filesystem":"apfs","free_gib":1000,"free_percent":50,"marker_id":"$marker_id","mode":"0700","mount_point":"$mount_point","mounted":true,"owner_gid":$(id -g),"owner_uid":$(id -u),"ownership_enabled":true,"parent_device":100,"spotlight":"disabled","time_machine_excluded":true,"volume_uuid":"$volume_uuid"}
 EOF
 cat >"$probe" <<'EOF'
 #!/usr/bin/env bash

--- a/tests/external-tmp-test.sh
+++ b/tests/external-tmp-test.sh
@@ -16,11 +16,11 @@ result="$temporary/result"
 mkdir -p "$mount_point"
 chmod 0700 "$mount_point"
 cat >"$config" <<EOF
-{"case_sensitive":false,"encrypted":true,"filesystem":"apfs","mount_point":"$mount_point","required":true,"schema_version":"external-worktree-storage.v1","volume_uuid":"11111111-2222-3333-4444-555555555555"}
+{"backing_directory_mode":"0000","case_sensitive":false,"device_location":"External","encrypted":true,"filesystem":"apfs","marker_id":"vcuriosity.external-worktree-storage.v1","minimum_free_gib":200,"minimum_free_percent":10,"mount_point":"$mount_point","owners":true,"required":true,"schema_version":"external-worktree-storage.v1","spotlight":"disabled","time_machine_excluded":true,"volume_uuid":"11111111-2222-3333-4444-555555555555"}
 EOF
 chmod 0600 "$config"
 cat >"$observed" <<EOF
-{"case_sensitive":false,"device":200,"encrypted":true,"filesystem":"apfs","mode":"0700","mount_point":"$mount_point","mounted":true,"owner_gid":$(id -g),"owner_uid":$(id -u),"ownership_enabled":true,"parent_device":100,"volume_uuid":"11111111-2222-3333-4444-555555555555"}
+{"case_sensitive":false,"device":200,"device_location":"External","encrypted":true,"filesystem":"apfs","free_gib":1000,"free_percent":50,"marker_id":"vcuriosity.external-worktree-storage.v1","mode":"0700","mount_point":"$mount_point","mounted":true,"owner_gid":$(id -g),"owner_uid":$(id -u),"ownership_enabled":true,"parent_device":100,"spotlight":"disabled","time_machine_excluded":true,"volume_uuid":"11111111-2222-3333-4444-555555555555"}
 EOF
 cat >"$probe" <<'EOF'
 #!/usr/bin/env bash
@@ -73,10 +73,12 @@ fi
 grep -Fq "simulated hot disappearance" "$temporary/hot.out"
 
 if HOME="$home" WORKTREE_STORAGE_CONFIG="$temporary/missing" \
+  WORKTREE_STORAGE_GUARD_TESTING=1 \
+  WORKTREE_STORAGE_GUARD_OBSERVED="$observed" \
   "$command_path" /usr/bin/true >"$temporary/missing.out" 2>&1; then
   echo "external-tmp must require configured storage" >&2
   exit 1
 fi
-grep -Fq "not configured" "$temporary/missing.out"
+grep -Fq "required config missing" "$temporary/missing.out"
 
 printf 'external tmp tests passed\n'

--- a/tests/gwt-cleanup-test.zsh
+++ b/tests/gwt-cleanup-test.zsh
@@ -16,7 +16,9 @@ mkdir -p "$home" "$runtime" "${gwt_source:h}"
 cp "$root/functions/gwt/gwt.zsh" "$gwt_source"
 cp "$root/bin/agent-worktree-ops/agent-worktree-clean" "$runtime/agent-worktree-clean"
 cp "$root/bin/agent-worktree-ops/agent-worktree-maintain" "$runtime/agent-worktree-maintain"
-chmod +x "$runtime/agent-worktree-clean" "$runtime/agent-worktree-maintain"
+cp "$root/bin/agent-worktree-ops/worktree-storage-guard" "$runtime/worktree-storage-guard"
+chmod +x "$runtime/agent-worktree-clean" "$runtime/agent-worktree-maintain" \
+  "$runtime/worktree-storage-guard"
 
 fake_bin="$temporary/bin"
 mkdir -p "$fake_bin"
@@ -226,6 +228,39 @@ git init -b main "$foreign_row" >/dev/null
 
 index_before="$(invalidate_index_stat_cache "$remove_path")"
 metadata_before="$(metadata_snapshot "$repo")"
+
+cat >"$runtime/worktree-storage-guard" <<'EOF'
+#!/bin/sh
+echo storage-unavailable >&2
+exit 78
+EOF
+chmod +x "$runtime/worktree-storage-guard"
+guarded_metadata_before="$(git -C "$repo" worktree list --porcelain | shasum -a 256)"
+for guarded_command in \
+  'audit' \
+  'clean' \
+  'new blocked main' \
+  'add blocked-add main' \
+  'rm remove-me' \
+  'prune'; do
+  if HOME="$home" DOTFILES_WORKTREES_ROOT="$worktrees_root" \
+    zsh -f -c '
+      source "$1"
+      cd "$2"
+      gwt ${(z)3}
+    ' zsh "$gwt_source" "$repo" "$guarded_command" \
+      >"$temporary/guarded.out" 2>&1; then
+    print -u2 "expected storage guard failure: $guarded_command"
+    exit 1
+  fi
+  grep -Fq storage-unavailable "$temporary/guarded.out"
+done
+[[ "$guarded_metadata_before" == "$(git -C "$repo" worktree list --porcelain | shasum -a 256)" ]]
+[[ ! -e "$TEST_PRUNE_LOG" ]]
+cp "$root/bin/agent-worktree-ops/worktree-storage-guard" \
+  "$runtime/worktree-storage-guard"
+chmod +x "$runtime/worktree-storage-guard"
+
 PATH="$fake_bin:$PATH" \
 GIT_OPTIONAL_LOCKS=caller-value \
 GIT_NO_LAZY_FETCH=caller-lazy-value \

--- a/tests/gwt-cleanup-test.zsh
+++ b/tests/gwt-cleanup-test.zsh
@@ -3,8 +3,10 @@ set -euo pipefail
 
 root="${0:A:h:h}"
 temporary="$(mktemp -d)"
+temporary="${temporary:A}"
 trap 'rm -rf "$temporary"' EXIT
 
+zdotdir="$temporary/zdotdir"
 home="$temporary/home"
 repo="$temporary/repo"
 foreign="$temporary/foreign"
@@ -12,7 +14,8 @@ worktrees_root="$home/worktrees"
 runtime="$home/Library/Application Support/agent-worktree-ops"
 gwt_fixture_root="$temporary/gwt-fixture"
 gwt_source="$gwt_fixture_root/functions/gwt/gwt.zsh"
-mkdir -p "$home" "$runtime" "${gwt_source:h}"
+mkdir -p "$zdotdir" "$home" "$runtime" "${gwt_source:h}"
+export ZDOTDIR="$zdotdir"
 cp "$root/functions/gwt/gwt.zsh" "$gwt_source"
 cp "$root/bin/agent-worktree-ops/agent-worktree-clean" "$runtime/agent-worktree-clean"
 cp "$root/bin/agent-worktree-ops/agent-worktree-maintain" "$runtime/agent-worktree-maintain"

--- a/tests/install-agent-worktree-ops-test.sh
+++ b/tests/install-agent-worktree-ops-test.sh
@@ -45,7 +45,8 @@ assert_runtime_only() {
     agent-worktree-clean \
     agent-worktree-maintain \
     agent-worktree-purge \
-    retire-agent-worktree-scheduler; do
+    retire-agent-worktree-scheduler \
+    worktree-storage-guard; do
     [[ -x "$runtime/$tool" ]]
     cmp -s "$root/bin/agent-worktree-ops/$tool" "$runtime/$tool"
   done

--- a/tests/worktree-storage-test.sh
+++ b/tests/worktree-storage-test.sh
@@ -17,7 +17,7 @@ chmod 0700 "$mount_point"
 write_config() {
   local uuid="${1:-11111111-2222-3333-4444-555555555555}"
   cat >"$config" <<EOF
-{"case_sensitive":false,"encrypted":true,"filesystem":"apfs","mount_point":"$mount_point","required":true,"schema_version":"external-worktree-storage.v1","volume_uuid":"$uuid"}
+{"backing_directory_mode":"0000","case_sensitive":false,"device_location":"External","encrypted":true,"filesystem":"apfs","marker_id":"vcuriosity.external-worktree-storage.v1","minimum_free_gib":200,"minimum_free_percent":10,"mount_point":"$mount_point","owners":true,"required":true,"schema_version":"external-worktree-storage.v1","spotlight":"disabled","time_machine_excluded":true,"volume_uuid":"$uuid"}
 EOF
   chmod 0600 "$config"
 }
@@ -29,8 +29,10 @@ write_observed() {
   local owner_uid="$4"
   local owner_gid="$5"
   local mode="$6"
+  local free_gib="${7:-1000}"
+  local free_percent="${8:-50}"
   cat >"$observed" <<EOF
-{"case_sensitive":false,"device":200,"encrypted":true,"filesystem":"$filesystem","mode":"$mode","mount_point":"$mount_point","mounted":$mounted,"owner_gid":$owner_gid,"owner_uid":$owner_uid,"ownership_enabled":true,"parent_device":100,"volume_uuid":"$uuid"}
+{"case_sensitive":false,"device":200,"device_location":"External","encrypted":true,"filesystem":"$filesystem","free_gib":$free_gib,"free_percent":$free_percent,"marker_id":"vcuriosity.external-worktree-storage.v1","mode":"$mode","mount_point":"$mount_point","mounted":$mounted,"owner_gid":$owner_gid,"owner_uid":$owner_uid,"ownership_enabled":true,"parent_device":100,"spotlight":"disabled","time_machine_excluded":true,"volume_uuid":"$uuid"}
 EOF
 }
 
@@ -45,6 +47,39 @@ run_guard() {
 write_config
 write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700
 [[ "$(run_guard --print-mount-point)" == "$mount_point" ]]
+python3 - "$guard" "$config" <<'PY'
+import importlib.util
+import importlib.machinery
+import os
+import pathlib
+import sys
+
+loader = importlib.machinery.SourceFileLoader("storage_guard", sys.argv[1])
+spec = importlib.util.spec_from_loader("storage_guard", loader)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader
+spec.loader.exec_module(module)
+assert str(module.DEFAULT_CONFIG) == (
+    "/Library/Application Support/agent-worktree-ops/"
+    "external-worktree-storage.json"
+)
+source = pathlib.Path(sys.argv[1]).read_text()
+assert "com.apple.metadata:com_apple_backup_excludeItem" not in source
+assert '"/usr/bin/tmutil", "isexcluded"' in source
+if os.getuid() != 0:
+    try:
+        module.load_config(pathlib.Path(sys.argv[2]), production_default=True)
+    except module.GuardError as error:
+        assert "wrong owner" in str(error)
+    else:
+        raise AssertionError("production config must be root-owned")
+PY
+if HOME="$home" WORKTREE_STORAGE_CONFIG="$config" "$guard" \
+  >"$temporary/override.out" 2>&1; then
+  echo "runtime config overrides must be test-only" >&2
+  exit 1
+fi
+grep -Fq "override requires guard test mode" "$temporary/override.out"
 
 owner_repo="$temporary/owner-repo"
 managed_worktree="$mount_point/owner-repo/feature"
@@ -74,6 +109,88 @@ if run_guard >"$temporary/exfat.out" 2>&1; then
   exit 1
 fi
 grep -Fq "not APFS" "$temporary/exfat.out"
+
+write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700 199 50
+if run_guard >"$temporary/low-gib.out" 2>&1; then
+  echo "minimum_free_gib must fail before mutation" >&2
+  exit 1
+fi
+grep -Fq "minimum_free_gib" "$temporary/low-gib.out"
+
+write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700 1000 9
+if run_guard >"$temporary/low-percent.out" 2>&1; then
+  echo "minimum_free_percent must fail before mutation" >&2
+  exit 1
+fi
+grep -Fq "minimum_free_percent" "$temporary/low-percent.out"
+
+write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700
+python3 - "$observed" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+value = json.loads(path.read_text())
+value["device_location"] = "Internal"
+path.write_text(json.dumps(value))
+PY
+if run_guard >"$temporary/internal-device.out" 2>&1; then
+  echo "internal device location must fail" >&2
+  exit 1
+fi
+grep -Fq "not an external device" "$temporary/internal-device.out"
+
+write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700
+python3 - "$observed" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+value = json.loads(path.read_text())
+value["marker_id"] = "vatlantis.external-worktree-storage.v1"
+path.write_text(json.dumps(value))
+PY
+if run_guard >"$temporary/wrong-marker.out" 2>&1; then
+  echo "wrong host marker must fail" >&2
+  exit 1
+fi
+grep -Fq "marker does not match" "$temporary/wrong-marker.out"
+
+write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700
+python3 - "$observed" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+value = json.loads(path.read_text())
+value["spotlight"] = "enabled_or_unknown"
+path.write_text(json.dumps(value))
+PY
+if run_guard >"$temporary/spotlight.out" 2>&1; then
+  echo "enabled Spotlight must fail" >&2
+  exit 1
+fi
+grep -Fq "Spotlight indexing is not disabled" "$temporary/spotlight.out"
+
+write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700
+python3 - "$observed" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+value = json.loads(path.read_text())
+value["time_machine_excluded"] = False
+path.write_text(json.dumps(value))
+PY
+if run_guard >"$temporary/time-machine.out" 2>&1; then
+  echo "missing persistent Time Machine exclusion must fail" >&2
+  exit 1
+fi
+grep -Fq "persistent Time Machine exclusion" "$temporary/time-machine.out"
 
 wheel_gid="$(python3 - <<'PY'
 import grp
@@ -122,15 +239,49 @@ if run_guard >"$temporary/pending.out" 2>&1; then
   echo "pending UUID must fail" >&2
   exit 1
 fi
-grep -Fq "policy is incomplete" "$temporary/pending.out"
+grep -Fq "required config missing or invalid" "$temporary/pending.out"
 
+write_config
+chmod 0666 "$config"
+write_observed "11111111-2222-3333-4444-555555555555" apfs false "$(id -u)" "$(id -g)" 0700
+if run_guard >"$temporary/writable-config.out" 2>&1; then
+  echo "writable runtime config must fail" >&2
+  exit 1
+fi
+grep -Fq "permissions are unsafe" "$temporary/writable-config.out"
+chmod 0600 "$config"
+
+real_config="$temporary/real-config.json"
+mv "$config" "$real_config"
+ln -s "$real_config" "$config"
+if run_guard >"$temporary/symlink-config.out" 2>&1; then
+  echo "symlinked runtime config must fail" >&2
+  exit 1
+fi
+grep -Fq "symlinked component" "$temporary/symlink-config.out"
 rm "$config"
-HOME="$home" WORKTREE_STORAGE_CONFIG="$config" "$guard"
-if HOME="$home" WORKTREE_STORAGE_CONFIG="$config" "$guard" --require-config \
+
+write_observed "11111111-2222-3333-4444-555555555555" apfs false 0 "$wheel_gid" 0000
+if run_guard >"$temporary/missing-sealed.out" 2>&1; then
+  echo "missing config with sealed fallback must fail" >&2
+  exit 1
+fi
+grep -Fq "required config missing" "$temporary/missing-sealed.out"
+
+write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700
+if run_guard >"$temporary/missing-mounted.out" 2>&1; then
+  echo "missing config with a direct mount must fail" >&2
+  exit 1
+fi
+grep -Fq "required config missing" "$temporary/missing-mounted.out"
+
+write_observed "11111111-2222-3333-4444-555555555555" apfs false "$(id -u)" "$(id -g)" 0700
+run_guard
+if run_guard --require-config \
   >"$temporary/unconfigured.out" 2>&1; then
   echo "required unconfigured storage must fail" >&2
   exit 1
 fi
-grep -Fq "not configured" "$temporary/unconfigured.out"
+grep -Fq "required config missing" "$temporary/unconfigured.out"
 
 printf 'worktree storage tests passed\n'

--- a/tests/worktree-storage-test.sh
+++ b/tests/worktree-storage-test.sh
@@ -11,13 +11,17 @@ home="$temporary/home"
 config="$temporary/external-worktree-storage.json"
 observed="$temporary/observed.json"
 mount_point="$home/.codex/worktrees"
+volume_uuid="$(printf '%s-%s-%s-%s-%s' 11111111 2222 3333 4444 555555555555)"
+other_uuid="$(printf '%s-%s-%s-%s-%s' aaaaaaaa bbbb cccc dddd eeeeeeeeeeee)"
+marker_id="studio-a.external-worktree-storage.v1"
+other_marker_id="studio-b.external-worktree-storage.v1"
 mkdir -p "$mount_point"
 chmod 0700 "$mount_point"
 
 write_config() {
-  local uuid="${1:-11111111-2222-3333-4444-555555555555}"
+  local uuid="${1:-$volume_uuid}"
   cat >"$config" <<EOF
-{"backing_directory_mode":"0000","case_sensitive":false,"device_location":"External","encrypted":true,"filesystem":"apfs","marker_id":"vcuriosity.external-worktree-storage.v1","minimum_free_gib":200,"minimum_free_percent":10,"mount_point":"$mount_point","owners":true,"required":true,"schema_version":"external-worktree-storage.v1","spotlight":"disabled","time_machine_excluded":true,"volume_uuid":"$uuid"}
+{"backing_directory_mode":"0000","case_sensitive":false,"device_location":"External","encrypted":true,"filesystem":"apfs","marker_id":"$marker_id","minimum_free_gib":200,"minimum_free_percent":10,"mount_point":"$mount_point","owners":true,"required":true,"schema_version":"external-worktree-storage.v1","spotlight":"disabled","time_machine_excluded":true,"volume_uuid":"$uuid"}
 EOF
   chmod 0600 "$config"
 }
@@ -32,7 +36,7 @@ write_observed() {
   local free_gib="${7:-1000}"
   local free_percent="${8:-50}"
   cat >"$observed" <<EOF
-{"case_sensitive":false,"device":200,"device_location":"External","encrypted":true,"filesystem":"$filesystem","free_gib":$free_gib,"free_percent":$free_percent,"marker_id":"vcuriosity.external-worktree-storage.v1","mode":"$mode","mount_point":"$mount_point","mounted":$mounted,"owner_gid":$owner_gid,"owner_uid":$owner_uid,"ownership_enabled":true,"parent_device":100,"spotlight":"disabled","time_machine_excluded":true,"volume_uuid":"$uuid"}
+{"case_sensitive":false,"device":200,"device_location":"External","encrypted":true,"filesystem":"$filesystem","free_gib":$free_gib,"free_percent":$free_percent,"marker_id":"$marker_id","mode":"$mode","mount_point":"$mount_point","mounted":$mounted,"owner_gid":$owner_gid,"owner_uid":$owner_uid,"ownership_enabled":true,"parent_device":100,"spotlight":"disabled","time_machine_excluded":true,"volume_uuid":"$uuid"}
 EOF
 }
 
@@ -45,7 +49,7 @@ run_guard() {
 }
 
 write_config
-write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
 [[ "$(run_guard --print-mount-point)" == "$mount_point" ]]
 python3 - "$guard" "$config" <<'PY'
 import importlib.util
@@ -96,35 +100,35 @@ worktree_common="$(git -C "$managed_worktree" rev-parse --path-format=absolute -
 [[ "$owner_common" == "$worktree_common" ]]
 git -C "$owner_repo" worktree remove "$managed_worktree"
 
-write_observed "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" apfs true "$(id -u)" "$(id -g)" 0700
+write_observed "$other_uuid" apfs true "$(id -u)" "$(id -g)" 0700
 if run_guard >"$temporary/wrong-uuid.out" 2>&1; then
   echo "wrong UUID must fail" >&2
   exit 1
 fi
 grep -Fq "UUID does not match policy" "$temporary/wrong-uuid.out"
 
-write_observed "11111111-2222-3333-4444-555555555555" exfat true "$(id -u)" "$(id -g)" 0700
+write_observed "$volume_uuid" exfat true "$(id -u)" "$(id -g)" 0700
 if run_guard >"$temporary/exfat.out" 2>&1; then
   echo "ExFAT must fail" >&2
   exit 1
 fi
 grep -Fq "not APFS" "$temporary/exfat.out"
 
-write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700 199 50
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700 199 50
 if run_guard >"$temporary/low-gib.out" 2>&1; then
   echo "minimum_free_gib must fail before mutation" >&2
   exit 1
 fi
 grep -Fq "minimum_free_gib" "$temporary/low-gib.out"
 
-write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700 1000 9
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700 1000 9
 if run_guard >"$temporary/low-percent.out" 2>&1; then
   echo "minimum_free_percent must fail before mutation" >&2
   exit 1
 fi
 grep -Fq "minimum_free_percent" "$temporary/low-percent.out"
 
-write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
 python3 - "$observed" <<'PY'
 import json
 import pathlib
@@ -141,15 +145,15 @@ if run_guard >"$temporary/internal-device.out" 2>&1; then
 fi
 grep -Fq "not an external device" "$temporary/internal-device.out"
 
-write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700
-python3 - "$observed" <<'PY'
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
+python3 - "$observed" "$other_marker_id" <<'PY'
 import json
 import pathlib
 import sys
 
 path = pathlib.Path(sys.argv[1])
 value = json.loads(path.read_text())
-value["marker_id"] = "vatlantis.external-worktree-storage.v1"
+value["marker_id"] = sys.argv[2]
 path.write_text(json.dumps(value))
 PY
 if run_guard >"$temporary/wrong-marker.out" 2>&1; then
@@ -158,7 +162,7 @@ if run_guard >"$temporary/wrong-marker.out" 2>&1; then
 fi
 grep -Fq "marker does not match" "$temporary/wrong-marker.out"
 
-write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
 python3 - "$observed" <<'PY'
 import json
 import pathlib
@@ -175,7 +179,7 @@ if run_guard >"$temporary/spotlight.out" 2>&1; then
 fi
 grep -Fq "Spotlight indexing is not disabled" "$temporary/spotlight.out"
 
-write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
 python3 - "$observed" <<'PY'
 import json
 import pathlib
@@ -200,23 +204,23 @@ except KeyError:
     print(0)
 PY
 )"
-write_observed "11111111-2222-3333-4444-555555555555" apfs false 0 "$wheel_gid" 0000
+write_observed "$volume_uuid" apfs false 0 "$wheel_gid" 0000
 if run_guard >"$temporary/absent.out" 2>&1; then
   echo "absent mount must fail" >&2
   exit 1
 fi
 grep -Fq "not mounted" "$temporary/absent.out"
 
-write_observed "11111111-2222-3333-4444-555555555555" apfs false "$(id -u)" "$(id -g)" 0700
+write_observed "$volume_uuid" apfs false "$(id -u)" "$(id -g)" 0700
 if run_guard >"$temporary/fallback.out" 2>&1; then
   echo "writable fallback must fail" >&2
   exit 1
 fi
 grep -Fq "fallback is writable" "$temporary/fallback.out"
 
-write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
 run_guard
-write_observed "11111111-2222-3333-4444-555555555555" apfs false 0 "$wheel_gid" 0000
+write_observed "$volume_uuid" apfs false 0 "$wheel_gid" 0000
 if run_guard >"$temporary/hot-disappearance.out" 2>&1; then
   echo "hot disappearance must fail closed" >&2
   exit 1
@@ -225,7 +229,7 @@ grep -Fq "not mounted" "$temporary/hot-disappearance.out"
 
 rm -rf "$mount_point"
 ln -s /Volumes/ExternalWorktrees "$mount_point"
-write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
 if run_guard >"$temporary/symlink.out" 2>&1; then
   echo "symlinked canonical mount point must fail" >&2
   exit 1
@@ -243,7 +247,7 @@ grep -Fq "required config missing or invalid" "$temporary/pending.out"
 
 write_config
 chmod 0666 "$config"
-write_observed "11111111-2222-3333-4444-555555555555" apfs false "$(id -u)" "$(id -g)" 0700
+write_observed "$volume_uuid" apfs false "$(id -u)" "$(id -g)" 0700
 if run_guard >"$temporary/writable-config.out" 2>&1; then
   echo "writable runtime config must fail" >&2
   exit 1
@@ -261,21 +265,21 @@ fi
 grep -Fq "symlinked component" "$temporary/symlink-config.out"
 rm "$config"
 
-write_observed "11111111-2222-3333-4444-555555555555" apfs false 0 "$wheel_gid" 0000
+write_observed "$volume_uuid" apfs false 0 "$wheel_gid" 0000
 if run_guard >"$temporary/missing-sealed.out" 2>&1; then
   echo "missing config with sealed fallback must fail" >&2
   exit 1
 fi
 grep -Fq "required config missing" "$temporary/missing-sealed.out"
 
-write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
 if run_guard >"$temporary/missing-mounted.out" 2>&1; then
   echo "missing config with a direct mount must fail" >&2
   exit 1
 fi
 grep -Fq "required config missing" "$temporary/missing-mounted.out"
 
-write_observed "11111111-2222-3333-4444-555555555555" apfs false "$(id -u)" "$(id -g)" 0700
+write_observed "$volume_uuid" apfs false "$(id -u)" "$(id -g)" 0700
 run_guard
 if run_guard --require-config \
   >"$temporary/unconfigured.out" 2>&1; then

--- a/tests/worktree-storage-test.sh
+++ b/tests/worktree-storage-test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+guard="$root/bin/agent-worktree-ops/worktree-storage-guard"
+temporary="$(mktemp -d)"
+temporary="$(cd "$temporary" && pwd -P)"
+trap 'rm -rf "$temporary"' EXIT
+
+home="$temporary/home"
+config="$temporary/external-worktree-storage.json"
+observed="$temporary/observed.json"
+mount_point="$home/.codex/worktrees"
+mkdir -p "$mount_point"
+chmod 0700 "$mount_point"
+
+write_config() {
+  local uuid="${1:-11111111-2222-3333-4444-555555555555}"
+  cat >"$config" <<EOF
+{"case_sensitive":false,"encrypted":true,"filesystem":"apfs","mount_point":"$mount_point","required":true,"schema_version":"external-worktree-storage.v1","volume_uuid":"$uuid"}
+EOF
+  chmod 0600 "$config"
+}
+
+write_observed() {
+  local uuid="$1"
+  local filesystem="$2"
+  local mounted="$3"
+  local owner_uid="$4"
+  local owner_gid="$5"
+  local mode="$6"
+  cat >"$observed" <<EOF
+{"case_sensitive":false,"device":200,"encrypted":true,"filesystem":"$filesystem","mode":"$mode","mount_point":"$mount_point","mounted":$mounted,"owner_gid":$owner_gid,"owner_uid":$owner_uid,"ownership_enabled":true,"parent_device":100,"volume_uuid":"$uuid"}
+EOF
+}
+
+run_guard() {
+  HOME="$home" \
+    WORKTREE_STORAGE_CONFIG="$config" \
+    WORKTREE_STORAGE_GUARD_TESTING=1 \
+    WORKTREE_STORAGE_GUARD_OBSERVED="$observed" \
+    "$guard" "$@"
+}
+
+write_config
+write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700
+[[ "$(run_guard --print-mount-point)" == "$mount_point" ]]
+
+owner_repo="$temporary/owner-repo"
+managed_worktree="$mount_point/owner-repo/feature"
+git init -q -b main "$owner_repo"
+git -C "$owner_repo" config user.name "Storage Test"
+git -C "$owner_repo" config user.email "storage@example.test"
+printf 'fixture\n' >"$owner_repo/README.md"
+git -C "$owner_repo" add README.md
+git -C "$owner_repo" commit -qm fixture
+mkdir -p "$(dirname "$managed_worktree")"
+git -C "$owner_repo" worktree add -q -b feature "$managed_worktree" main
+owner_common="$(git -C "$owner_repo" rev-parse --path-format=absolute --git-common-dir)"
+worktree_common="$(git -C "$managed_worktree" rev-parse --path-format=absolute --git-common-dir)"
+[[ "$owner_common" == "$worktree_common" ]]
+git -C "$owner_repo" worktree remove "$managed_worktree"
+
+write_observed "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" apfs true "$(id -u)" "$(id -g)" 0700
+if run_guard >"$temporary/wrong-uuid.out" 2>&1; then
+  echo "wrong UUID must fail" >&2
+  exit 1
+fi
+grep -Fq "UUID does not match policy" "$temporary/wrong-uuid.out"
+
+write_observed "11111111-2222-3333-4444-555555555555" exfat true "$(id -u)" "$(id -g)" 0700
+if run_guard >"$temporary/exfat.out" 2>&1; then
+  echo "ExFAT must fail" >&2
+  exit 1
+fi
+grep -Fq "not APFS" "$temporary/exfat.out"
+
+wheel_gid="$(python3 - <<'PY'
+import grp
+try:
+    print(grp.getgrnam("wheel").gr_gid)
+except KeyError:
+    print(0)
+PY
+)"
+write_observed "11111111-2222-3333-4444-555555555555" apfs false 0 "$wheel_gid" 0000
+if run_guard >"$temporary/absent.out" 2>&1; then
+  echo "absent mount must fail" >&2
+  exit 1
+fi
+grep -Fq "not mounted" "$temporary/absent.out"
+
+write_observed "11111111-2222-3333-4444-555555555555" apfs false "$(id -u)" "$(id -g)" 0700
+if run_guard >"$temporary/fallback.out" 2>&1; then
+  echo "writable fallback must fail" >&2
+  exit 1
+fi
+grep -Fq "fallback is writable" "$temporary/fallback.out"
+
+write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700
+run_guard
+write_observed "11111111-2222-3333-4444-555555555555" apfs false 0 "$wheel_gid" 0000
+if run_guard >"$temporary/hot-disappearance.out" 2>&1; then
+  echo "hot disappearance must fail closed" >&2
+  exit 1
+fi
+grep -Fq "not mounted" "$temporary/hot-disappearance.out"
+
+rm -rf "$mount_point"
+ln -s /Volumes/ExternalWorktrees "$mount_point"
+write_observed "11111111-2222-3333-4444-555555555555" apfs true "$(id -u)" "$(id -g)" 0700
+if run_guard >"$temporary/symlink.out" 2>&1; then
+  echo "symlinked canonical mount point must fail" >&2
+  exit 1
+fi
+grep -Fq "symlinked component" "$temporary/symlink.out"
+
+rm "$mount_point"
+mkdir "$mount_point"
+write_config pending
+if run_guard >"$temporary/pending.out" 2>&1; then
+  echo "pending UUID must fail" >&2
+  exit 1
+fi
+grep -Fq "policy is incomplete" "$temporary/pending.out"
+
+rm "$config"
+HOME="$home" WORKTREE_STORAGE_CONFIG="$config" "$guard"
+if HOME="$home" WORKTREE_STORAGE_CONFIG="$config" "$guard" --require-config \
+  >"$temporary/unconfigured.out" 2>&1; then
+  echo "required unconfigured storage must fail" >&2
+  exit 1
+fi
+grep -Fq "not configured" "$temporary/unconfigured.out"
+
+printf 'worktree storage tests passed\n'

--- a/tests/worktree-storage-test.sh
+++ b/tests/worktree-storage-test.sh
@@ -70,6 +70,38 @@ assert str(module.DEFAULT_CONFIG) == (
 source = pathlib.Path(sys.argv[1]).read_text()
 assert "com.apple.metadata:com_apple_backup_excludeItem" not in source
 assert '"/usr/bin/tmutil", "isexcluded"' in source
+assert module.normalized_device_location(
+    {
+        "BusProtocol": "USB",
+        "Internal": False,
+        "RemovableMediaOrExternalDevice": True,
+    }
+) == "External"
+assert module.normalized_device_location(
+    {
+        "BusProtocol": "USB",
+        "Internal": True,
+        "RemovableMediaOrExternalDevice": False,
+    }
+) is None
+assert module.normalized_device_location(
+    {
+        "BusProtocol": "Disk Image",
+        "Internal": False,
+        "RemovableMediaOrExternalDevice": True,
+    }
+) is None
+assert module.normalized_device_location(
+    {
+        "Internal": False,
+        "RemovableMediaOrExternalDevice": True,
+    }
+) is None
+assert module.normalized_device_location({}) is None
+assert module.normalized_encryption({"Encryption": True}) is True
+assert module.normalized_encryption({"Encryption": False, "Encrypted": True}) is False
+assert module.normalized_encryption({"Encrypted": True}) is True
+assert module.normalized_encryption({}) is None
 if os.getuid() != 0:
     try:
         module.load_config(pathlib.Path(sys.argv[2]), production_default=True)


### PR DESCRIPTION
## Summary

- add a fail-closed external worktree storage policy and runtime guard
- gate worktree creation, cleanup, maintenance, and deep-clean flows on verified storage
- add opt-in external scratch storage without changing global temporary directories

## Verification

- worktree storage guard tests
- external temporary-directory tests
- gwt cleanup tests
- agent worktree cleaner tests (36)
- agent worktree maintainer tests
- deepclean tests
- runtime installer tests
- codebase-memory policy tests
- privacy scan, diff check, merge compatibility, and signed-commit verification
