### PR TITLE
fix(linux): harden server user refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,17 @@ public shell links, pinned prompt tooling, Node/pnpm, and the public Codex
 launcher. It never invokes sudo, package management, firewall, account, or SSH
 server mutations. PNPM globals live directly in `PNPM_HOME`, and the server
 profile adds `cx` as an argument-preserving `codex --no-alt-screen` shortcut.
-The empty private `~/.codex` surface remains host-local; no hooks, global
-instructions, model catalog, credentials, QuickSSH, Mosh, or OpenClaw launcher
-configuration is linked.
+After the complete safety preflight, the owned dotfiles checkout and its
+managed `codex`, `dotfiles-audit`, and `linux-server-bootstrap` source launchers
+are normalized to mode `0755`. A fresh host gets the public Codex wrapper; an
+existing, user-owned executable link from `~/.local/bin/codex` to the official
+standalone target under `~/.codex/packages/standalone/current/bin/codex` is
+preserved only when `current` resolves through owned, non-world-writable
+directories to an unlinked mode-`0755` binary beneath the standalone
+`releases` directory. Other Codex launcher files or links are rejected. The
+private `~/.codex` surface remains host-local; no hooks, global instructions,
+model catalog, credentials, QuickSSH, Mosh, or OpenClaw launcher configuration
+is linked.
 
 Obtain the SHA256 fingerprint of the designated recovery public key through an
 independent trusted path, then explicitly enable the temporary proof phase:

--- a/bin/linux-server-bootstrap
+++ b/bin/linux-server-bootstrap
@@ -742,6 +742,10 @@ owned_path_mode() {
   stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1"
 }
 
+owned_path_links() {
+  stat -c %h "$1" 2>/dev/null || stat -f %l "$1"
+}
+
 canonical_absolute_path() {
   local path="$1"
   local component
@@ -835,6 +839,135 @@ preflight_home_directory() {
   }
 }
 
