### PR TITLE
fix(claude): preserve writable managed settings

### DIFF
--- a/bin/claude-managed-settings
+++ b/bin/claude-managed-settings
@@ -136,11 +136,25 @@ def same(actual: dict, expected: dict) -> bool:
     return actual == expected
 
 
-def validate_json_file(value: dict, reason: str) -> bytes:
+def validate_json_file(
+    value: dict,
+    reason: str,
+    *,
+    require_writable: bool = True,
+) -> bytes:
+    mode = value.get("mode")
     if (
         value.get("kind") != "file"
         or value.get("uid") != os.getuid()
         or value.get("nlink") != 1
+        or not isinstance(mode, int)
+        or (
+            require_writable
+            and (
+                not mode & stat.S_IWUSR
+                or mode & (stat.S_IWGRP | stat.S_IWOTH)
+            )
+        )
     ):
         raise ManagedSettingsError(reason)
     payload = value["payload"]
@@ -174,7 +188,11 @@ def validate_baseline(dotfiles: pathlib.Path) -> tuple[dict, bytes]:
     parent = open_directory(dotfiles / ".claude")
     try:
         baseline = classify(parent["fd"], "settings.json", include_payload=True)
-        payload = validate_json_file(baseline, "baseline_incompatible")
+        payload = validate_json_file(
+            baseline,
+            "baseline_incompatible",
+            require_writable=False,
+        )
         check_directory(parent)
         return baseline, payload
     finally:

