### PR TITLE
fix(worktrees): attest exact storage encryption

### DIFF
--- a/bin/agent-worktree-ops/README.md
+++ b/bin/agent-worktree-ops/README.md
@@ -12,8 +12,18 @@ Bins in this folder:
   - treats a missing contract as unconfigured only when the canonical path has
     neither a direct mount nor the sealed `root:wheel` mode-0000 backing directory
   - requires the exact UUID to be mounted directly at canonical
-    `~/.codex/worktrees` as encrypted, case-insensitive APFS with ownership
-    enabled and a user-owned mode-0700 mounted root
+    `~/.codex/worktrees` as case-insensitive APFS with policy-matching
+    encryption, ownership enabled, and a user-owned mode-0700 mounted root
+  - requires policy `encrypted` to be an exact JSON boolean and requires the
+    observed encryption boolean to match it exactly; unknown or mismatched
+    encryption fails without disclosing either value
+  - treats modern `diskutil` `Encryption` as authoritative whenever present;
+    malformed modern values are unknown, and legacy `Encrypted` is consulted
+    only when the modern field is absent
+  - exposes static integration discovery only through
+    `worktree-storage-guard --capabilities --json`; this returns the v1 exact-
+    boolean capability contract before reading environment configuration,
+    filesystem state, or `diskutil`, and rejects runtime options
   - requires at least 200 GiB and 10% free, an exact host marker, external-device
     location, disabled Spotlight indexing, and a UUID-tracked Time Machine volume
     exclusion verified with `tmutil isexcluded`

--- a/bin/agent-worktree-ops/worktree-storage-guard
+++ b/bin/agent-worktree-ops/worktree-storage-guard
@@ -16,6 +16,13 @@ from typing import Any
 
 
 SCHEMA = "external-worktree-storage.v2"