+refresh_user_source_directories() {
+  printf '%s\n' \
+    "$repo_root" \
+    "$repo_root/bin"
+}
+
+preflight_dotfiles_source_directory() {
+  local path="$1"
+  local source_mode
+  [[ ! -L "$path" && -d "$path" ]] || {
+    printf 'refusing unsafe dotfiles source directory: %s\n' "$path" >&2
+    return 1
+  }
+  [[ "$(owned_path_uid "$path")" == "$(id -u)" ]] || {
+    printf 'refusing foreign-owned dotfiles source directory: %s\n' "$path" >&2
+    return 1
+  }
+  source_mode="$(owned_path_mode "$path")" || return 1
+  (( (8#$source_mode & 8#0100) != 0 )) || {
+    printf 'refusing non-traversable dotfiles source directory: %s\n' "$path" >&2
+    return 1
+  }
+  (( (8#$source_mode & 8#0002) == 0 )) || {
+    printf 'refusing world-writable dotfiles source directory: %s\n' "$path" >&2
+    return 1
+  }
+}
+
+refresh_user_source_files() {
+  printf '%s\n' \
+    "$repo_root/bin/codex" \
+    "$repo_root/bin/dotfiles-audit" \
+    "$repo_root/bin/linux-server-bootstrap"
+}
+
+preflight_dotfiles_source_file() {
+  local path="$1"
+  local source_mode
+  [[ ! -L "$path" && -f "$path" ]] || {
+    printf 'refusing unsafe dotfiles source file: %s\n' "$path" >&2
+    return 1
+  }
+  [[ "$(owned_path_uid "$path")" == "$(id -u)" ]] || {
+    printf 'refusing foreign-owned dotfiles source file: %s\n' "$path" >&2
+    return 1
+  }
+  [[ "$(owned_path_links "$path")" == 1 ]] || {
+    printf 'refusing linked dotfiles source file: %s\n' "$path" >&2
+    return 1
+  }
+  source_mode="$(owned_path_mode "$path")" || return 1
+  (( (8#$source_mode & 8#0100) != 0 )) || {
+    printf 'refusing non-executable dotfiles source file: %s\n' "$path" >&2
+    return 1
+  }
+  (( (8#$source_mode & 8#0002) == 0 )) || {
+    printf 'refusing world-writable dotfiles source file: %s\n' "$path" >&2
+    return 1
+  }
+}
+
+preflight_standalone_codex_target() {
+  local path="$1"
+  local current="$HOME/.codex/packages/standalone/current"
+  local releases="$HOME/.codex/packages/standalone/releases"
+  local canonical_release release_relative logical_release
+  local resolved_release resolved_releases resolved_target
+  local target_mode
+  [[ "$path" == "$current/bin/codex" && -L "$current" ]] || {
+    printf 'refusing unsafe standalone Codex current link: %s\n' "$current" >&2
+    return 1
+  }
+  [[ "$(owned_path_uid "$current")" == "$(id -u)" ]] || {
+    printf 'refusing foreign-owned standalone Codex current link: %s\n' "$current" >&2
+    return 1
+  }
+  [[ "$(owned_path_links "$current")" == 1 ]] || {
+    printf 'refusing linked standalone Codex current link: %s\n' "$current" >&2
+    return 1
+  }
+  preflight_owned_directory "$releases" || return 1
+  resolved_releases="$(readlink -f "$releases")" || {
+    printf 'refusing unsafe standalone Codex releases directory: %s\n' "$releases" >&2
+    return 1
+  }
+  resolved_release="$(readlink -f "$current")" || {
+    printf 'refusing unsafe standalone Codex current link: %s\n' "$current" >&2
+    return 1
+  }
+  canonical_release="$(canonical_absolute_path "$resolved_release")" || {
+    printf 'refusing unsafe standalone Codex release: %s\n' "$current" >&2
+    return 1
+  }
+  [[ "$canonical_release" == "$resolved_release" &&
+    "$resolved_release" == "$resolved_releases/"* ]] || {
+    printf 'refusing unsafe standalone Codex release: %s\n' "$current" >&2
+    return 1
+  }
+  release_relative="${resolved_release#"$resolved_releases"/}"
+  logical_release="$releases/$release_relative"
+  preflight_owned_directory "$logical_release/bin" || return 1
+  resolved_target="$(readlink -f "$path")" || {
+    printf 'refusing unsafe standalone Codex target: %s\n' "$path" >&2
+    return 1
+  }
+  [[ "$resolved_target" == "$resolved_release/bin/codex" ]] || {
+    printf 'refusing unsafe standalone Codex target: %s\n' "$path" >&2
+    return 1
+  }
+  path="$resolved_target"
+  [[ ! -L "$path" && -f "$path" ]] || {
+    printf 'refusing unsafe standalone Codex target: %s\n' "$path" >&2
+    return 1
+  }
+  [[ "$(owned_path_uid "$path")" == "$(id -u)" ]] || {
+    printf 'refusing foreign-owned standalone Codex target: %s\n' "$path" >&2
+    return 1
+  }
+  [[ "$(owned_path_links "$path")" == 1 ]] || {
+    printf 'refusing linked standalone Codex target: %s\n' "$path" >&2
+    return 1
+  }
+  target_mode="$(owned_path_mode "$path")" || return 1
+  [[ "$target_mode" == 755 && -x "$path" ]] || {
+    printf 'refusing unsafe standalone Codex target mode: %s\n' "$path" >&2
+    return 1
+  }
+}
+
 preflight_owned_directory() {
   local path="$1"
   local relative component current="$HOME" current_mode
@@ -897,6 +1030,37 @@ preflight_link_destination() {
       return 1
     }
   fi
+}
+
+refresh_user_codex_source() {
+  local destination="$HOME/.local/bin/codex"
+  local public_wrapper="$repo_root/bin/codex"
+  local standalone="$HOME/.codex/packages/standalone/current/bin/codex"
+  local target
+
+  if [[ ! -e "$destination" && ! -L "$destination" ]]; then
+    printf '%s\n' "$public_wrapper"
+    return
+  fi
+  [[ -L "$destination" ]] || {
+    printf 'refusing unexpected Codex launcher type: %s\n' "$destination" >&2
+    return 1
+  }
+  target="$(readlink "$destination")" || return 1
+  if [[ "$target" == "$public_wrapper" ]]; then
+    printf '%s\n' "$public_wrapper"
+    return
+  fi
+  [[ "$target" == "$standalone" ]] || {
+    printf 'refusing unexpected Codex launcher target: %s\n' "$destination" >&2
+    return 1
+  }
+  [[ "$(owned_path_uid "$destination")" == "$(id -u)" ]] || {
+    printf 'refusing foreign-owned Codex launcher symlink: %s\n' "$destination" >&2
+    return 1
+  }
+  preflight_standalone_codex_target "$standalone" || return 1
+  printf '%s\n' "$standalone"
 }
 
 refresh_user_directory_targets() {
@@ -979,7 +1143,7 @@ refresh_user_directory_manifest() {
 }
 
 refresh_user_link_manifest() {
-  local source destination
+  local source destination codex_source
   while read -r source destination; do
     printf '%s\t%s\n' "$repo_root/$source" "$HOME/$destination"
   done <<'EOF'
@@ -1000,8 +1164,10 @@ bin/gh .local/bin/gh
 bin/ghx .local/bin/ghx
 bin/linux-server-bootstrap .local/bin/linux-server-bootstrap
 bin/tt .local/bin/tt
-bin/codex .local/bin/codex
 EOF
+
+  codex_source="$(refresh_user_codex_source)" || return 1
+  printf '%s\t%s\n' "$codex_source" "$HOME/.local/bin/codex"
 
   printf '%s\t%s\n' \
     "$HOME/.oh-my-zsh/custom/themes/spaceship-prompt/spaceship.zsh-theme" \
@@ -1058,16 +1224,16 @@ preflight_corepack_pnpm() {
 
 preflight_refresh_user() {
   local directory_manifest="$1"
-  local path mode source destination install_root
+  local path mode source destination install_root link_manifest
   preflight_home_directory || return 1
-  [[ ! -L "$repo_root" && -d "$repo_root" ]] || {
-    printf 'refusing unsafe dotfiles source directory\n' >&2
-    return 1
-  }
-  [[ "$(owned_path_uid "$repo_root")" == "$(id -u)" ]] || {
-    printf 'refusing foreign-owned dotfiles source directory\n' >&2
-    return 1
-  }
+  while IFS= read -r path; do
+    [[ -n "$path" ]] || return 1
+    preflight_dotfiles_source_directory "$path" || return 1
+  done < <(refresh_user_source_directories)
+  while IFS= read -r source; do
+    [[ -n "$source" ]] || return 1
+    preflight_dotfiles_source_file "$source" || return 1
+  done < <(refresh_user_source_files)
   while IFS=$'\t' read -r path mode; do
     [[ -n "$path" && -n "$mode" ]] || return 1
     preflight_owned_directory "$path" || return 1
@@ -1075,16 +1241,27 @@ preflight_refresh_user() {
 
   install_root="$HOME/.local/opt/node-v$node_version"
   preflight_owned_directory "$install_root" || return 1
+  link_manifest="$(refresh_user_link_manifest)" || return 1
   while IFS=$'\t' read -r source destination; do
     [[ -n "$source" && -n "$destination" ]] || return 1
     preflight_link_destination "$source" "$destination" || return 1
-  done < <(refresh_user_link_manifest)
+  done <<<"$link_manifest"
   for source in node npm npx corepack; do
     preflight_link_destination \
       "$install_root/bin/$source" \
       "$HOME/.local/bin/$source" || return 1
   done
   preflight_corepack_pnpm || return 1
+}
+
+normalize_refresh_user_source() {
+  local path source
+  while IFS= read -r path; do
+    run chmod 0755 "$path" || return 1
+  done < <(refresh_user_source_directories)
+  while IFS= read -r source; do
+    run chmod 0755 "$source" || return 1
+  done < <(refresh_user_source_files)
 }
 
 ensure_owned_directory() {
@@ -1190,10 +1367,11 @@ install_openclaw_toolchain() {
 }
 
 link_server_dotfiles() {
-  local source destination
+  local source destination link_manifest
+  link_manifest="$(refresh_user_link_manifest)" || return 1
   while IFS=$'\t' read -r source destination; do
     backup_and_link "$source" "$destination" || return 1
-  done < <(refresh_user_link_manifest)
+  done <<<"$link_manifest"
 }
 
 ensure_sudo_access() {
@@ -1207,7 +1385,8 @@ refresh_user_content() {
   if ! preflight_refresh_user "$directory_manifest"; then
     return 1
   fi
-  normalize_refresh_user_directories "$directory_manifest"
+  normalize_refresh_user_source || return 1
+  normalize_refresh_user_directories "$directory_manifest" || return 1
 
   install_pinned_checkout \
     https://github.com/ohmyzsh/ohmyzsh.git \

--- a/tests/linux-server-refresh-user-test.sh
+++ b/tests/linux-server-refresh-user-test.sh
@@ -10,6 +10,36 @@ mode() {
   stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1"
 }
 
+create_test_repo() {
+  local destination="$1"
+  mkdir "$destination"
+  (
+    cd "$root"
+    tar -cf - \
+      .aliases \
+      .functions \
+      .ripgreprc \
+      .tmux.conf \
+      profiles/linux-server \
+      bin/codex \
+      bin/dotfiles-audit \
+      bin/dotfiles-platform \
+      bin/gh \
+      bin/ghx \
+      bin/linux-server-bootstrap \
+      bin/tt
+  ) | (
+    cd "$destination"
+    tar -xf -
+  )
+  chmod 0775 "$destination"
+  chmod 0775 "$destination/bin"
+  chmod 0775 \
+    "$destination/bin/codex" \
+    "$destination/bin/dotfiles-audit" \
+    "$destination/bin/linux-server-bootstrap"
+}
+
 fakebin="$temporary/fakebin"
 mkdir "$fakebin"
 for command_name in sudo apt apt-get apt-cache dpkg-query usermod chsh sshd ufw systemctl; do
@@ -20,6 +50,24 @@ exit 97
 EOF
   chmod +x "$fakebin/$command_name"
 done
+cat >"$fakebin/chmod" <<'EOF'
+#!/usr/bin/env bash
+if [[ -n "${CHMOD_CALL_LOG:-}" ]]; then
+  printf '%s\n' "$*" >>"$CHMOD_CALL_LOG"
+fi
+for argument in "$@"; do
+  if [[ -n "${FAIL_CHMOD_PATH:-}" && "$argument" == "$FAIL_CHMOD_PATH" ]]; then
+    printf 'injected chmod failure: %s\n' "$argument" >>"$CHMOD_FAILURE_LOG"
+    exit 96
+  fi
+  if [[ "$argument" == "$DEVELOPER_REPO_ROOT" ]]; then
+    printf 'refusing test chmod of developer worktree\n' >>"$DEVELOPER_CHMOD_LOG"
+    exit 98
+  fi
+done
+exec /bin/chmod "$@"
+EOF
+chmod +x "$fakebin/chmod"
 
 refresh_case="$temporary/refresh-case.sh"
 cat >"$refresh_case" <<'EOF'
@@ -29,6 +77,7 @@ umask 0002
 
 # shellcheck disable=SC1090
 DOTFILES_SERVER_SOURCE_ONLY=1 source "$BOOTSTRAP_SCRIPT"
+repo_root="$TEST_REPO_ROOT"
 
 uname() {
   [[ "${1:-}" == -s ]] && {
@@ -91,7 +140,25 @@ chmod 0775 \
   "$HOME/.oh-my-zsh/custom/themes" \
   "$HOME/.oh-my-zsh/custom/themes/spaceship-prompt"
 
+if [[ "${PRESERVE_STANDALONE_CODEX:-0}" == 1 ]]; then
+  standalone="$HOME/.codex/packages/standalone/current/bin/codex"
+  standalone_release="$HOME/.codex/packages/standalone/releases/test-release"
+  mkdir -p "$standalone_release/bin"
+  chmod 0700 "$HOME/.codex"
+  chmod 0755 \
+    "$HOME/.codex/packages" \
+    "$HOME/.codex/packages/standalone" \
+    "$HOME/.codex/packages/standalone/releases" \
+    "$standalone_release" \
+    "$standalone_release/bin"
+  ln -s "$standalone_release" "$HOME/.codex/packages/standalone/current"
+  printf '#!/usr/bin/env bash\n' >"$standalone_release/bin/codex"
+  chmod 0755 "$standalone_release/bin/codex"
+  ln -s "$standalone" "$HOME/.local/bin/codex"
+fi
+
 refresh_user
+[[ "$(owned_path_mode "$repo_root/bin")" == 755 ]]
 first_links="$(
   find "$HOME" -type l -print |
     LC_ALL=C sort |
@@ -99,6 +166,7 @@ first_links="$(
 )"
 first_backups="$(find "$state_root/backups" -mindepth 1 -print)"
 refresh_user
+[[ "$(owned_path_mode "$repo_root/bin")" == 755 ]]
 second_links="$(
   find "$HOME" -type l -print |
     LC_ALL=C sort |
@@ -112,22 +180,39 @@ chmod +x "$refresh_case"
 
 home="$temporary/home"
 mkdir "$home"
+test_repo="$home/.dotfiles"
+create_test_repo "$test_repo"
 : >"$temporary/forbidden.log"
+: >"$temporary/developer-chmod.log"
 HOME="$home" \
   XDG_DATA_HOME="$home/.local/share" \
   XDG_STATE_HOME="$home/.local/state" \
   PNPM_HOME="$home/.local/share/pnpm" \
   PATH="$fakebin:/usr/bin:/bin" \
   FORBIDDEN_LOG="$temporary/forbidden.log" \
+  DEVELOPER_CHMOD_LOG="$temporary/developer-chmod.log" \
+  DEVELOPER_REPO_ROOT="$root" \
   BOOTSTRAP_SCRIPT="$script" \
+  TEST_REPO_ROOT="$test_repo" \
   "$refresh_case"
 [[ ! -s "$temporary/forbidden.log" ]]
+[[ ! -s "$temporary/developer-chmod.log" ]]
+[[ "$(mode "$test_repo")" == 755 ]]
+[[ "$(mode "$test_repo/bin")" == 755 ]]
+[[ "$(mode "$test_repo/bin/codex")" == 755 ]]
+[[ "$(mode "$test_repo/bin/linux-server-bootstrap")" == 755 ]]
+[[ "$(mode "$test_repo/bin/dotfiles-audit")" == 755 ]]
 
 run_refresh_component_case() {
   local name="$1"
   local case_home="$2"
   local case_pnpm_home="$3"
+  local preserve_standalone="${4:-0}"
+  local source_bin_mode="${5:-0775}"
   local forbidden="$temporary/forbidden-$name.log"
+  local case_repo="$case_home/.dotfiles"
+  create_test_repo "$case_repo"
+  chmod "$source_bin_mode" "$case_repo/bin"
   : >"$forbidden"
   HOME="$case_home" \
     XDG_DATA_HOME="$case_home/.local/share" \
@@ -135,9 +220,18 @@ run_refresh_component_case() {
     PNPM_HOME="$case_pnpm_home" \
     PATH="$fakebin:/usr/bin:/bin" \
     FORBIDDEN_LOG="$forbidden" \
+    DEVELOPER_CHMOD_LOG="$temporary/developer-chmod.log" \
+    DEVELOPER_REPO_ROOT="$root" \
     BOOTSTRAP_SCRIPT="$script" \
+    TEST_REPO_ROOT="$case_repo" \
+    PRESERVE_STANDALONE_CODEX="$preserve_standalone" \
     "$refresh_case"
   [[ ! -s "$forbidden" ]]
+  [[ "$(mode "$case_repo")" == 755 ]]
+  [[ "$(mode "$case_repo/bin")" == 755 ]]
+  [[ "$(mode "$case_repo/bin/codex")" == 755 ]]
+  [[ "$(mode "$case_repo/bin/linux-server-bootstrap")" == 755 ]]
+  [[ "$(mode "$case_repo/bin/dotfiles-audit")" == 755 ]]
 }
 
 direct_home="$temporary/direct-home"
@@ -172,6 +266,31 @@ for path in \
   [[ "$(mode "$path")" == 755 ]]
 done
 
+private_bin_home="$temporary/private-bin-home"
+mkdir "$private_bin_home"
+run_refresh_component_case \
+  private-bin \
+  "$private_bin_home" \
+  "$private_bin_home/.local/share/pnpm" \
+  0 \
+  0700
+
+standalone_home="$temporary/standalone-home"
+mkdir "$standalone_home"
+run_refresh_component_case \
+  standalone \
+  "$standalone_home" \
+  "$standalone_home/.local/share/pnpm" \
+  1
+standalone_target="$standalone_home/.codex/packages/standalone/current/bin/codex"
+standalone_release="$standalone_home/.codex/packages/standalone/releases/test-release"
+[[ "$(readlink "$standalone_home/.local/bin/codex")" == "$standalone_target" ]]
+[[ "$(readlink "$standalone_home/.codex/packages/standalone/current")" == \
+  "$standalone_release" ]]
+[[ "$(readlink -f "$standalone_target")" == \
+  "$(readlink -f "$standalone_release/bin/codex")" ]]
+[[ -x "$standalone_release/bin/codex" ]]
+
 for secure_path in \
   "$home/.ssh" \
   "$home/.codex" \
@@ -198,7 +317,7 @@ done
 [[ -x "$home/.local/share/pnpm/pnpm" ]]
 [[ -x "$home/.local/share/pnpm/pnpx" ]]
 [[ ! -e "$home/.local/share/pnpm/bin" ]]
-[[ "$(readlink "$home/.local/bin/codex")" == "$root/bin/codex" ]]
+[[ "$(readlink "$home/.local/bin/codex")" == "$test_repo/bin/codex" ]]
 for absent in \
   "$home/.local/bin/quickssh" \
   "$home/.local/bin/op" \
@@ -258,6 +377,7 @@ set -euo pipefail
 
 # shellcheck disable=SC1090
 DOTFILES_SERVER_SOURCE_ONLY=1 source "$BOOTSTRAP_SCRIPT"
+repo_root="$TEST_REPO_ROOT"
 uname() {
   [[ "${1:-}" == -s ]] && {
     printf 'Linux\n'
@@ -292,6 +412,18 @@ create_corepack_targets() {
   done
 }
 
+create_standalone_codex_target() {
+  standalone="$HOME/.codex/packages/standalone/current/bin/codex"
+  standalone_current="$HOME/.codex/packages/standalone/current"
+  standalone_release="$HOME/.codex/packages/standalone/releases/test-release"
+  standalone_binary="$standalone_release/bin/codex"
+  mkdir -p "$standalone_release/bin" "$HOME/.local/bin"
+  ln -s "$standalone_release" "$standalone_current"
+  printf '#!/usr/bin/env bash\n' >"$standalone_binary"
+  chmod 0755 "$standalone_binary"
+  ln -s "$standalone" "$HOME/.local/bin/codex"
+}
+
 directory_metadata() {
   stat -c '%f:%s:%Y:%Z' "$1" 2>/dev/null ||
     stat -f '%p:%z:%m:%c' "$1"
@@ -309,9 +441,61 @@ case "$DRIFT_CASE" in
     mkdir -p "$HOME/.local/share/pnpm"
     simulate_foreign_owner "$HOME/.local/share/pnpm"
     ;;
-  link)
+  codex-wrong-target)
     mkdir -p "$HOME/.local/bin"
     ln -s "$HOME/wrong-codex" "$HOME/.local/bin/codex"
+    ;;
+  codex-file)
+    mkdir -p "$HOME/.local/bin"
+    printf 'keep-codex\n' >"$HOME/.local/bin/codex"
+    ;;
+  codex-foreign-target)
+    create_standalone_codex_target
+    simulate_foreign_owner "$(readlink -f "$standalone_binary")"
+    ;;
+  codex-standalone-symlink)
+    create_standalone_codex_target
+    rm "$standalone_binary"
+    ln -s /bin/sh "$standalone_binary"
+    ;;
+  codex-standalone-hardlink)
+    create_standalone_codex_target
+    ln "$standalone_binary" "$HOME/standalone-codex-hardlink"
+    ;;
+  codex-standalone-unsafe-mode)
+    create_standalone_codex_target
+    chmod 0777 "$standalone_binary"
+    ;;
+  codex-standalone-noncanonical-mode)
+    create_standalone_codex_target
+    chmod 0775 "$standalone_binary"
+    ;;
+  codex-current-file)
+    create_standalone_codex_target
+    rm "$standalone_current"
+    mkdir "$standalone_current"
+    ;;
+  codex-current-outside)
+    standalone="$HOME/.codex/packages/standalone/current/bin/codex"
+    standalone_current="$HOME/.codex/packages/standalone/current"
+    standalone_release="$OUTSIDE_ROOT/release"
+    standalone_binary="$standalone_release/bin/codex"
+    mkdir -p "$HOME/.codex/packages/standalone/releases" "$HOME/.local/bin"
+    ln -s "$standalone_release" "$standalone_current"
+    ln -s "$standalone" "$HOME/.local/bin/codex"
+    ;;
+  codex-release-owner)
+    create_standalone_codex_target
+    simulate_foreign_owner "$standalone_release"
+    ;;
+  codex-release-world-mode)
+    create_standalone_codex_target
+    chmod 0777 "$standalone_release"
+    ;;
+  codex-release-bin-symlink)
+    create_standalone_codex_target
+    rm -rf "$standalone_release/bin"
+    ln -s "$OUTSIDE_ROOT/release-bin" "$standalone_release/bin"
     ;;
   home | terminal-parent | outside)
     ;;
@@ -329,6 +513,33 @@ case "$DRIFT_CASE" in
   world-mode)
     mkdir "$HOME/nested"
     chmod 0777 "$HOME/nested"
+    ;;
+  repo-world-mode)
+    chmod 0777 "$repo_root"
+    ;;
+  source-parent-symlink)
+    mv "$repo_root/bin" "$OUTSIDE_ROOT/source-bin"
+    ln -s "$OUTSIDE_ROOT/source-bin" "$repo_root/bin"
+    ;;
+  source-parent-file)
+    mv "$repo_root/bin" "$OUTSIDE_ROOT/source-bin"
+    printf 'keep-source-parent\n' >"$repo_root/bin"
+    ;;
+  source-parent-owner)
+    simulate_foreign_owner "$repo_root/bin"
+    ;;
+  source-parent-world-mode)
+    chmod 0777 "$repo_root/bin"
+    ;;
+  source-world-mode)
+    chmod 0777 "$repo_root/bin/dotfiles-audit"
+    ;;
+  source-symlink)
+    rm "$repo_root/bin/dotfiles-audit"
+    ln -s "$OUTSIDE_ROOT/marker" "$repo_root/bin/dotfiles-audit"
+    ;;
+  source-hardlink)
+    ln "$repo_root/bin/dotfiles-audit" "$OUTSIDE_ROOT/dotfiles-audit"
     ;;
   non-traversable)
     mkdir "$HOME/.local"