--- a/bin/claude-managed-settings
+++ b/bin/claude-managed-settings
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ctypes
+import hashlib
+import json
+import os
+import pathlib
+import stat
+import subprocess
+import sys
+
+
+MANAGED_LINK = "settings.managed.json"
+LINK_SIBLING = ".settings.json.managed-link"
+SEED_SIBLING = ".settings.managed.json.seed"
+RENAME_EXCL = 0x00000004
+RENAME_SWAP = 0x00000002
+
+
+class ManagedSettingsError(RuntimeError):
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+def sha256(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def write_all(descriptor: int, payload: bytes) -> None:
+    offset = 0
+    while offset < len(payload):
+        offset += os.write(descriptor, payload[offset:])
+
+
+def failpoint(name: str) -> None:
+    if os.environ.get("CLAUDE_MANAGED_SETTINGS_FAILPOINT") == name:
+        os._exit(86)
+
+
+def open_directory(path: pathlib.Path, create: bool = False) -> dict:
+    if create:
+        try:
+            os.mkdir(path, 0o700)
+        except FileExistsError:
+            pass
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as error:
+        raise ManagedSettingsError("parent_incompatible") from error
+    metadata = os.fstat(descriptor)
+    if not stat.S_ISDIR(metadata.st_mode) or metadata.st_uid != os.getuid():
+        os.close(descriptor)
+        raise ManagedSettingsError("parent_incompatible")
+    return {
+        "fd": descriptor,
+        "path": path,
+        "device": metadata.st_dev,
+        "inode": metadata.st_ino,
+    }
+
+
+def check_directory(parent: dict) -> None:
+    opened = os.fstat(parent["fd"])
+    try:
+        listed = os.stat(parent["path"], follow_symlinks=False)
+    except OSError as error:
+        raise ManagedSettingsError("parent_retargeted") from error
+    expected = (parent["device"], parent["inode"])
+    if (
+        not stat.S_ISDIR(opened.st_mode)
+        or (opened.st_dev, opened.st_ino) != expected
+        or (listed.st_dev, listed.st_ino) != expected
+    ):
+        raise ManagedSettingsError("parent_retargeted")
+
+
+def read_descriptor(descriptor: int) -> bytes:
+    blocks = []
+    while True:
+        block = os.read(descriptor, 1024 * 1024)
+        if not block:
+            return b"".join(blocks)
+        blocks.append(block)
+
+
+def classify(directory: int, name: str, include_payload: bool = False) -> dict:
+    try:
+        metadata = os.stat(name, dir_fd=directory, follow_symlinks=False)
+    except FileNotFoundError:
+        return {"kind": "absent"}
+    base = {
+        "device": metadata.st_dev,
+        "inode": metadata.st_ino,
+        "mode": stat.S_IMODE(metadata.st_mode),
+        "nlink": metadata.st_nlink,
+        "uid": metadata.st_uid,
+    }
+    if stat.S_ISLNK(metadata.st_mode):
+        return {
+            **base,
+            "kind": "symlink",
+            "target": os.readlink(name, dir_fd=directory),
+        }
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_nlink != 1:
+        return {**base, "kind": "other"}
+    try:
+        descriptor = os.open(
+            name,
+            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=directory,
+        )
+    except OSError as error:
+        raise ManagedSettingsError("target_changed") from error
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_nlink != 1
+            or (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino)
+        ):
+            raise ManagedSettingsError("target_changed")
+        payload = read_descriptor(descriptor)
+        result = {**base, "kind": "file", "size": len(payload), "sha256": sha256(payload)}
+        if include_payload:
+            result["payload"] = payload
+        return result
+    finally:
+        os.close(descriptor)
+
+
+def same(actual: dict, expected: dict) -> bool:
+    return actual == expected
+
+
+def validate_json_file(value: dict, reason: str) -> bytes:
+    if (
+        value.get("kind") != "file"
+        or value.get("uid") != os.getuid()
+        or value.get("nlink") != 1
+    ):
+        raise ManagedSettingsError(reason)
+    payload = value["payload"]
+    try:
+        parsed = json.loads(payload)
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise ManagedSettingsError("invalid_json") from error
+    if not isinstance(parsed, dict):
+        raise ManagedSettingsError("invalid_json")
+    return payload
+
+
+def git(*arguments: str, cwd: pathlib.Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *arguments],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def validate_baseline(dotfiles: pathlib.Path) -> tuple[dict, bytes]:
+    relative = ".claude/settings.json"
+    if git("ls-files", "--error-unmatch", "--", relative, cwd=dotfiles).returncode != 0:
+        raise ManagedSettingsError("baseline_untracked")
+    if (
+        git("diff", "--quiet", "--", relative, cwd=dotfiles).returncode != 0
+        or git("diff", "--cached", "--quiet", "--", relative, cwd=dotfiles).returncode != 0
+    ):
+        raise ManagedSettingsError("baseline_dirty")
+    parent = open_directory(dotfiles / ".claude")
+    try:
+        baseline = classify(parent["fd"], "settings.json", include_payload=True)
+        payload = validate_json_file(baseline, "baseline_incompatible")
+        check_directory(parent)
+        return baseline, payload
+    finally:
+        os.close(parent["fd"])
+
+
+def rename_atomic(directory: int, source: str, destination: str, flag: int) -> None:
+    if sys.platform == "darwin":
+        function = ctypes.CDLL(None, use_errno=True).renameatx_np
+    elif sys.platform.startswith("linux"):
+        function = ctypes.CDLL(None, use_errno=True).renameat2
+        flag = 1 if flag == RENAME_EXCL else 2
+    else:
+        raise ManagedSettingsError("atomic_rename_unavailable")
+    result = function(
+        directory,
+        source.encode(),
+        directory,
+        destination.encode(),
+        flag,
+    )
+    if result != 0:
+        raise ManagedSettingsError("atomic_rename_failed")
+    os.fsync(directory)
+
+
+def unlink_exact(parent: dict, name: str, expected: dict) -> None:
+    check_directory(parent)
+    if not same(classify(parent["fd"], name), expected):
+        raise ManagedSettingsError("target_changed")
+    os.unlink(name, dir_fd=parent["fd"])
+    os.fsync(parent["fd"])
+    check_directory(parent)
+
+
+def validate_symlink(value: dict, target: str) -> None:
+    if (
+        value.get("kind") != "symlink"
+        or value.get("target") != target
+        or value.get("uid") != os.getuid()
+        or value.get("nlink") != 1
+    ):
+        raise ManagedSettingsError("target_incompatible")
+
+
+def write_seed(parent: dict, payload: bytes) -> dict:
+    existing = classify(parent["fd"], SEED_SIBLING)
+    if existing["kind"] != "absent":
+        if (
+            existing["kind"] != "file"
+            or existing.get("uid") != os.getuid()
+            or existing.get("nlink") != 1
+        ):
+            raise ManagedSettingsError("recovery_required")
+        unlink_exact(parent, SEED_SIBLING, existing)
+    descriptor = os.open(
+        SEED_SIBLING,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+        0o600,
+        dir_fd=parent["fd"],
+    )
+    try:
+        write_all(descriptor, payload)
+        os.fchmod(descriptor, 0o600)
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    os.fsync(parent["fd"])
+    return classify(parent["fd"], SEED_SIBLING)
+
+
+def ensure_managed_target(parent: dict, baseline_payload: bytes) -> dict:
+    managed = classify(parent["fd"], MANAGED_LINK, include_payload=True)
+    if managed["kind"] == "absent":
+        seed = write_seed(parent, baseline_payload)
+        if seed.get("sha256") != sha256(baseline_payload):
+            raise ManagedSettingsError("seed_failed")
+        failpoint("before_managed_target")
+        rename_atomic(parent["fd"], SEED_SIBLING, MANAGED_LINK, RENAME_EXCL)
+        failpoint("after_managed_target")
+        managed = classify(parent["fd"], MANAGED_LINK, include_payload=True)
+    payload = validate_json_file(managed, "managed_target_incompatible")
+    if payload != baseline_payload:
+        raise ManagedSettingsError("managed_target_conflict")
+    seed = classify(parent["fd"], SEED_SIBLING)
+    if seed["kind"] != "absent":
+        if (
+            seed["kind"] != "file"
+            or seed.get("uid") != os.getuid()
+            or seed.get("nlink") != 1
+        ):
+            raise ManagedSettingsError("recovery_required")
+        unlink_exact(parent, SEED_SIBLING, seed)
+    return classify(parent["fd"], MANAGED_LINK)
+
+
+def ensure_link_sibling(parent: dict) -> dict:
+    sibling = classify(parent["fd"], LINK_SIBLING)
+    if sibling["kind"] == "absent":
+        os.symlink(MANAGED_LINK, LINK_SIBLING, dir_fd=parent["fd"])
+        os.fsync(parent["fd"])
+        sibling = classify(parent["fd"], LINK_SIBLING)
+    validate_symlink(sibling, MANAGED_LINK)
+    return sibling
+
+
+def finish_managed_recovery(parent: dict, legacy_target: str) -> None:
+    sibling = classify(parent["fd"], LINK_SIBLING)
+    if sibling["kind"] == "absent":
+        return
+    validate_symlink(sibling, legacy_target)
+    unlink_exact(parent, LINK_SIBLING, sibling)
+
+
+def apply(dotfiles: pathlib.Path, claude_dir: pathlib.Path) -> str:
+    baseline_spec, baseline_payload = validate_baseline(dotfiles)
+    baseline_path = str(dotfiles / ".claude/settings.json")
+    parent = open_directory(claude_dir, create=True)
+    try:
+        check_directory(parent)
+        settings = classify(parent["fd"], "settings.json", include_payload=True)
+        sibling = classify(parent["fd"], LINK_SIBLING)
+        if settings["kind"] == "file":
+            if sibling["kind"] != "absent":
+                raise ManagedSettingsError("recovery_required")
+            validate_json_file(settings, "target_incompatible")
+            state = "regular"
+        elif settings["kind"] == "symlink" and settings.get("target") == MANAGED_LINK:
+            validate_symlink(settings, MANAGED_LINK)
+            managed = classify(parent["fd"], MANAGED_LINK, include_payload=True)
+            validate_json_file(managed, "managed_target_incompatible")
+            finish_managed_recovery(parent, baseline_path)
+            state = "managed"
+        elif settings["kind"] == "symlink" and settings.get("target") == baseline_path:
+            validate_symlink(settings, baseline_path)
+            ensure_managed_target(parent, baseline_payload)
+            ensure_link_sibling(parent)
+            if not same(classify(parent["fd"], "settings.json"), settings):
+                raise ManagedSettingsError("target_changed")
+            failpoint("before_link_publish")
+            rename_atomic(parent["fd"], "settings.json", LINK_SIBLING, RENAME_SWAP)
+            failpoint("after_link_publish")
+            validate_symlink(classify(parent["fd"], "settings.json"), MANAGED_LINK)
+            if not same(classify(parent["fd"], LINK_SIBLING), settings):
+                raise ManagedSettingsError("target_changed")
+            unlink_exact(parent, LINK_SIBLING, settings)
+            state = "migrated"
+        elif settings["kind"] == "absent":
+            ensure_managed_target(parent, baseline_payload)
+            ensure_link_sibling(parent)
+            if classify(parent["fd"], "settings.json")["kind"] != "absent":
+                raise ManagedSettingsError("target_changed")
+            failpoint("before_link_publish")
+            rename_atomic(parent["fd"], LINK_SIBLING, "settings.json", RENAME_EXCL)
+            failpoint("after_link_publish")
+            validate_symlink(classify(parent["fd"], "settings.json"), MANAGED_LINK)
+            state = "created"
+        else:
+            raise ManagedSettingsError("target_incompatible")
+        check_directory(parent)
+        current_baseline, current_payload = validate_baseline(dotfiles)
+        if not same(current_baseline, baseline_spec) or current_payload != baseline_payload:
+            raise ManagedSettingsError("baseline_changed")
+        return state
+    finally:
+        os.close(parent["fd"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dotfiles-dir", type=pathlib.Path, required=True)
+    parser.add_argument("--claude-dir", type=pathlib.Path, required=True)
+    args = parser.parse_args()
+    if not args.dotfiles_dir.is_absolute() or not args.claude_dir.is_absolute():
+        print("claude_managed_settings=blocked reason=path_not_absolute")
+        return 2
+    try:
+        state = apply(args.dotfiles_dir, args.claude_dir)
+    except ManagedSettingsError as error:
+        print(f"claude_managed_settings=blocked reason={error.reason}")
+        return 2
+    print(f"claude_managed_settings=ready state={state}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/install.sh
+++ b/install.sh
@@ -94,24 +94,24 @@ install_linux_dependencies() {
     if command -v apt-get &>/dev/null; then
         info "Installing Linux packages via apt..."
         run_privileged apt-get update
-        run_privileged apt-get install -y zsh git curl locales ca-certificates gh unzip sqlite3
+        run_privileged apt-get install -y zsh git curl locales ca-certificates gh unzip sqlite3 python3
     elif command -v dnf &>/dev/null; then
         info "Installing Linux packages via dnf..."
-        run_privileged dnf install -y zsh git curl glibc-langpack-en ca-certificates
+        run_privileged dnf install -y zsh git curl glibc-langpack-en ca-certificates python3
     elif command -v yum &>/dev/null; then
         info "Installing Linux packages via yum..."
-        run_privileged yum install -y zsh git curl glibc-langpack-en ca-certificates
+        run_privileged yum install -y zsh git curl glibc-langpack-en ca-certificates python3
     elif command -v pacman &>/dev/null; then
         info "Installing Linux packages via pacman..."
-        run_privileged pacman -Sy --noconfirm zsh git curl ca-certificates
+        run_privileged pacman -Sy --noconfirm zsh git curl ca-certificates python
     elif command -v zypper &>/dev/null; then
         info "Installing Linux packages via zypper..."
-        run_privileged zypper --non-interactive install zsh git curl glibc-locale ca-certificates
+        run_privileged zypper --non-interactive install zsh git curl glibc-locale ca-certificates python3
     elif command -v apk &>/dev/null; then
         info "Installing Linux packages via apk..."
-        run_privileged apk add --no-cache zsh git curl ca-certificates musl-locales
+        run_privileged apk add --no-cache zsh git curl ca-certificates musl-locales python3
     else
-        warn "No supported package manager found. Ensure zsh, git, and curl are installed."
+        warn "No supported package manager found. Ensure zsh, git, curl, and python3 are installed."
     fi
 }
 
@@ -675,8 +675,12 @@ setup_claude_dotfiles() {
         error "Claude managed-settings helper missing: $claude_settings_helper"
         return 1
     fi
+    if ! command -v python3 >/dev/null 2>&1; then
+        error "Python 3 is required before Claude managed-settings setup"
+        return 1
+    fi
     if ! claude_settings_output="$(
-        "$claude_settings_helper" \
+        python3 "$claude_settings_helper" \
             --dotfiles-dir "$df_dir" \
             --claude-dir "$claude_dir"
     )"; then

--- a/install.sh
+++ b/install.sh
@@ -662,24 +662,28 @@ setup_codex_dotfiles() {
 }
 
 setup_claude_dotfiles() {
-    local df_dir claude_dir claude_settings_src claude_settings_dest
+    local df_dir claude_dir claude_settings_helper claude_settings_output
     local claude_desktop_dest claude_sessions_dir claude_account_uuid tmp_file
     local -a claude_session_files
     df_dir="$(dotfiles_dir)"
     claude_dir="$HOME/.claude"
-    claude_settings_src="$df_dir/.claude/settings.json"
-    claude_settings_dest="$claude_dir/settings.json"
+    claude_settings_helper="$df_dir/bin/claude-managed-settings"
     claude_desktop_dest="$HOME/Library/Application Support/Claude/claude_desktop_config.json"
     claude_sessions_dir="$HOME/Library/Application Support/Claude/claude-code-sessions"
 
-    if [[ ! -f "$claude_settings_src" ]]; then
-        warn "Claude settings file missing in dotfiles: $claude_settings_src"
-        return
+    if [[ ! -x "$claude_settings_helper" ]]; then
+        error "Claude managed-settings helper missing: $claude_settings_helper"
+        return 1
     fi
-
-    mkdir -p "$claude_dir"
-    link_dotfile "$claude_settings_src" "$claude_settings_dest"
-    success "Claude settings linked to $claude_settings_src"
+    if ! claude_settings_output="$(
+        "$claude_settings_helper" \
+            --dotfiles-dir "$df_dir" \
+            --claude-dir "$claude_dir"
+    )"; then
+        error "$claude_settings_output"
+        return 1
+    fi
+    success "$claude_settings_output"
 
     if [[ "$(uname)" == "Darwin" ]] && command -v jq >/dev/null 2>&1; then
         mkdir -p "$(dirname "$claude_desktop_dest")"

--- a/tests/claude-managed-settings-test.sh
+++ b/tests/claude-managed-settings-test.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+helper="$root/bin/claude-managed-settings"
+fixture="$(cd "$(mktemp -d "${TMPDIR:-/tmp}/claude-managed-settings-test.XXXXXX")" && pwd -P)"
+trap 'rm -rf "$fixture"' EXIT
+
+new_repo() {
+  local name="$1"
+  local repo="$fixture/$name/dotfiles"
+  mkdir -p "$repo/.claude"
+  printf '{"hooks":{"baseline":true}}\n' >"$repo/.claude/settings.json"
+  git -C "$repo" init -q -b master
+  git -C "$repo" add .claude/settings.json
+  git -C "$repo" \
+    -c user.name=Test \
+    -c user.email=test@example.com \
+    -c commit.gpgsign=false \
+    commit -qm 'test: baseline'
+  printf '%s\n' "$repo"
+}
+
+run_helper() {
+  local repo="$1"
+  local claude_dir="$2"
+  shift 2
+  "$@" "$helper" --dotfiles-dir "$repo" --claude-dir "$claude_dir"
+}
+
+assert_repo_clean() {
+  local repo="$1"
+  [[ -z "$(git -C "$repo" status --porcelain)" ]]
+}
+
+legacy_repo="$(new_repo legacy)"
+legacy_claude="$fixture/legacy/home/.claude"
+mkdir -p "$legacy_claude"
+ln -s "$legacy_repo/.claude/settings.json" "$legacy_claude/settings.json"
+legacy_baseline_hash="$(shasum -a 256 "$legacy_repo/.claude/settings.json" | awk '{print $1}')"
+legacy_output="$(run_helper "$legacy_repo" "$legacy_claude" env)"
+[[ "$legacy_output" == "claude_managed_settings=ready state=migrated" ]]
+[[ "$(readlink "$legacy_claude/settings.json")" == settings.managed.json ]]
+cmp -s "$legacy_repo/.claude/settings.json" "$legacy_claude/settings.managed.json"
+[[ "$(shasum -a 256 "$legacy_repo/.claude/settings.json" | awk '{print $1}')" == "$legacy_baseline_hash" ]]
+managed_hash="$(shasum -a 256 "$legacy_claude/settings.managed.json" | awk '{print $1}')"
+[[ "$(run_helper "$legacy_repo" "$legacy_claude" env)" == "claude_managed_settings=ready state=managed" ]]
+[[ "$(shasum -a 256 "$legacy_claude/settings.managed.json" | awk '{print $1}')" == "$managed_hash" ]]
+assert_repo_clean "$legacy_repo"
+
+managed_repo="$(new_repo managed)"
+managed_claude="$fixture/managed/home/.claude"
+mkdir -p "$managed_claude"
+printf '{"hooks":{"machine":true}}\n' >"$managed_claude/settings.managed.json"
+ln -s settings.managed.json "$managed_claude/settings.json"
+managed_before="$(shasum -a 256 "$managed_claude/settings.managed.json" | awk '{print $1}')"
+[[ "$(run_helper "$managed_repo" "$managed_claude" env)" == "claude_managed_settings=ready state=managed" ]]
+[[ "$(shasum -a 256 "$managed_claude/settings.managed.json" | awk '{print $1}')" == "$managed_before" ]]
+assert_repo_clean "$managed_repo"
+
+regular_repo="$(new_repo regular)"
+regular_claude="$fixture/regular/home/.claude"
+mkdir -p "$regular_claude"
+printf '{"hooks":{"machine":true}}\n' >"$regular_claude/settings.json"
+regular_before="$(shasum -a 256 "$regular_claude/settings.json" | awk '{print $1}')"
+[[ "$(run_helper "$regular_repo" "$regular_claude" env)" == "claude_managed_settings=ready state=regular" ]]
+[[ "$(shasum -a 256 "$regular_claude/settings.json" | awk '{print $1}')" == "$regular_before" ]]
+[[ ! -e "$regular_claude/settings.managed.json" ]]
+assert_repo_clean "$regular_repo"
+
+absent_repo="$(new_repo absent)"
+absent_claude="$fixture/absent/home/.claude"
+mkdir -p "$(dirname "$absent_claude")"
+[[ "$(run_helper "$absent_repo" "$absent_claude" env)" == "claude_managed_settings=ready state=created" ]]
+[[ "$(readlink "$absent_claude/settings.json")" == settings.managed.json ]]
+cmp -s "$absent_repo/.claude/settings.json" "$absent_claude/settings.managed.json"
+assert_repo_clean "$absent_repo"
+
+for link_target in /tmp/absolute.json ../escape.json missing.json intermediate.json; do
+  name="$(printf '%s' "$link_target" | tr '/.' '__')"
+  repo="$(new_repo "hostile-$name")"
+  claude="$fixture/hostile-$name/home/.claude"
+  mkdir -p "$claude"
+  if [[ "$link_target" == intermediate.json ]]; then
+    ln -s final.json "$claude/intermediate.json"
+  fi
+  ln -s "$link_target" "$claude/settings.json"
+  if output="$(run_helper "$repo" "$claude" env 2>&1)"; then
+    printf 'expected hostile link rejection: %s\n' "$link_target" >&2
+    exit 1
+  fi
+  [[ "$output" == "claude_managed_settings=blocked reason=target_incompatible" ]]
+  [[ "$(readlink "$claude/settings.json")" == "$link_target" ]]
+  assert_repo_clean "$repo"
+done
+
+broken_repo="$(new_repo broken-managed)"
+broken_claude="$fixture/broken-managed/home/.claude"
+mkdir -p "$broken_claude"
+ln -s settings.managed.json "$broken_claude/settings.json"
+if broken_output="$(run_helper "$broken_repo" "$broken_claude" env 2>&1)"; then
+  printf 'expected broken managed link rejection\n' >&2
+  exit 1
+fi
+[[ "$broken_output" == "claude_managed_settings=blocked reason=managed_target_incompatible" ]]
+
+hardlink_repo="$(new_repo hardlink)"
+hardlink_claude="$fixture/hardlink/home/.claude"
+mkdir -p "$hardlink_claude"
+printf '{}\n' >"$hardlink_claude/source.json"
+ln "$hardlink_claude/source.json" "$hardlink_claude/settings.json"
+if hardlink_output="$(run_helper "$hardlink_repo" "$hardlink_claude" env 2>&1)"; then
+  printf 'expected settings hard-link rejection\n' >&2
+  exit 1
+fi
+[[ "$hardlink_output" == "claude_managed_settings=blocked reason=target_incompatible" ]]
+
+managed_hardlink_repo="$(new_repo managed-hardlink)"
+managed_hardlink_claude="$fixture/managed-hardlink/home/.claude"
+mkdir -p "$managed_hardlink_claude"
+printf '{}\n' >"$managed_hardlink_claude/source.json"
+ln "$managed_hardlink_claude/source.json" "$managed_hardlink_claude/settings.managed.json"
+ln -s settings.managed.json "$managed_hardlink_claude/settings.json"
+if managed_hardlink_output="$(run_helper "$managed_hardlink_repo" "$managed_hardlink_claude" env 2>&1)"; then
+  printf 'expected managed-target hard-link rejection\n' >&2
+  exit 1
+fi
+[[ "$managed_hardlink_output" == "claude_managed_settings=blocked reason=managed_target_incompatible" ]]
+
+nonregular_repo="$(new_repo nonregular)"
+nonregular_claude="$fixture/nonregular/home/.claude"
+mkdir -p "$nonregular_claude/settings.managed.json"
+ln -s settings.managed.json "$nonregular_claude/settings.json"
+if nonregular_output="$(run_helper "$nonregular_repo" "$nonregular_claude" env 2>&1)"; then
+  printf 'expected nonregular managed-target rejection\n' >&2
+  exit 1
+fi
+[[ "$nonregular_output" == "claude_managed_settings=blocked reason=managed_target_incompatible" ]]
+
+invalid_repo="$(new_repo invalid)"
+invalid_claude="$fixture/invalid/home/.claude"
+mkdir -p "$invalid_claude"
+printf '{broken\n' >"$invalid_claude/settings.json"
+if invalid_output="$(run_helper "$invalid_repo" "$invalid_claude" env 2>&1)"; then
+  printf 'expected invalid JSON rejection\n' >&2
+  exit 1
+fi
+[[ "$invalid_output" == "claude_managed_settings=blocked reason=invalid_json" ]]
+
+invalid_baseline_repo="$(new_repo invalid-baseline)"
+invalid_baseline_claude="$fixture/invalid-baseline/home/.claude"
+printf '{broken\n' >"$invalid_baseline_repo/.claude/settings.json"
+git -C "$invalid_baseline_repo" add .claude/settings.json
+git -C "$invalid_baseline_repo" \
+  -c user.name=Test \
+  -c user.email=test@example.com \
+  -c commit.gpgsign=false \
+  commit -qm 'test: invalid baseline'
+if invalid_baseline_output="$(run_helper "$invalid_baseline_repo" "$invalid_baseline_claude" env 2>&1)"; then
+  printf 'expected invalid tracked baseline rejection\n' >&2
+  exit 1
+fi
+[[ "$invalid_baseline_output" == "claude_managed_settings=blocked reason=invalid_json" ]]
+[[ ! -e "$invalid_baseline_claude" ]]
+
+for initial in absent legacy; do
+  for point in before_managed_target after_managed_target before_link_publish after_link_publish; do
+    name="interrupt-$initial-${point//_/-}"
+    repo="$(new_repo "$name")"
+    claude="$fixture/$name/home/.claude"
+    mkdir -p "$claude"
+    if [[ "$initial" == legacy ]]; then
+      ln -s "$repo/.claude/settings.json" "$claude/settings.json"
+    fi
+    set +e
+    run_helper "$repo" "$claude" env CLAUDE_MANAGED_SETTINGS_FAILPOINT="$point" >/dev/null 2>&1
+    status=$?
+    set -e
+    [[ "$status" == 86 ]]
+    recovered="$(run_helper "$repo" "$claude" env)"
+    case "$recovered" in
+      "claude_managed_settings=ready state=created" | \
+      "claude_managed_settings=ready state=migrated" | \
+      "claude_managed_settings=ready state=managed") ;;
+      *)
+        printf 'unexpected recovery result: %s\n' "$recovered" >&2
+        exit 1
+        ;;
+    esac
+    [[ "$(readlink "$claude/settings.json")" == settings.managed.json ]]
+    cmp -s "$repo/.claude/settings.json" "$claude/settings.managed.json"
+    [[ ! -e "$claude/.settings.json.managed-link" ]]
+    [[ ! -e "$claude/.settings.managed.json.seed" ]]
+    assert_repo_clean "$repo"
+  done
+done
+
+dirty_repo="$(new_repo dirty-baseline)"
+dirty_claude="$fixture/dirty-baseline/home/.claude"
+printf ' ' >>"$dirty_repo/.claude/settings.json"
+if dirty_output="$(run_helper "$dirty_repo" "$dirty_claude" env 2>&1)"; then
+  printf 'expected dirty baseline rejection\n' >&2
+  exit 1
+fi
+[[ "$dirty_output" == "claude_managed_settings=blocked reason=baseline_dirty" ]]
+[[ ! -e "$dirty_claude" ]]
+
+setup_home="$fixture/setup-integration/home"
+setup_repo="$(new_repo setup-integration)"
+mkdir -p "$setup_repo/bin"
+cp "$helper" "$setup_repo/bin/claude-managed-settings"
+chmod 0755 "$setup_repo/bin/claude-managed-settings"
+git -C "$setup_repo" add bin/claude-managed-settings
+git -C "$setup_repo" \
+  -c user.name=Test \
+  -c user.email=test@example.com \
+  -c commit.gpgsign=false \
+  commit -qm 'test: helper'
+mkdir -p "$setup_home/GIT/_Perso"
+mv "$setup_repo" "$setup_home/GIT/_Perso/dotfiles"
+fake_bin="$fixture/setup-integration/bin"
+mkdir -p "$fake_bin"
+cat >"$fake_bin/uname" <<'EOF'
+#!/usr/bin/env bash
+printf 'Linux\n'
+EOF
+chmod 0755 "$fake_bin/uname"
+HOME="$setup_home" PATH="$fake_bin:$PATH" bash -c '
+  source "$1/install.sh"
+  setup_claude_dotfiles
+' _ "$root" >/dev/null
+[[ "$(readlink "$setup_home/.claude/settings.json")" == settings.managed.json ]]
+cmp -s \
+  "$setup_home/GIT/_Perso/dotfiles/.claude/settings.json" \
+  "$setup_home/.claude/settings.managed.json"
+assert_repo_clean "$setup_home/GIT/_Perso/dotfiles"
+
+printf 'claude_managed_settings_test=passed\n'

--- a/tests/claude-managed-settings-test.sh
+++ b/tests/claude-managed-settings-test.sh
@@ -33,6 +33,12 @@ assert_repo_clean() {
   [[ -z "$(git -C "$repo" status --porcelain)" ]]
 }
 
+file_mode() {
+  python3 -c \
+    'import os, sys; print(format(os.stat(sys.argv[1], follow_symlinks=False).st_mode & 0o777, "o"))' \
+    "$1"
+}
+
 legacy_repo="$(new_repo legacy)"
 legacy_claude="$fixture/legacy/home/.claude"
 mkdir -p "$legacy_claude"
@@ -67,6 +73,33 @@ regular_before="$(shasum -a 256 "$regular_claude/settings.json" | awk '{print $1
 [[ "$(shasum -a 256 "$regular_claude/settings.json" | awk '{print $1}')" == "$regular_before" ]]
 [[ ! -e "$regular_claude/settings.managed.json" ]]
 assert_repo_clean "$regular_repo"
+
+for state in regular managed; do
+  for mode in 0400 0666; do
+    name="unsafe-mode-$state-$mode"
+    repo="$(new_repo "$name")"
+    claude="$fixture/$name/home/.claude"
+    mkdir -p "$claude"
+    if [[ "$state" == managed ]]; then
+      target="$claude/settings.managed.json"
+      printf '{"hooks":{"machine":true}}\n' >"$target"
+      ln -s settings.managed.json "$claude/settings.json"
+      expected_reason=managed_target_incompatible
+    else
+      target="$claude/settings.json"
+      printf '{"hooks":{"machine":true}}\n' >"$target"
+      expected_reason=target_incompatible
+    fi
+    chmod "$mode" "$target"
+    if mode_output="$(run_helper "$repo" "$claude" env 2>&1)"; then
+      printf 'expected unsafe mode rejection: %s %s\n' "$state" "$mode" >&2
+      exit 1
+    fi
+    [[ "$mode_output" == "claude_managed_settings=blocked reason=$expected_reason" ]]
+    [[ "$(file_mode "$target")" == "${mode#0}" ]]
+    assert_repo_clean "$repo"
+  done
+done
 
 absent_repo="$(new_repo absent)"
 absent_claude="$fixture/absent/home/.claude"
@@ -126,6 +159,29 @@ if managed_hardlink_output="$(run_helper "$managed_hardlink_repo" "$managed_hard
   exit 1
 fi
 [[ "$managed_hardlink_output" == "claude_managed_settings=blocked reason=managed_target_incompatible" ]]
+
+reserved_link_repo="$(new_repo reserved-link)"
+reserved_link_claude="$fixture/reserved-link/home/.claude"
+mkdir -p "$reserved_link_claude"
+printf '{}\n' >"$reserved_link_claude/settings.json"
+printf 'operator marker\n' >"$reserved_link_claude/.settings.json.managed-link"
+if reserved_link_output="$(run_helper "$reserved_link_repo" "$reserved_link_claude" env 2>&1)"; then
+  printf 'expected reserved link marker rejection\n' >&2
+  exit 1
+fi
+[[ "$reserved_link_output" == "claude_managed_settings=blocked reason=recovery_required" ]]
+[[ "$(cat "$reserved_link_claude/.settings.json.managed-link")" == "operator marker" ]]
+
+reserved_seed_repo="$(new_repo reserved-seed)"
+reserved_seed_claude="$fixture/reserved-seed/home/.claude"
+mkdir -p "$reserved_seed_claude"
+ln -s operator.json "$reserved_seed_claude/.settings.managed.json.seed"
+if reserved_seed_output="$(run_helper "$reserved_seed_repo" "$reserved_seed_claude" env 2>&1)"; then
+  printf 'expected reserved seed marker rejection\n' >&2
+  exit 1
+fi
+[[ "$reserved_seed_output" == "claude_managed_settings=blocked reason=recovery_required" ]]
+[[ "$(readlink "$reserved_seed_claude/.settings.managed.json.seed")" == operator.json ]]
 
 nonregular_repo="$(new_repo nonregular)"
 nonregular_claude="$fixture/nonregular/home/.claude"
@@ -204,6 +260,27 @@ if dirty_output="$(run_helper "$dirty_repo" "$dirty_claude" env 2>&1)"; then
 fi
 [[ "$dirty_output" == "claude_managed_settings=blocked reason=baseline_dirty" ]]
 [[ ! -e "$dirty_claude" ]]
+
+minimal_home="$fixture/minimal-linux/home"
+minimal_repo="$(new_repo minimal-linux)"
+mkdir -p "$minimal_repo/bin" "$minimal_home/GIT/_Perso"
+cp "$helper" "$minimal_repo/bin/claude-managed-settings"
+chmod 0755 "$minimal_repo/bin/claude-managed-settings"
+mv "$minimal_repo" "$minimal_home/GIT/_Perso/dotfiles"
+minimal_bin="$fixture/minimal-linux/bin"
+mkdir -p "$minimal_bin"
+set +e
+minimal_output="$(
+  HOME="$minimal_home" PATH="$minimal_bin" /bin/bash -c '
+    source "$1/install.sh"
+    setup_claude_dotfiles
+  ' _ "$root" 2>&1
+)"
+minimal_status=$?
+set -e
+[[ "$minimal_status" == 1 ]]
+grep -Fq 'Python 3 is required before Claude managed-settings setup' <<<"$minimal_output"
+[[ ! -e "$minimal_home/.claude" ]]
 
 setup_home="$fixture/setup-integration/home"
 setup_repo="$(new_repo setup-integration)"