+CAPABILITIES = {
+    "encryption_attestation": "exact_boolean",
+    "encryption_policy": "exact_boolean",
+    "schema_version": "worktree-storage-guard-capabilities.v1",
+    "storage_schema": SCHEMA,
+    "unknown_encryption": "reject",
+}
 DEFAULT_CONFIG = (
     pathlib.Path("/Library/Application Support")
     / "agent-worktree-ops"
@@ -127,7 +134,7 @@ def load_config(
         or value.get("required") is not True
         or not children_contract_is_exact(value.get("children"))
         or value.get("filesystem") != "apfs"
-        or value.get("encrypted") is not True
+        or type(value.get("encrypted")) is not bool
         or value.get("case_sensitive") is not False
         or value.get("owners") is not True
         or value.get("device_location") != "External"
@@ -273,11 +280,11 @@ def normalized_device_location(disk: dict[str, Any]) -> str | None:
 
 
 def normalized_encryption(disk: dict[str, Any]) -> bool | None:
-    encryption = disk.get("Encryption")
-    if isinstance(encryption, bool):
-        return encryption
+    if "Encryption" in disk:
+        encryption = disk["Encryption"]
+        return encryption if type(encryption) is bool else None
     legacy = disk.get("Encrypted")
-    return legacy if isinstance(legacy, bool) else None
+    return legacy if type(legacy) is bool else None
 
 
 def live_observation(mount_point: pathlib.Path) -> dict[str, Any]:
@@ -333,7 +340,7 @@ def live_observation(mount_point: pathlib.Path) -> dict[str, Any]:
         "mount_point": disk.get("MountPoint"),
         "volume_uuid": disk.get("VolumeUUID"),
         "filesystem": "apfs" if "apfs" in personality.casefold() else personality.casefold(),
-        "encrypted": normalized_encryption(disk) is True,
+        "encrypted": normalized_encryption(disk),
         "free_gib": free_gib,
         "free_percent": free_percent,
         "case_sensitive": "case-sensitive" in personality.casefold(),
@@ -408,8 +415,12 @@ def validate_observation(
         raise GuardError("mounted external volume UUID does not match policy")
     if str(observed.get("filesystem") or "").casefold() != "apfs":
         raise GuardError("mounted external volume is not APFS")
-    if observed.get("encrypted") is not True:
-        raise GuardError("mounted external volume is not encrypted")
+    observed_encrypted = observed.get("encrypted")
+    if (
+        type(observed_encrypted) is not bool
+        or observed_encrypted is not config["encrypted"]
+    ):
+        raise GuardError("mounted external volume encryption does not match policy")
     if observed.get("case_sensitive") is not False:
         raise GuardError("mounted external volume must be case-insensitive")
     if observed.get("ownership_enabled") is not True:
@@ -445,22 +456,44 @@ def validate_observation(
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(allow_abbrev=False)
-    parser.add_argument("--config", default=os.environ.get("WORKTREE_STORAGE_CONFIG"))
+    parser.add_argument("--config")
     parser.add_argument("--require-config", action="store_true")
     parser.add_argument("--print-mount-point", action="store_true")
+    parser.add_argument("--capabilities", action="store_true")
     parser.add_argument("--json", action="store_true")
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
-    config_path = pathlib.Path(args.config).expanduser() if args.config else DEFAULT_CONFIG
     try:
-        if args.config and os.environ.get("WORKTREE_STORAGE_GUARD_TESTING") != "1":
+        if args.capabilities:
+            if (
+                not args.json
+                or args.config is not None
+                or args.require_config
+                or args.print_mount_point
+            ):
+                raise GuardError(
+                    "--capabilities requires --json and cannot be combined with runtime options"
+                )
+            print(json.dumps(CAPABILITIES, sort_keys=True, separators=(",", ":")))
+            return 0
+        config_override = args.config
+        if config_override is None:
+            config_override = os.environ.get("WORKTREE_STORAGE_CONFIG")
+        config_path = (
+            pathlib.Path(config_override).expanduser()
+            if config_override
+            else DEFAULT_CONFIG
+        )
+        if config_override and os.environ.get("WORKTREE_STORAGE_GUARD_TESTING") != "1":
             raise GuardError("runtime config override requires guard test mode")
         config_error = None
         try:
-            config = load_config(config_path, production_default=args.config is None)
+            config = load_config(
+                config_path, production_default=config_override is None
+            )
         except GuardError as error:
             config = None
             config_error = error
@@ -493,6 +526,7 @@ def main() -> int:
                         "backing_directory_mode": config["backing_directory_mode"],
                         "children": config["children"],
                         "device_location": observed.get("device_location"),
+                        "encrypted": observed.get("encrypted"),
                         "free_gib": observed.get("free_gib"),
                         "free_percent": observed.get("free_percent"),
                         "marker_id": observed.get("marker_id"),

--- a/functions/gwt/README.md
+++ b/functions/gwt/README.md
@@ -27,8 +27,9 @@ Key responsibilities:
 
 External storage behavior:
 
-- Configured hosts mount an encrypted, case-insensitive APFS volume directly at
-  canonical `~/.codex/worktrees`; a symlinked `~/.codex/worktrees` is rejected.
+- Configured hosts mount a case-insensitive APFS volume in the policy-selected
+  encrypted or unencrypted state directly at canonical `~/.codex/worktrees`;
+  a symlinked `~/.codex/worktrees` is rejected.
 - The root-owned system policy binds the exact UUID and host marker, requires an
   external device with ownership enabled, disabled Spotlight, persistent Time
   Machine volume exclusion, and at least 200 GiB plus 10% free.

--- a/functions/gwt/README.md
+++ b/functions/gwt/README.md
@@ -32,6 +32,10 @@ External storage behavior:
 - The root-owned system policy binds the exact UUID and host marker, requires an
   external device with ownership enabled, disabled Spotlight, persistent Time
   Machine volume exclusion, and at least 200 GiB plus 10% free.
+- Encryption policy and observation are exact JSON booleans. The observed value
+  must match policy; unknown or mismatched state fails without disclosing the
+  values. Integrations can discover this contract statically with
+  `worktree-storage-guard --capabilities --json` before any storage probe.
 - `gwt new`, `add`, `rm`, `audit`, `clean`, and `prune` stop before worktree
   access when the configured volume is absent, wrong, or replaced by a writable
   internal fallback. Missing policy also fails closed when the direct mount or

--- a/tests/worktree-storage-test.sh
+++ b/tests/worktree-storage-test.sh
@@ -157,6 +157,10 @@ assert module.normalized_encryption({"Encryption": True}) is True
 assert module.normalized_encryption({"Encryption": False, "Encrypted": True}) is False
 assert module.normalized_encryption({"Encryption": "true", "Encrypted": True}) is None
 assert module.normalized_encryption({"Encryption": "true", "Encrypted": False}) is None
+for legacy_encrypted in (False, True):
+    assert module.normalized_encryption(
+        {"Encryption": 1.0, "Encrypted": legacy_encrypted}
+    ) is None
 assert module.normalized_encryption({"Encryption": 1, "Encrypted": True}) is None
 assert module.normalized_encryption({"Encryption": None, "Encrypted": True}) is None
 assert module.normalized_encryption({"Encrypted": True}) is True

--- a/tests/worktree-storage-test.sh
+++ b/tests/worktree-storage-test.sh
@@ -156,6 +156,7 @@ assert module.normalized_device_location({}) is None
 assert module.normalized_encryption({"Encryption": True}) is True
 assert module.normalized_encryption({"Encryption": False, "Encrypted": True}) is False
 assert module.normalized_encryption({"Encryption": "true", "Encrypted": True}) is None
+assert module.normalized_encryption({"Encryption": "true", "Encrypted": False}) is None
 assert module.normalized_encryption({"Encryption": 1, "Encrypted": True}) is None
 assert module.normalized_encryption({"Encryption": None, "Encrypted": True}) is None
 assert module.normalized_encryption({"Encrypted": True}) is True
@@ -241,6 +242,20 @@ path.write_text(json.dumps(value, sort_keys=True) + "\n")
 PY
 }
 
+mutate_observed() {
+  local expression="$1"
+  python3 - "$observed" "$expression" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+value = json.loads(path.read_text())
+exec(sys.argv[2], {"value": value})
+path.write_text(json.dumps(value, sort_keys=True) + "\n")
+PY
+}
+
 write_config
 mutate_config 'value["schema_version"] = "external-worktree-storage.v1"'
 assert_invalid_config v1-schema "required config missing or invalid"
@@ -278,8 +293,16 @@ mutate_config 'value["encrypted"] = 1'
 assert_invalid_config integer-encrypted "required config missing or invalid"
 
 write_config
+mutate_config 'value["encrypted"] = 0'
+assert_invalid_config integer-zero-encrypted "required config missing or invalid"
+
+write_config
 mutate_config 'value["encrypted"] = 1.0'
 assert_invalid_config float-encrypted "required config missing or invalid"
+
+write_config
+mutate_config 'value["encrypted"] = 0.0'
+assert_invalid_config float-zero-encrypted "required config missing or invalid"
 
 write_config
 mutate_config 'value["encrypted"] = "true"'
@@ -358,6 +381,26 @@ value["encrypted"] = None
 path.write_text(json.dumps(value))
 PY
 assert_encryption_failure encrypted-observation-unknown
+
+write_config
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
+mutate_observed 'value.pop("encrypted")'
+assert_encryption_failure encrypted-observation-missing
+
+write_config
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
+mutate_observed 'value["encrypted"] = "true"'
+assert_encryption_failure encrypted-observation-string
+
+write_config
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
+mutate_observed 'value["encrypted"] = 1'
+assert_encryption_failure encrypted-observation-integer
+
+write_config
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
+mutate_observed 'value["encrypted"] = 1.0'
+assert_encryption_failure encrypted-observation-float
 
 write_config
 mutate_config 'value["encrypted"] = False'

--- a/tests/worktree-storage-test.sh
+++ b/tests/worktree-storage-test.sh
@@ -57,6 +57,35 @@ run_guard() {
     "$guard" "$@"
 }
 
+capabilities='{"encryption_attestation":"exact_boolean","encryption_policy":"exact_boolean","schema_version":"worktree-storage-guard-capabilities.v1","storage_schema":"external-worktree-storage.v2","unknown_encryption":"reject"}'
+actual_capabilities="$(
+  HOME="$temporary/capability-home" \
+    WORKTREE_STORAGE_CONFIG="$temporary/missing-capability-config.json" \
+    WORKTREE_STORAGE_GUARD_OBSERVED="$temporary/missing-observation.json" \
+    "$guard" --capabilities --json
+)"
+[[ "$actual_capabilities" == "$capabilities" ]]
+
+assert_invalid_capabilities() {
+  local name="$1"
+  shift
+  if "$guard" "$@" >"$temporary/$name.out" 2>&1; then
+    echo "$name capabilities invocation must fail" >&2
+    exit 1
+  fi
+  grep -Fq -- \
+    "--capabilities requires --json and cannot be combined with runtime options" \
+    "$temporary/$name.out"
+}
+
+assert_invalid_capabilities capabilities-without-json --capabilities
+assert_invalid_capabilities capabilities-with-config \
+  --capabilities --json --config "$config"
+assert_invalid_capabilities capabilities-with-required \
+  --capabilities --json --require-config
+assert_invalid_capabilities capabilities-with-mount-point \
+  --capabilities --json --print-mount-point
+
 write_config
 write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
 [[ "$(run_guard --print-mount-point)" == "$mount_point" ]]
@@ -126,7 +155,12 @@ assert module.normalized_device_location(
 assert module.normalized_device_location({}) is None
 assert module.normalized_encryption({"Encryption": True}) is True
 assert module.normalized_encryption({"Encryption": False, "Encrypted": True}) is False
+assert module.normalized_encryption({"Encryption": "true", "Encrypted": True}) is None
+assert module.normalized_encryption({"Encryption": 1, "Encrypted": True}) is None
+assert module.normalized_encryption({"Encryption": None, "Encrypted": True}) is None
 assert module.normalized_encryption({"Encrypted": True}) is True
+assert module.normalized_encryption({"Encrypted": False}) is False
+assert module.normalized_encryption({"Encrypted": 1}) is None
 assert module.normalized_encryption({}) is None
 if os.getuid() != 0:
     try:
@@ -143,6 +177,7 @@ import sys
 
 value = json.loads(pathlib.Path(sys.argv[1]).read_text())
 assert value["configured"] is True
+assert value["encrypted"] is True
 assert value["schema_version"] == "external-worktree-storage.v2"
 assert value["children"] == {
     "openclaw_managed": {
@@ -239,6 +274,22 @@ mutate_config 'value["children"]["openclaw_pnpm_store"]["disposable"] = 1.0'
 assert_invalid_config float-disposable "required config missing or invalid"
 
 write_config
+mutate_config 'value["encrypted"] = 1'
+assert_invalid_config integer-encrypted "required config missing or invalid"
+
+write_config
+mutate_config 'value["encrypted"] = 1.0'
+assert_invalid_config float-encrypted "required config missing or invalid"
+
+write_config
+mutate_config 'value["encrypted"] = "true"'
+assert_invalid_config string-encrypted "required config missing or invalid"
+
+write_config
+mutate_config 'value["encrypted"] = None'
+assert_invalid_config null-encrypted "required config missing or invalid"
+
+write_config
 mutate_config 'value["children"]["openclaw_pnpm_store"]["relative_path"] = "openclaw-managed/cache"'
 assert_invalid_config overlapping-child "required config missing or invalid"
 
@@ -262,6 +313,76 @@ if run_guard >"$temporary/exfat.out" 2>&1; then
 fi
 grep -Fq "not APFS" "$temporary/exfat.out"
 
+assert_encryption_failure() {
+  local name="$1"
+  if run_guard >"$temporary/$name.out" 2>&1; then
+    echo "$name encryption attestation must fail" >&2
+    exit 1
+  fi
+  grep -Fq "encryption does not match policy" "$temporary/$name.out"
+  if grep -Eq "expected|actual|true|false|null" "$temporary/$name.out"; then
+    echo "$name encryption failure must not disclose values" >&2
+    exit 1
+  fi
+}
+
+write_config
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
+python3 - "$observed" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+value = json.loads(path.read_text())
+value["encrypted"] = False
+path.write_text(json.dumps(value))
+PY
+assert_encryption_failure encrypted-policy-true-observed-false
+
+write_config
+mutate_config 'value["encrypted"] = False'
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
+assert_encryption_failure encrypted-policy-false-observed-true
+
+write_config
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
+python3 - "$observed" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+value = json.loads(path.read_text())
+value["encrypted"] = None
+path.write_text(json.dumps(value))
+PY
+assert_encryption_failure encrypted-observation-unknown
+
+write_config
+mutate_config 'value["encrypted"] = False'
+write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700
+python3 - "$observed" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+value = json.loads(path.read_text())
+value["encrypted"] = False
+path.write_text(json.dumps(value))
+PY
+run_guard --json >"$temporary/unencrypted-ready.json"
+python3 - "$temporary/unencrypted-ready.json" <<'PY'
+import json
+import pathlib
+import sys
+
+value = json.loads(pathlib.Path(sys.argv[1]).read_text())
+assert value["encrypted"] is False
+PY
+
+write_config
 write_observed "$volume_uuid" apfs true "$(id -u)" "$(id -g)" 0700 199 50
 if run_guard >"$temporary/low-gib.out" 2>&1; then
   echo "minimum_free_gib must fail before mutation" >&2


### PR DESCRIPTION
## Summary

- require exact JSON booleans for encryption policy and observed attestation
- keep modern `diskutil` encryption state authoritative and reject unknown or mismatched observations without disclosing values
- expose the static `worktree-storage-guard --capabilities --json` integration contract before runtime storage access
- document and test the capability and attestation behavior while preserving existing storage checks

## Testing

- `/bin/bash tests/worktree-storage-test.sh` (Bash 3.2.57)
- `/bin/bash tests/external-tmp-test.sh` (Bash 3.2.57)
- `/bin/bash tests/agent-worktree-maintain-test.sh` (Bash 3.2.57)
- `/bin/zsh tests/gwt-cleanup-test.zsh`
- `/usr/bin/python3 tests/agent-worktree-ops-test.py` (Python 3.9.6)
- `/bin/bash tests/install-agent-worktree-ops-test.sh` (Bash 3.2.57)
- `/usr/bin/python3 -m py_compile bin/agent-worktree-ops/worktree-storage-guard`
- `/bin/bash -n tests/worktree-storage-test.sh`
- `git diff --check`