@@ -353,6 +564,11 @@ case "$DRIFT_CASE" in
     ;;
 esac
 
+repo_mode_before="$(owned_path_mode "$repo_root")"
+bin_mode_before="$(owned_path_mode "$repo_root/bin" 2>/dev/null || true)"
+bootstrap_mode_before="$(owned_path_mode "$repo_root/bin/linux-server-bootstrap" 2>/dev/null || true)"
+audit_mode_before="$(owned_path_mode "$repo_root/bin/dotfiles-audit" 2>/dev/null || true)"
+: >"$CHMOD_CALL_LOG"
 if refresh_user >"$CASE_OUTPUT" 2>&1; then
   printf 'drift case unexpectedly succeeded: %s\n' "$DRIFT_CASE" >&2
   exit 1
@@ -360,26 +576,84 @@ fi
 if [[ "$DRIFT_CASE" == non-traversable ]]; then
   [[ "$(directory_metadata "$HOME/.local")" == "$NON_TRAVERSABLE_METADATA" ]]
 fi
+case "$DRIFT_CASE" in
+  chmod-failure-root | chmod-failure-bin | chmod-failure-first-source) ;;
+  *)
+    [[ "$(owned_path_mode "$repo_root")" == "$repo_mode_before" ]]
+    [[ "$(owned_path_mode "$repo_root/bin" 2>/dev/null || true)" == "$bin_mode_before" ]]
+    [[ "$(owned_path_mode "$repo_root/bin/linux-server-bootstrap" 2>/dev/null || true)" == \
+      "$bootstrap_mode_before" ]]
+    [[ "$(owned_path_mode "$repo_root/bin/dotfiles-audit" 2>/dev/null || true)" == \
+      "$audit_mode_before" ]]
+    ;;
+esac
+if [[ "$DRIFT_CASE" == source-parent-symlink ]]; then
+  [[ -L "$repo_root/bin" ]]
+  [[ "$(owned_path_mode "$OUTSIDE_ROOT/source-bin/codex")" == 775 ]]
+  [[ "$(owned_path_mode "$OUTSIDE_ROOT/source-bin/dotfiles-audit")" == 775 ]]
+  [[ "$(owned_path_mode "$OUTSIDE_ROOT/source-bin/linux-server-bootstrap")" == 775 ]]
+  rm "$repo_root/bin"
+  mv "$OUTSIDE_ROOT/source-bin" "$repo_root/bin"
+fi
+if [[ "$DRIFT_CASE" == source-parent-file ]]; then
+  [[ -f "$repo_root/bin" && "$(<"$repo_root/bin")" == keep-source-parent ]]
+  rm "$repo_root/bin"
+  mv "$OUTSIDE_ROOT/source-bin" "$repo_root/bin"
+fi
+if [[ "$DRIFT_CASE" == source-hardlink ]]; then
+  [[ "$(owned_path_links "$repo_root/bin/dotfiles-audit")" == 2 ]]
+  rm "$OUTSIDE_ROOT/dotfiles-audit"
+fi
+if [[ "$DRIFT_CASE" == codex-standalone-hardlink ]]; then
+  [[ "$(owned_path_links "$standalone_binary")" == 2 ]]
+  rm "$HOME/standalone-codex-hardlink"
+fi
 [[ ! -e "$HOME/.ssh" && ! -L "$HOME/.ssh" ]]
 [[ ! -e "$HOME/.local/state" && ! -L "$HOME/.local/state" ]]
 EOF
 chmod +x "$drift_case"
 
 for case_name in \