--- a/tests/test_claude_managed_settings.py
+++ b/tests/test_claude_managed_settings.py
@@ -20,11 +20,38 @@ class ValidationTests(unittest.TestCase):
             "kind": "file",
             "uid": MODULE.os.getuid() + 1,
             "nlink": 1,
+            "mode": 0o600,
             "payload": b"{}\n",
         }
         with self.assertRaises(MODULE.ManagedSettingsError) as raised:
             MODULE.validate_json_file(value, "target_incompatible")
         self.assertEqual(raised.exception.reason, "target_incompatible")
+
+    def test_read_only_file_is_rejected(self):
+        value = {
+            "kind": "file",
+            "uid": MODULE.os.getuid(),
+            "nlink": 1,
+            "mode": 0o400,
+            "payload": b"{}\n",
+        }
+        with self.assertRaises(MODULE.ManagedSettingsError) as raised:
+            MODULE.validate_json_file(value, "target_incompatible")
+        self.assertEqual(raised.exception.reason, "target_incompatible")
+
+    def test_group_or_world_writable_file_is_rejected(self):
+        for mode in (0o620, 0o602, 0o666):
+            with self.subTest(mode=oct(mode)):
+                value = {
+                    "kind": "file",
+                    "uid": MODULE.os.getuid(),
+                    "nlink": 1,
+                    "mode": mode,
+                    "payload": b"{}\n",
+                }
+                with self.assertRaises(MODULE.ManagedSettingsError) as raised:
+                    MODULE.validate_json_file(value, "target_incompatible")
+                self.assertEqual(raised.exception.reason, "target_incompatible")
 
     def test_managed_symlink_wrong_owner_is_rejected(self):
         value = {

--- a/tests/test_claude_managed_settings.py
+++ b/tests/test_claude_managed_settings.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.machinery
+import importlib.util
+import pathlib
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "bin" / "claude-managed-settings"
+LOADER = importlib.machinery.SourceFileLoader("claude_managed_settings", str(SCRIPT))
+SPEC = importlib.util.spec_from_loader(LOADER.name, LOADER)
+MODULE = importlib.util.module_from_spec(SPEC)
+LOADER.exec_module(MODULE)
+
+
+class ValidationTests(unittest.TestCase):
+    def test_regular_file_wrong_owner_is_rejected(self):
+        value = {
+            "kind": "file",
+            "uid": MODULE.os.getuid() + 1,
+            "nlink": 1,
+            "payload": b"{}\n",
+        }
+        with self.assertRaises(MODULE.ManagedSettingsError) as raised:
+            MODULE.validate_json_file(value, "target_incompatible")
+        self.assertEqual(raised.exception.reason, "target_incompatible")
+
+    def test_managed_symlink_wrong_owner_is_rejected(self):
+        value = {
+            "kind": "symlink",
+            "uid": MODULE.os.getuid() + 1,
+            "nlink": 1,
+            "target": MODULE.MANAGED_LINK,
+        }
+        with self.assertRaises(MODULE.ManagedSettingsError) as raised:
+            MODULE.validate_symlink(value, MODULE.MANAGED_LINK)
+        self.assertEqual(raised.exception.reason, "target_incompatible")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a standalone Claude managed-settings helper used by `setup_claude_dotfiles`
- preserve the tracked settings baseline while maintaining a writable `settings.managed.json`
- install or preflight Python 3 before any helper invocation on supported Linux setup paths
- require effective settings files to be owner-writable and reject group/world-writable modes
- support exact legacy migration, existing managed links, regular machine-local settings, and absent settings
- refuse hostile, escaping, broken, multi-hop, hard-linked, nonregular, wrong-owner, unsafe-mode, dirty-baseline, invalid-JSON, and reserved-marker states
- recover idempotently across managed-target and logical-link publication interruptions

## Verification

- `bash tests/claude-managed-settings-test.sh`
- `python3 tests/test_claude_managed_settings.py -v` (4 tests)
- Python compile checks, `bash -n`, and `git diff --check`
- private-path, hostname, IP, email, and secret scans

## Scope

No deployment, fleet convergence, codebase-memory, credential, browser, or process-control changes.
