### PR TITLE
fix(git): separate SSH signing from GPG

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -17,7 +17,6 @@
 
 [gpg]
 	format = ssh
-	program = /opt/homebrew/bin/gpg
 	# git config --global gpg.program "$(which gpg)"
 	# TODO: fix gpg alias for github client
 	# program = /opt/homebrew/bin/gpg

--- a/bin/git-signing-mode
+++ b/bin/git-signing-mode
@@ -66,6 +66,37 @@ ssh_allowed_signer_ready() {
   [[ "$canonical_count" == 1 && "$matching_count" == 1 ]]
 }
 
+clear_gpg_program() {
+  local status
+
+  if git config --global --get-all gpg.program >/dev/null; then
+    if git config --global --unset-all gpg.program; then
+      :
+    else
+      status=$?
+      echo "git-signing-mode: failed to remove gpg.program" >&2
+      return "$status"
+    fi
+  else
+    status=$?
+    if [[ "$status" -ne 1 ]]; then
+      echo "git-signing-mode: failed to inspect gpg.program" >&2
+      return "$status"
+    fi
+  fi
+
+  if git config --global --get-all gpg.program >/dev/null; then
+    echo "git-signing-mode: gpg.program remains configured" >&2
+    return 1
+  else
+    status=$?
+    if [[ "$status" -ne 1 ]]; then
+      echo "git-signing-mode: failed to verify gpg.program removal" >&2
+      return "$status"
+    fi
+  fi
+}
+
 set_ssh_mode() {
   local configured_allowed_signers derived_public_key observed_fingerprint observed_public_key
   local ssh_allowed_signers="$HOME/GIT/_Perso/dotfiles/.ssh/allowed_signers"
@@ -110,8 +141,8 @@ set_ssh_mode() {
     exit 1
   fi
 
+  clear_gpg_program
   git config --global gpg.format ssh
-  git config --global --unset-all gpg.program >/dev/null 2>&1 || true
   git config --global gpg.ssh.program "${ssh_program}"
   git config --global gpg.ssh.allowedSignersFile "${ssh_allowed_signers_config}"
   git config --global user.signingkey "${ssh_key_config}"

--- a/bin/git-signing-mode
+++ b/bin/git-signing-mode
@@ -12,6 +12,7 @@ ssh_signing_fingerprint='SHA256:OIEOnMWCJeKhWpBNlB42wwPuUG5gsC8Crq1ibnt7ylQ'
 ssh_allowed_signers_config='~/GIT/_Perso/dotfiles/.ssh/allowed_signers'
 gpg_program="/opt/homebrew/bin/gpg"
 gpg_key_id="FB4C24AE87080A95"
+ssh_program="/usr/bin/ssh-keygen"
 
 usage() {
   cat <<'EOF'
@@ -31,7 +32,7 @@ require_git_config() {
 }
 
 show_status() {
-  git config --global --show-origin --get-regexp '^(user.signingkey|commit.gpgsign|tag.gpgsign|gpg\.format|gpg\.program|gpg\.ssh\.allowedSignersFile)$' || true
+  git config --global --show-origin --get-regexp '^(user.signingkey|commit.gpgsign|tag.gpgsign|gpg\.format|gpg\.program|gpg\.ssh\.(allowedSignersFile|program))$' || true
 }
 
 canonical_ssh_allowed_signer() {
@@ -110,7 +111,8 @@ set_ssh_mode() {
   fi
 
   git config --global gpg.format ssh
-  git config --global gpg.program "${gpg_program}"
+  git config --global --unset-all gpg.program >/dev/null 2>&1 || true
+  git config --global gpg.ssh.program "${ssh_program}"
   git config --global gpg.ssh.allowedSignersFile "${ssh_allowed_signers_config}"
   git config --global user.signingkey "${ssh_key_config}"
   git config --global commit.gpgsign true

--- a/tests/git-signing-trust-test.sh
+++ b/tests/git-signing-trust-test.sh
@@ -191,6 +191,83 @@ if grep -Fq "$mode_home" "$mode_home/.gitconfig"; then
   exit 1
 fi
 
+(
+  export HOME="$mode_home"
+  export GIT_CONFIG_GLOBAL="$mode_home/.gitconfig"
+  source "$repo_root/bin/git-signing-mode"
+  ssh_signing_public_key="$fixture_public_key"
+  ssh_signing_fingerprint="$fixture_fingerprint"
+  main ssh
+) >"$fixture/mode-absent.out"
+grep -Fq 'git signing mode: ssh' "$fixture/mode-absent.out"
+if HOME="$mode_home" GIT_CONFIG_GLOBAL="$mode_home/.gitconfig" \
+  git config --global --get-all gpg.program >/dev/null 2>&1; then
+  echo 'git-signing-mode recreated gpg.program from the absent path' >&2
+  exit 1
+fi
+
+unset_failure_home="$fixture/unset-failure-home"
+unset_failure_allowed_signers="$unset_failure_home/GIT/_Perso/dotfiles/.ssh/allowed_signers"
+failing_git_dir="$fixture/failing-git"
+real_git="$(command -v git)"
+mkdir -p \
+  "$(dirname "$unset_failure_allowed_signers")" \
+  "$unset_failure_home/.ssh" \
+  "$failing_git_dir"
+cp "$fixture_key" "$unset_failure_home/.ssh/git_signing_vincentkoc_ieee"
+cp "$fixture_key.pub" "$unset_failure_home/.ssh/git_signing_vincentkoc_ieee.pub"
+printf '%s\n' "$mode_expected" > "$unset_failure_allowed_signers"
+HOME="$unset_failure_home" GIT_CONFIG_GLOBAL="$unset_failure_home/.gitconfig" \
+  git config --global gpg.program /stale/gpg
+HOME="$unset_failure_home" GIT_CONFIG_GLOBAL="$unset_failure_home/.gitconfig" \
+  git config --global test.preserved unrelated-value
+cat > "$failing_git_dir/git" <<EOF
+#!/usr/bin/env bash
+if [[ "\${1:-}" == config &&
+  "\${2:-}" == --global &&
+  "\${3:-}" == --unset-all &&
+  "\${4:-}" == gpg.program ]]; then
+  echo 'forced gpg.program unset failure' >&2
+  exit 73
+fi
+exec "$real_git" "\$@"
+EOF
+chmod +x "$failing_git_dir/git"
+unset_failure_before="$(
+  shasum -a 256 "$unset_failure_home/.gitconfig" | awk '{print $1}'
+)"
+set +e
+(
+  export HOME="$unset_failure_home"
+  export GIT_CONFIG_GLOBAL="$unset_failure_home/.gitconfig"
+  export PATH="$failing_git_dir:$PATH"
+  source "$repo_root/bin/git-signing-mode"
+  ssh_signing_public_key="$fixture_public_key"
+  ssh_signing_fingerprint="$fixture_fingerprint"
+  main ssh
+) >"$fixture/mode-unset-failure.out" 2>&1
+unset_failure_status=$?
+set -e
+[[ "$unset_failure_status" == 73 ]]
+unset_failure_after="$(
+  shasum -a 256 "$unset_failure_home/.gitconfig" | awk '{print $1}'
+)"
+[[ "$unset_failure_before" == "$unset_failure_after" ]]
+[[ "$(
+  HOME="$unset_failure_home" GIT_CONFIG_GLOBAL="$unset_failure_home/.gitconfig" \
+    git config --global --get-all gpg.program
+)" == /stale/gpg ]]
+[[ "$(
+  HOME="$unset_failure_home" GIT_CONFIG_GLOBAL="$unset_failure_home/.gitconfig" \
+    git config --global --get test.preserved
+)" == unrelated-value ]]
+grep -Fq 'forced gpg.program unset failure' "$fixture/mode-unset-failure.out"
+grep -Fq 'failed to remove gpg.program' "$fixture/mode-unset-failure.out"
+if grep -Fq 'git signing mode: ssh' "$fixture/mode-unset-failure.out"; then
+  echo 'git-signing-mode reported success after gpg.program unset failure' >&2
+  exit 1
+fi
+
 mode_config_before="$(shasum -a 256 "$mode_home/.gitconfig" | awk '{print $1}')"
 if (
   export HOME="$mode_home"

--- a/tests/git-signing-trust-test.sh
+++ b/tests/git-signing-trust-test.sh
@@ -137,6 +137,14 @@ cp "$fixture_key.pub" "$mode_home/.ssh/git_signing_vincentkoc_ieee.pub"
 fixture_fingerprint="$(ssh-keygen -lf "$fixture_key.pub" | awk '{print $2}')"
 mode_expected="$SSH_SIGNING_PRINCIPAL namespaces=\"$SSH_SIGNING_NAMESPACES\" $fixture_public_key"
 printf '%s\n' "$mode_expected" > "$mode_allowed_signers"
+HOME="$mode_home" GIT_CONFIG_GLOBAL="$mode_home/.gitconfig" \
+  git config --global gpg.program /stale/gpg
+HOME="$mode_home" GIT_CONFIG_GLOBAL="$mode_home/.gitconfig" \
+  git config --global --add gpg.program /second-stale/gpg
+HOME="$mode_home" GIT_CONFIG_GLOBAL="$mode_home/.gitconfig" \
+  git config --global gpg.ssh.program /stale/ssh-keygen
+HOME="$mode_home" GIT_CONFIG_GLOBAL="$mode_home/.gitconfig" \
+  git config --global test.preserved unrelated-value
 (
   export HOME="$mode_home"
   export GIT_CONFIG_GLOBAL="$mode_home/.gitconfig"
@@ -147,16 +155,60 @@ printf '%s\n' "$mode_expected" > "$mode_allowed_signers"
 ) >/dev/null
 [[ "$(
   HOME="$mode_home" GIT_CONFIG_GLOBAL="$mode_home/.gitconfig" \
-    git config --global --get user.signingkey
+    git config --global --get-all user.signingkey
 )" == '~/.ssh/git_signing_vincentkoc_ieee' ]]
 [[ "$(
   HOME="$mode_home" GIT_CONFIG_GLOBAL="$mode_home/.gitconfig" \
-    git config --global --get gpg.ssh.allowedSignersFile
+    git config --global --get-all gpg.ssh.allowedSignersFile
 )" == '~/GIT/_Perso/dotfiles/.ssh/allowed_signers' ]]
+[[ "$(
+  HOME="$mode_home" GIT_CONFIG_GLOBAL="$mode_home/.gitconfig" \
+    git config --global --get-all gpg.format
+)" == ssh ]]
+[[ "$(
+  HOME="$mode_home" GIT_CONFIG_GLOBAL="$mode_home/.gitconfig" \
+    git config --global --get-all gpg.ssh.program
+)" == /usr/bin/ssh-keygen ]]
+[[ "$(
+  HOME="$mode_home" GIT_CONFIG_GLOBAL="$mode_home/.gitconfig" \
+    git config --global --get-all commit.gpgsign
+)" == true ]]
+[[ "$(
+  HOME="$mode_home" GIT_CONFIG_GLOBAL="$mode_home/.gitconfig" \
+    git config --global --get-all tag.gpgsign
+)" == true ]]
+[[ "$(
+  HOME="$mode_home" GIT_CONFIG_GLOBAL="$mode_home/.gitconfig" \
+    git config --global --get test.preserved
+)" == unrelated-value ]]
+if HOME="$mode_home" GIT_CONFIG_GLOBAL="$mode_home/.gitconfig" \
+  git config --global --get-all gpg.program >/dev/null 2>&1; then
+  echo 'git-signing-mode left a stale gpg.program in SSH mode' >&2
+  exit 1
+fi
 if grep -Fq "$mode_home" "$mode_home/.gitconfig"; then
   echo 'git-signing-mode wrote a machine-specific home path' >&2
   exit 1
 fi
+
+mode_config_before="$(shasum -a 256 "$mode_home/.gitconfig" | awk '{print $1}')"
+if (
+  export HOME="$mode_home"
+  export GIT_CONFIG_GLOBAL="$mode_home/.gitconfig"
+  source "$repo_root/bin/git-signing-mode"
+  gpg_program="$fixture/missing-gpg"
+  main gpg
+) >"$fixture/mode-gpg-missing.out" 2>&1; then
+  echo 'git-signing-mode accepted a missing gpg program' >&2
+  exit 1
+fi
+mode_config_after="$(shasum -a 256 "$mode_home/.gitconfig" | awk '{print $1}')"
+[[ "$mode_config_before" == "$mode_config_after" ]]
+grep -Fq "missing gpg program at $fixture/missing-gpg" "$fixture/mode-gpg-missing.out"
+[[ "$(
+  HOME="$mode_home" GIT_CONFIG_GLOBAL="$mode_home/.gitconfig" \
+    git config --global --get test.preserved
+)" == unrelated-value ]]
 
 printf '%s namespaces="git" %s\n' \
   "$SSH_SIGNING_PRINCIPAL" \


### PR DESCRIPTION
## Summary

- remove the active OpenPGP program from the default SSH-signing config
- make SSH mode clear stale `gpg.program` values, fail closed on Git config errors, and pin `gpg.ssh.program`
- guard GPG mode against missing executables without changing unrelated config

## Tests

- `tests/git-signing-trust-test.sh`
- forced `git config --unset-all` failure and already-absent path fixtures
- `bash -n bin/git-signing-mode tests/git-signing-trust-test.sh`
- `shellcheck --severity=error bin/git-signing-mode tests/git-signing-trust-test.sh`
- `git diff --check`
- focused privacy scan