-  symlink type owner link home terminal-parent outside \
-  nested-symlink nested-type nested-owner world-mode non-traversable \
+  symlink type owner codex-wrong-target codex-file codex-foreign-target \
+  codex-standalone-symlink codex-standalone-hardlink codex-standalone-unsafe-mode \
+  codex-standalone-noncanonical-mode codex-current-file codex-current-outside \
+  codex-release-owner codex-release-world-mode codex-release-bin-symlink \
+  home terminal-parent outside \
+  nested-symlink nested-type nested-owner world-mode repo-world-mode non-traversable \
+  source-parent-symlink source-parent-file source-parent-owner source-parent-world-mode \
+  source-world-mode source-symlink source-hardlink \
+  chmod-failure-root chmod-failure-bin chmod-failure-first-source \
   pnpm-file pnpx-symlink pnpm-owner; do
   case_home="$temporary/drift-$case_name"
   outside_root="$temporary/outside-$case_name"
   mkdir "$case_home"
   mkdir "$outside_root"
+  case_repo="$case_home/.dotfiles"
+  create_test_repo "$case_repo"
   chmod 0777 "$outside_root"
   printf 'outside-marker\n' >"$outside_root/marker"
+  case "$case_name" in
+    codex-current-outside)
+      mkdir -p "$outside_root/release/bin"
+      printf '#!/usr/bin/env bash\n' >"$outside_root/release/bin/codex"
+      chmod 0755 "$outside_root/release/bin/codex"
+      ;;
+    codex-release-bin-symlink)
+      mkdir -p "$outside_root/release-bin"
+      printf '#!/usr/bin/env bash\n' >"$outside_root/release-bin/codex"
+      chmod 0755 "$outside_root/release-bin/codex"
+      ;;
+  esac
   outside_mode_before="$(mode "$outside_root")"
   outside_listing_before="$(find "$outside_root" -mindepth 1 -print | LC_ALL=C sort)"
   home_mode_before="$(mode "$case_home")"
   case_pnpm_home="$case_home/.local/share/pnpm"
   case_state_home="$case_home/.local/state"
