### PR TITLE
feat(worktrees): require APFS storage guard v2

### DIFF
--- a/bin/agent-worktree-ops/README.md
+++ b/bin/agent-worktree-ops/README.md
@@ -6,7 +6,7 @@ Bins in this folder:
 
 - `worktree-storage-guard`
   - reads the private system policy
-    `external-worktree-storage.v1`
+    `external-worktree-storage.v2`; schema v1 is rejected
   - reads the root-owned, non-writable policy at
     `/Library/Application Support/agent-worktree-ops/external-worktree-storage.json`
   - treats a missing contract as unconfigured only when the canonical path has
@@ -17,8 +17,15 @@ Bins in this folder:
   - requires at least 200 GiB and 10% free, an exact host marker, external-device
     location, disabled Spotlight indexing, and a UUID-tracked Time Machine volume
     exclusion verified with `tmutil isexcluded`
+  - requires the exact `openclaw-managed` and `.pnpm-store/openclaw` child
+    contracts; every path component must remain a real, user-owned mode-0700
+    directory on the mounted volume's filesystem
+  - reserves `openclaw-managed` for OpenClaw's registered-worktree lifecycle and
+    `.pnpm-store/openclaw` as a disposable store owned by `dotfiles-private`
   - rejects symlinked mountpoints or parent components, wrong UUID/filesystem,
-    writable internal fallback, and hot disappearance
+    missing, overlapping, symlinked, cross-filesystem, wrongly owned, or
+    wrongly permissioned children, writable internal fallback, and hot
+    disappearance
   - when absent, the underlying mountpoint must remain `root:wheel` mode `0000`
 - `agent-worktree-clean`
   - dry-run/apply cleanup of idle worktrees and stale artifacts

--- a/bin/agent-worktree-ops/worktree-storage-guard
+++ b/bin/agent-worktree-ops/worktree-storage-guard
@@ -15,7 +15,7 @@ import sys
 from typing import Any
 
 