+  fail_chmod_path=
+  chmod_failure_log="$temporary/chmod-failure-$case_name.log"
+  chmod_call_log="$temporary/chmod-calls-$case_name.log"
+  : >"$chmod_failure_log"
+  : >"$chmod_call_log"
   case "$case_name" in
     home) case_pnpm_home="$case_home" ;;
     terminal-parent) case_pnpm_home="$case_home/.." ;;
@@ -388,6 +662,9 @@ for case_name in \
     nested-type | nested-owner | world-mode)
       case_pnpm_home="$case_home/nested/tools/pnpm"
       ;;
+    chmod-failure-root) fail_chmod_path="$case_repo" ;;
+    chmod-failure-bin) fail_chmod_path="$case_repo/bin" ;;
+    chmod-failure-first-source) fail_chmod_path="$case_repo/bin/codex" ;;
   esac
   : >"$temporary/forbidden-$case_name.log"
   HOME="$case_home" \
@@ -396,14 +673,44 @@ for case_name in \
     PNPM_HOME="$case_pnpm_home" \
     PATH="$fakebin:/usr/bin:/bin" \
     FORBIDDEN_LOG="$temporary/forbidden-$case_name.log" \
+    DEVELOPER_CHMOD_LOG="$temporary/developer-chmod.log" \
+    DEVELOPER_REPO_ROOT="$root" \
     BOOTSTRAP_SCRIPT="$script" \
+    TEST_REPO_ROOT="$case_repo" \
     DRIFT_CASE="$case_name" \
     OUTSIDE_ROOT="$outside_root" \
     CASE_OUTPUT="$temporary/drift-$case_name.out" \
+    FAIL_CHMOD_PATH="$fail_chmod_path" \
+    CHMOD_FAILURE_LOG="$chmod_failure_log" \
+    CHMOD_CALL_LOG="$chmod_call_log" \
     "$drift_case"
   [[ ! -s "$temporary/forbidden-$case_name.log" ]]
-  grep -Eq 'refusing (unsafe|non-canonical|symlinked|non-directory|non-traversable|foreign-owned|world-writable|unexpected|user path outside)' \
-    "$temporary/drift-$case_name.out"
+  if [[ "$case_name" == chmod-failure-* ]]; then
+    grep -Fxq "injected chmod failure: $fail_chmod_path" "$chmod_failure_log"
+    [[ "$(wc -l <"$chmod_failure_log" | tr -d ' ')" == 1 ]]
+    expected_chmod_calls="$temporary/chmod-calls-$case_name.expected"
+    case "$case_name" in
+      chmod-failure-root)
+        printf '0755 %s\n' "$case_repo" >"$expected_chmod_calls"
+        ;;
+      chmod-failure-bin)
+        printf '0755 %s\n' \
+          "$case_repo" \
+          "$case_repo/bin" >"$expected_chmod_calls"
+        ;;
+      chmod-failure-first-source)
+        printf '0755 %s\n' \
+          "$case_repo" \
+          "$case_repo/bin" \
+          "$case_repo/bin/codex" >"$expected_chmod_calls"
+        ;;
+    esac
+    cmp "$expected_chmod_calls" "$chmod_call_log"
+  else
+    grep -Eq 'refusing (unsafe|non-canonical|symlinked|linked|non-directory|non-traversable|foreign-owned|world-writable|unexpected|user path outside)' \
+      "$temporary/drift-$case_name.out"
+    [[ ! -s "$chmod_failure_log" ]]
+  fi
   [[ "$(mode "$case_home")" == "$home_mode_before" ]]
   [[ "$(mode "$outside_root")" == "$outside_mode_before" ]]
   [[ "$(<"$outside_root/marker")" == outside-marker ]]