-SCHEMA = "external-worktree-storage.v1"
+SCHEMA = "external-worktree-storage.v2"
 DEFAULT_CONFIG = (
     pathlib.Path("/Library/Application Support")
     / "agent-worktree-ops"
@@ -27,6 +27,21 @@ PHYSICAL_EXTERNAL_BUS_PROTOCOLS = frozenset(
 )
 REQUIRED_MINIMUM_FREE_GIB = 200
 REQUIRED_MINIMUM_FREE_PERCENT = 10
+EXPECTED_CHILDREN = {
+    "openclaw_managed": {
+        "relative_path": "openclaw-managed",
+        "ownership": "home_owner",
+        "mode": "0700",
+        "cleanup_authority": "openclaw_registered_worktrees",
+    },
+    "openclaw_pnpm_store": {
+        "relative_path": ".pnpm-store/openclaw",
+        "ownership": "home_owner",
+        "mode": "0700",
+        "cleanup_authority": "dotfiles-private",
+        "disposable": True,
+    },
+}
 UUID_RE = re.compile(
     r"^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-"
     r"[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
@@ -80,6 +95,7 @@ def load_config(
     expected_keys = {
         "case_sensitive",
         "backing_directory_mode",
+        "children",
         "device_location",
         "encrypted",
         "filesystem",
@@ -99,6 +115,7 @@ def load_config(
     if (
         value.get("schema_version") != SCHEMA
         or value.get("required") is not True
+        or value.get("children") != EXPECTED_CHILDREN
         or value.get("filesystem") != "apfs"
         or value.get("encrypted") is not True
         or value.get("case_sensitive") is not False
@@ -120,6 +137,76 @@ def load_config(
     if not mount_point.is_absolute() or os.path.normpath(mount_point) != str(canonical):
         raise GuardError(f"runtime config mount point is not canonical: {mount_point}")
     return value
+
+
+def storage_child_paths(
+    config: dict[str, Any], mount_point: pathlib.Path
+) -> dict[str, pathlib.Path]:
+    root = pathlib.Path(os.path.abspath(mount_point))
+    children = config.get("children")
+    if not isinstance(children, dict) or children != EXPECTED_CHILDREN:
+        raise GuardError("runtime config child policy is incomplete or invalid")
+    paths: dict[str, pathlib.Path] = {}
+    for name, contract in children.items():
+        relative_value = contract.get("relative_path")
+        if not isinstance(relative_value, str):
+            raise GuardError(f"storage child path is invalid: {name}")
+        relative = pathlib.PurePosixPath(relative_value)
+        if relative.is_absolute() or not relative.parts or ".." in relative.parts:
+            raise GuardError(f"storage child path is invalid: {name}")
+        child = pathlib.Path(os.path.abspath(root / pathlib.Path(*relative.parts)))
+        try:
+            child.relative_to(root)
+        except ValueError as error:
+            raise GuardError(f"storage child escapes the mounted root: {name}") from error
+        if child == root:
+            raise GuardError(f"storage child resolves to the mounted root: {name}")
+        paths[name] = child
+    child_items = list(paths.items())
+    for index, (left_name, left) in enumerate(child_items):
+        for right_name, right in child_items[index + 1 :]:
+            if (
+                left == right
+                or left in right.parents
+                or right in left.parents
+            ):
+                raise GuardError(
+                    f"storage children overlap: {left_name}, {right_name}"
+                )
+    return paths
+
+
+def validate_storage_children(
+    config: dict[str, Any], mount_point: pathlib.Path
+) -> None:
+    root_metadata = os.lstat(mount_point)
+    if (
+        stat.S_ISLNK(root_metadata.st_mode)
+        or not stat.S_ISDIR(root_metadata.st_mode)
+    ):
+        raise GuardError("mounted external volume root is not a real directory")
+    home_metadata = os.stat(pathlib.Path.home())
+    expected_owner = (home_metadata.st_uid, home_metadata.st_gid)
+    root_device = root_metadata.st_dev
+    for name, child in storage_child_paths(config, mount_point).items():
+        relative = child.relative_to(mount_point)
+        current = mount_point
+        for component in relative.parts:
+            current /= component
+            if not path_has_no_symlink_components(current):
+                raise GuardError(f"storage child has a symlinked component: {name}")
+            try:
+                metadata = os.lstat(current)
+            except FileNotFoundError as error:
+                raise GuardError(f"required storage child is missing: {name}") from error
+            if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+                raise GuardError(f"storage child is not a real directory: {name}")
+            if (metadata.st_uid, metadata.st_gid) != expected_owner:
+                raise GuardError(f"storage child has the wrong owner: {name}")
+            if stat.S_IMODE(metadata.st_mode) != 0o700:
+                raise GuardError(f"storage child must use mode 0700: {name}")
+            if metadata.st_dev != root_device:
+                raise GuardError(f"storage child crosses filesystems: {name}")
 
 
 def test_observation() -> dict[str, Any] | None:
@@ -342,6 +429,7 @@ def validate_observation(
         or free_percent < config["minimum_free_percent"]
     ):
         raise GuardError("worktree volume free space is below minimum_free_percent")
+    validate_storage_children(config, mount_point)
     return mount_point
 
 
@@ -393,6 +481,7 @@ def main() -> int:
                     {
                         "configured": True,
                         "backing_directory_mode": config["backing_directory_mode"],
+                        "children": config["children"],
                         "device_location": observed.get("device_location"),
                         "free_gib": observed.get("free_gib"),
                         "free_percent": observed.get("free_percent"),

--- a/bin/agent-worktree-ops/worktree-storage-guard
+++ b/bin/agent-worktree-ops/worktree-storage-guard
@@ -52,6 +52,16 @@ class GuardError(RuntimeError):
     pass
 
 
+def children_contract_is_exact(value: Any) -> bool:
+    if not isinstance(value, dict) or value != EXPECTED_CHILDREN:
+        return False
+    pnpm_store = value.get("openclaw_pnpm_store")
+    return (
+        isinstance(pnpm_store, dict)
+        and pnpm_store.get("disposable") is True
+    )
+
+
 def path_has_no_symlink_components(path: pathlib.Path) -> bool:
     path = pathlib.Path(os.path.abspath(path))
     current = pathlib.Path(path.anchor)
@@ -115,7 +125,7 @@ def load_config(
     if (
         value.get("schema_version") != SCHEMA
         or value.get("required") is not True
-        or value.get("children") != EXPECTED_CHILDREN
+        or not children_contract_is_exact(value.get("children"))
         or value.get("filesystem") != "apfs"
         or value.get("encrypted") is not True
         or value.get("case_sensitive") is not False
@@ -144,7 +154,7 @@ def storage_child_paths(
 ) -> dict[str, pathlib.Path]:
     root = pathlib.Path(os.path.abspath(mount_point))
     children = config.get("children")
-    if not isinstance(children, dict) or children != EXPECTED_CHILDREN:
+    if not children_contract_is_exact(children):
         raise GuardError("runtime config child policy is incomplete or invalid")
     paths: dict[str, pathlib.Path] = {}
     for name, contract in children.items():

--- a/tests/external-tmp-test.sh
+++ b/tests/external-tmp-test.sh
@@ -14,11 +14,12 @@ observed="$temporary/observed.json"
 probe="$temporary/probe.sh"
 result="$temporary/result"
 volume_uuid="$(printf '%s-%s-%s-%s-%s' 11111111 2222 3333 4444 555555555555)"
-marker_id="studio-a.external-worktree-storage.v1"
-mkdir -p "$mount_point"
-chmod 0700 "$mount_point"
+marker_id="studio-a.external-worktree-storage.v2"
+mkdir -p "$mount_point/openclaw-managed" "$mount_point/.pnpm-store/openclaw"
+chmod 0700 "$mount_point" "$mount_point/openclaw-managed" \
+  "$mount_point/.pnpm-store" "$mount_point/.pnpm-store/openclaw"
 cat >"$config" <<EOF
-{"backing_directory_mode":"0000","case_sensitive":false,"device_location":"External","encrypted":true,"filesystem":"apfs","marker_id":"$marker_id","minimum_free_gib":200,"minimum_free_percent":10,"mount_point":"$mount_point","owners":true,"required":true,"schema_version":"external-worktree-storage.v1","spotlight":"disabled","time_machine_excluded":true,"volume_uuid":"$volume_uuid"}
+{"backing_directory_mode":"0000","case_sensitive":false,"children":{"openclaw_managed":{"cleanup_authority":"openclaw_registered_worktrees","mode":"0700","ownership":"home_owner","relative_path":"openclaw-managed"},"openclaw_pnpm_store":{"cleanup_authority":"dotfiles-private","disposable":true,"mode":"0700","ownership":"home_owner","relative_path":".pnpm-store/openclaw"}},"device_location":"External","encrypted":true,"filesystem":"apfs","marker_id":"$marker_id","minimum_free_gib":200,"minimum_free_percent":10,"mount_point":"$mount_point","owners":true,"required":true,"schema_version":"external-worktree-storage.v2","spotlight":"disabled","time_machine_excluded":true,"volume_uuid":"$volume_uuid"}
 EOF
 chmod 0600 "$config"
 cat >"$observed" <<EOF

--- a/tests/worktree-storage-test.sh
+++ b/tests/worktree-storage-test.sh
@@ -13,15 +13,24 @@ observed="$temporary/observed.json"
 mount_point="$home/.codex/worktrees"
 volume_uuid="$(printf '%s-%s-%s-%s-%s' 11111111 2222 3333 4444 555555555555)"
 other_uuid="$(printf '%s-%s-%s-%s-%s' aaaaaaaa bbbb cccc dddd eeeeeeeeeeee)"
-marker_id="studio-a.external-worktree-storage.v1"
-other_marker_id="studio-b.external-worktree-storage.v1"
+marker_id="studio-a.external-worktree-storage.v2"
+other_marker_id="studio-b.external-worktree-storage.v2"
+openclaw_managed="$mount_point/openclaw-managed"
+openclaw_pnpm_store="$mount_point/.pnpm-store/openclaw"
+
+create_storage_children() {
+  mkdir -p "$openclaw_managed" "$openclaw_pnpm_store"
+  chmod 0700 "$mount_point" "$openclaw_managed" \
+    "$mount_point/.pnpm-store" "$openclaw_pnpm_store"
+}
+
 mkdir -p "$mount_point"
-chmod 0700 "$mount_point"
+create_storage_children
 
 write_config() {
   local uuid="${1:-$volume_uuid}"
   cat >"$config" <<EOF
-{"backing_directory_mode":"0000","case_sensitive":false,"device_location":"External","encrypted":true,"filesystem":"apfs","marker_id":"$marker_id","minimum_free_gib":200,"minimum_free_percent":10,"mount_point":"$mount_point","owners":true,"required":true,"schema_version":"external-worktree-storage.v1","spotlight":"disabled","time_machine_excluded":true,"volume_uuid":"$uuid"}
+{"backing_directory_mode":"0000","case_sensitive":false,"children":{"openclaw_managed":{"cleanup_authority":"openclaw_registered_worktrees","mode":"0700","ownership":"home_owner","relative_path":"openclaw-managed"},"openclaw_pnpm_store":{"cleanup_authority":"dotfiles-private","disposable":true,"mode":"0700","ownership":"home_owner","relative_path":".pnpm-store/openclaw"}},"device_location":"External","encrypted":true,"filesystem":"apfs","marker_id":"$marker_id","minimum_free_gib":200,"minimum_free_percent":10,"mount_point":"$mount_point","owners":true,"required":true,"schema_version":"external-worktree-storage.v2","spotlight":"disabled","time_machine_excluded":true,"volume_uuid":"$uuid"}
 EOF
   chmod 0600 "$config"
 }
@@ -51,7 +60,8 @@ run_guard() {
 write_config
 write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
 [[ "$(run_guard --print-mount-point)" == "$mount_point" ]]
-python3 - "$guard" "$config" <<'PY'
+run_guard --json >"$temporary/ready.json"
+HOME="$home" python3 - "$guard" "$config" <<'PY'
 import importlib.util
 import importlib.machinery
 import os
@@ -67,6 +77,22 @@ assert str(module.DEFAULT_CONFIG) == (
     "/Library/Application Support/agent-worktree-ops/"
     "external-worktree-storage.json"
 )
+assert module.SCHEMA == "external-worktree-storage.v2"
+assert module.EXPECTED_CHILDREN == {
+    "openclaw_managed": {
+        "relative_path": "openclaw-managed",
+        "ownership": "home_owner",
+        "mode": "0700",
+        "cleanup_authority": "openclaw_registered_worktrees",
+    },
+    "openclaw_pnpm_store": {
+        "relative_path": ".pnpm-store/openclaw",
+        "ownership": "home_owner",
+        "mode": "0700",
+        "cleanup_authority": "dotfiles-private",
+        "disposable": True,
+    },
+}
 source = pathlib.Path(sys.argv[1]).read_text()
 assert "com.apple.metadata:com_apple_backup_excludeItem" not in source
 assert '"/usr/bin/tmutil", "isexcluded"' in source
@@ -110,6 +136,30 @@ if os.getuid() != 0:
     else:
         raise AssertionError("production config must be root-owned")
 PY
+python3 - "$temporary/ready.json" <<'PY'
+import json
+import pathlib
+import sys
+
+value = json.loads(pathlib.Path(sys.argv[1]).read_text())
+assert value["configured"] is True
+assert value["schema_version"] == "external-worktree-storage.v2"
+assert value["children"] == {
+    "openclaw_managed": {
+        "cleanup_authority": "openclaw_registered_worktrees",
+        "mode": "0700",
+        "ownership": "home_owner",
+        "relative_path": "openclaw-managed",
+    },
+    "openclaw_pnpm_store": {
+        "cleanup_authority": "dotfiles-private",
+        "disposable": True,
+        "mode": "0700",
+        "ownership": "home_owner",
+        "relative_path": ".pnpm-store/openclaw",
+    },
+}
+PY
 if HOME="$home" WORKTREE_STORAGE_CONFIG="$config" "$guard" \
   >"$temporary/override.out" 2>&1; then
   echo "runtime config overrides must be test-only" >&2
@@ -131,6 +181,64 @@ owner_common="$(git -C "$owner_repo" rev-parse --path-format=absolute --git-comm
 worktree_common="$(git -C "$managed_worktree" rev-parse --path-format=absolute --git-common-dir)"
 [[ "$owner_common" == "$worktree_common" ]]
 git -C "$owner_repo" worktree remove "$managed_worktree"
+
+assert_invalid_config() {
+  local name="$1"
+  local expected="$2"
+  if run_guard >"$temporary/$name.out" 2>&1; then
+    echo "$name config must fail" >&2
+    exit 1
+  fi
+  grep -Fq "$expected" "$temporary/$name.out"
+}
+
+mutate_config() {
+  local expression="$1"
+  python3 - "$config" "$expression" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+value = json.loads(path.read_text())
+exec(sys.argv[2], {"value": value})
+path.write_text(json.dumps(value, sort_keys=True) + "\n")
+PY
+}
+
+write_config
+mutate_config 'value["schema_version"] = "external-worktree-storage.v1"'
+assert_invalid_config v1-schema "required config missing or invalid"
+
+write_config
+mutate_config 'value.pop("required")'
+assert_invalid_config missing-required "required config missing or invalid"
+
+write_config
+mutate_config 'value["unknown"] = True'
+assert_invalid_config unknown-field "required config missing or invalid"
+
+write_config
+mutate_config 'value.pop("children")'
+assert_invalid_config missing-children "required config missing or invalid"
+
+write_config
+mutate_config 'value["children"]["openclaw_managed"]["extra"] = True'
+assert_invalid_config unknown-child-field "required config missing or invalid"
+
+write_config
+mutate_config 'value["children"]["openclaw_managed"].pop("mode")'
+assert_invalid_config missing-child-field "required config missing or invalid"
+
+write_config
+mutate_config 'value["children"]["openclaw_pnpm_store"]["relative_path"] = "openclaw-managed/cache"'
+assert_invalid_config overlapping-child "required config missing or invalid"
+
+write_config
+mutate_config 'value["children"]["openclaw_managed"]["relative_path"] = "../escape"'
+assert_invalid_config escaping-child "required config missing or invalid"
+
+write_config
 
 write_observed "$other_uuid" apfs true "$(id -u)" "$(id -g)" 0700
 if run_guard >"$temporary/wrong-uuid.out" 2>&1; then
@@ -270,6 +378,7 @@ grep -Fq "symlinked component" "$temporary/symlink.out"
 
 rm "$mount_point"
 mkdir "$mount_point"
+create_storage_children
 write_config pending
 if run_guard >"$temporary/pending.out" 2>&1; then
   echo "pending UUID must fail" >&2
@@ -287,6 +396,97 @@ fi
 grep -Fq "permissions are unsafe" "$temporary/writable-config.out"
 chmod 0600 "$config"
 
+write_config
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
+rm -rf "$openclaw_managed"
+if run_guard >"$temporary/missing-child.out" 2>&1; then
+  echo "missing storage child must fail" >&2
+  exit 1
+fi
+grep -Fq "required storage child is missing: openclaw_managed" \
+  "$temporary/missing-child.out"
+mkdir "$openclaw_managed"
+chmod 0700 "$openclaw_managed"
+
+chmod 0755 "$openclaw_managed"
+if run_guard >"$temporary/child-mode.out" 2>&1; then
+  echo "wrong storage child mode must fail" >&2
+  exit 1
+fi
+grep -Fq "storage child must use mode 0700: openclaw_managed" \
+  "$temporary/child-mode.out"
+chmod 0700 "$openclaw_managed"
+
+rm -rf "$openclaw_managed"
+printf 'not a directory\n' >"$openclaw_managed"
+if run_guard >"$temporary/child-file.out" 2>&1; then
+  echo "storage child file must fail" >&2
+  exit 1
+fi
+grep -Fq "storage child is not a real directory: openclaw_managed" \
+  "$temporary/child-file.out"
+rm "$openclaw_managed"
+mkdir "$openclaw_managed"
+chmod 0700 "$openclaw_managed"
+
+rm -rf "$openclaw_managed"
+ln -s "$openclaw_pnpm_store" "$openclaw_managed"
+if run_guard >"$temporary/child-symlink.out" 2>&1; then
+  echo "symlinked storage child must fail" >&2
+  exit 1
+fi
+grep -Fq "storage child has a symlinked component: openclaw_managed" \
+  "$temporary/child-symlink.out"
+rm "$openclaw_managed"
+mkdir "$openclaw_managed"
+chmod 0700 "$openclaw_managed"
+
+HOME="$home" python3 - "$guard" "$config" <<'PY'
+import importlib.machinery
+import importlib.util
+import os
+import pathlib
+import sys
+from unittest import mock
+
+loader = importlib.machinery.SourceFileLoader("storage_guard_metadata", sys.argv[1])
+spec = importlib.util.spec_from_loader("storage_guard_metadata", loader)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader
+spec.loader.exec_module(module)
+config = module.load_config(pathlib.Path(sys.argv[2]), production_default=False)
+assert config is not None
+root = pathlib.Path(config["mount_point"])
+child = root / "openclaw-managed"
+real_lstat = module.os.lstat
+
+def changed_lstat(path, *, uid_delta=0, gid_delta=0, device_delta=0):
+    metadata = real_lstat(path)
+    if pathlib.Path(path) != child:
+        return metadata
+    values = list(metadata)
+    values[2] = metadata.st_dev + device_delta
+    values[4] = metadata.st_uid + uid_delta
+    values[5] = metadata.st_gid + gid_delta
+    return os.stat_result(values)
+
+for error, kwargs in (
+    ("wrong owner", {"uid_delta": 1}),
+    ("wrong owner", {"gid_delta": 1}),
+    ("crosses filesystems", {"device_delta": 1}),
+):
+    with mock.patch.object(
+        module.os, "lstat", side_effect=lambda path, kwargs=kwargs: changed_lstat(path, **kwargs)
+    ):
+        try:
+            module.validate_storage_children(config, root)
+        except module.GuardError as caught:
+            assert error in str(caught), caught
+        else:
+            raise AssertionError(error)
+PY
+
+write_observed "$volume_uuid" apfs false "$(id -u)" "$(id -g)" 0700
 real_config="$temporary/real-config.json"
 mv "$config" "$real_config"
 ln -s "$real_config" "$config"

--- a/tests/worktree-storage-test.sh
+++ b/tests/worktree-storage-test.sh
@@ -231,6 +231,14 @@ mutate_config 'value["children"]["openclaw_managed"].pop("mode")'
 assert_invalid_config missing-child-field "required config missing or invalid"
 
 write_config
+mutate_config 'value["children"]["openclaw_pnpm_store"]["disposable"] = 1'
+assert_invalid_config integer-disposable "required config missing or invalid"
+
+write_config
+mutate_config 'value["children"]["openclaw_pnpm_store"]["disposable"] = 1.0'
+assert_invalid_config float-disposable "required config missing or invalid"
+
+write_config
 mutate_config 'value["children"]["openclaw_pnpm_store"]["relative_path"] = "openclaw-managed/cache"'
 assert_invalid_config overlapping-child "required config missing or invalid"
 


### PR DESCRIPTION
## Summary

- hard-cut the external worktree storage guard from schema v1 to v2
- require the exact OpenClaw managed-worktree and scoped pnpm-store child contracts
- fail closed on missing, overlapping, symlinked, misowned, wrongly permissioned, or cross-filesystem child paths
- include the exact children contract in successful JSON output and document the ownership boundaries

## Tests

- `tests/worktree-storage-test.sh`
- `tests/external-tmp-test.sh`
- `tests/install-agent-worktree-ops-test.sh`
- `tests/agent-worktree-maintain-test.sh`
- `tests/gwt-cleanup-test.zsh`
- `tests/deepclean-test.sh`
- Python and shell syntax checks
- ShellCheck
- diff and privacy scans