@@ -415,8 +722,47 @@ for case_name in \
     type)
       [[ -f "$case_home/.codex" && ! -L "$case_home/.codex" ]]
       ;;
-    link)
+    codex-wrong-target)
       [[ "$(readlink "$case_home/.local/bin/codex")" == "$case_home/wrong-codex" ]]
+      ;;
+    codex-file)
+      [[ "$(<"$case_home/.local/bin/codex")" == keep-codex ]]
+      ;;
+    codex-foreign-target)
+      [[ "$(readlink "$case_home/.local/bin/codex")" == \
+        "$case_home/.codex/packages/standalone/current/bin/codex" ]]
+      ;;
+    codex-standalone-symlink)
+      [[ "$(readlink "$case_home/.codex/packages/standalone/releases/test-release/bin/codex")" == \
+        /bin/sh ]]
+      ;;
+    codex-standalone-hardlink)
+      [[ ! -e "$case_home/standalone-codex-hardlink" ]]
+      ;;
+    codex-standalone-unsafe-mode)
+      [[ "$(mode "$case_home/.codex/packages/standalone/releases/test-release/bin/codex")" == \
+        777 ]]
+      ;;
+    codex-standalone-noncanonical-mode)
+      [[ "$(mode "$case_home/.codex/packages/standalone/releases/test-release/bin/codex")" == \
+        775 ]]
+      ;;
+    codex-current-file)
+      [[ -d "$case_home/.codex/packages/standalone/current" ]]
+      ;;
+    codex-current-outside)
+      [[ "$(readlink "$case_home/.codex/packages/standalone/current")" == \
+        "$outside_root/release" ]]
+      ;;
+    codex-release-owner)
+      [[ -d "$case_home/.codex/packages/standalone/releases/test-release" ]]
+      ;;
+    codex-release-world-mode)
+      [[ "$(mode "$case_home/.codex/packages/standalone/releases/test-release")" == 777 ]]
+      ;;
+    codex-release-bin-symlink)
+      [[ "$(readlink "$case_home/.codex/packages/standalone/releases/test-release/bin")" == \
+        "$outside_root/release-bin" ]]
       ;;
     nested-symlink)
       [[ "$(readlink "$case_home/nested/redirect")" == "$outside_root" ]]
@@ -426,6 +772,50 @@ for case_name in \
       ;;
     world-mode)
       [[ "$(mode "$case_home/nested")" == 777 ]]
+      ;;
+    repo-world-mode)
+      [[ "$(mode "$case_repo")" == 777 ]]
+      ;;
+    source-parent-symlink)
+      [[ -d "$case_repo/bin" && ! -L "$case_repo/bin" ]]
+      ;;
+    source-parent-file)
+      [[ -d "$case_repo/bin" && ! -L "$case_repo/bin" ]]
+      ;;
+    source-parent-owner)
+      [[ -d "$case_repo/bin" && ! -L "$case_repo/bin" ]]
+      ;;
+    source-parent-world-mode)
+      [[ "$(mode "$case_repo/bin")" == 777 ]]
+      ;;
+    source-world-mode)
+      [[ "$(mode "$case_repo/bin/dotfiles-audit")" == 777 ]]
+      ;;
+    source-symlink)
+      [[ "$(readlink "$case_repo/bin/dotfiles-audit")" == \
+        "$outside_root/marker" ]]
+      ;;
+    source-hardlink) [[ ! -e "$outside_root/dotfiles-audit" ]] ;;
+    chmod-failure-root)
+      [[ "$(mode "$case_repo")" == 775 ]]
+      [[ "$(mode "$case_repo/bin")" == 775 ]]
+      [[ "$(mode "$case_repo/bin/codex")" == 775 ]]
+      [[ "$(mode "$case_repo/bin/dotfiles-audit")" == 775 ]]
+      [[ "$(mode "$case_repo/bin/linux-server-bootstrap")" == 775 ]]
+      ;;
+    chmod-failure-bin)
+      [[ "$(mode "$case_repo")" == 755 ]]
+      [[ "$(mode "$case_repo/bin")" == 775 ]]
+      [[ "$(mode "$case_repo/bin/codex")" == 775 ]]
+      [[ "$(mode "$case_repo/bin/dotfiles-audit")" == 775 ]]
+      [[ "$(mode "$case_repo/bin/linux-server-bootstrap")" == 775 ]]
+      ;;
+    chmod-failure-first-source)
+      [[ "$(mode "$case_repo")" == 755 ]]
+      [[ "$(mode "$case_repo/bin")" == 755 ]]
+      [[ "$(mode "$case_repo/bin/codex")" == 775 ]]
+      [[ "$(mode "$case_repo/bin/dotfiles-audit")" == 775 ]]
+      [[ "$(mode "$case_repo/bin/linux-server-bootstrap")" == 775 ]]
       ;;
     non-traversable)
       [[ "$(mode "$case_home/.local")" == 600 ]]
@@ -443,6 +833,7 @@ for case_name in \
       ;;
   esac
 done
+[[ ! -s "$temporary/developer-chmod.log" ]]
 
 refresh_definitions="$(
   # shellcheck disable=SC1090


### PR DESCRIPTION
## Summary

- fail closed on unsafe or mutable dotfiles source paths before `refresh-user` changes user state
- preserve a production-shaped standalone Codex launcher only when `current/bin/codex` resolves beneath the owned `releases` tree
- validate the `current` link, complete resolved parent chain, binary ownership, mode, hardlink count, and symlink boundaries
- normalize owned source modes after the complete preflight and expand regression coverage for failure ordering

## Verification

- `bash tests/linux-server-refresh-user-test.sh`
- `bash tests/linux-server-bootstrap-test.sh`
- `bash tests/codex-wrapper-test.sh`
- `bash -n bin/linux-server-bootstrap tests/linux-server-refresh-user-test.sh tests/linux-server-bootstrap-test.sh tests/codex-wrapper-test.sh`
- `shellcheck bin/linux-server-bootstrap tests/linux-server-refresh-user-test.sh tests/linux-server-bootstrap-test.sh tests/codex-wrapper-test.sh`
- production-shaped standalone preflight against the installed `current -> releases/<version>` layout
- `git diff --check origin/master...HEAD`
- `git verify-commit HEAD`
- privacy scrub of the complete PR diff
