### PR TITLE
fix(terminal): restore Ghostty font ownership

### DIFF
--- a/.config/ghostty/config.ghostty
+++ b/.config/ghostty/config.ghostty
@@ -2,10 +2,9 @@
 # reading comfort instead of relying on ad hoc app-local settings.
 theme = TokyoNight Night
 
+# Preserve the original reading face; use Meslo only for Nerd Font glyphs.
+font-family = Monaco
 font-family = MesloLGL Nerd Font Mono
-font-family-bold = MesloLGL Nerd Font Mono
-font-family-italic = MesloLGL Nerd Font Mono
-font-family-bold-italic = MesloLGL Nerd Font Mono
 font-size = 12
 
 background = #1a1b26

--- a/bin/terminal-sync
+++ b/bin/terminal-sync
@@ -33,7 +33,7 @@ check_link() {
 
     report "$target" drift
     failures=$((failures + 1))
-    [[ "$mode" == "apply" ]] || return
+    [[ "$mode" == "apply" ]] || return 0
 
     mkdir -p "$(dirname "$target")"
     if [[ -e "$target" || -L "$target" ]]; then
@@ -44,6 +44,26 @@ check_link() {
         fi
     fi
     ln -s "$source" "$target"
+}
+
+check_absent() {
+    local target="$1"
+    local legacy_source="${2:-}"
+
+    if [[ ! -e "$target" && ! -L "$target" ]]; then
+        report "$target" ready
+        return
+    fi
+
+    report "$target" drift
+    failures=$((failures + 1))
+    [[ "$mode" == "apply" ]] || return 0
+
+    if [[ -n "$legacy_source" && -L "$target" && "$(readlink "$target")" == "$legacy_source" ]]; then
+        unlink "$target"
+    else
+        mv "$target" "$target.pre-terminal-sync.$(date +%Y%m%d%H%M%S).bak"
+    fi
 }
 
 has_meslo_font_payload() {
@@ -88,7 +108,7 @@ sync_font_pack() {
 
     report "terminal font pack ($total)" "drift missing=${#missing[@]}"
     failures=$((failures + 1))
-    [[ "$mode" == "apply" ]] || return
+    [[ "$mode" == "apply" ]] || return 0
     brew install --cask "${missing[@]}"
 }
 
@@ -100,7 +120,7 @@ repair_font() {
 
     report "MesloLGL Nerd Font Mono" drift
     failures=$((failures + 1))
-    [[ "$mode" == "apply" ]] || return
+    [[ "$mode" == "apply" ]] || return 0
 
     command -v brew >/dev/null 2>&1 || {
         report Homebrew missing
@@ -142,13 +162,22 @@ PY
 validate_ghostty() {
     local binary="/Applications/Ghostty.app/Contents/MacOS/ghostty"
     local effective_config
+    local expected_stack
+    local font_key
+    local font_stack
+    local fonts_ready=1
     if [[ ! -x "$binary" ]]; then
         report Ghostty missing
         failures=$((failures + 1))
         return
     fi
     effective_config="$($binary +show-config 2>/dev/null || true)"
-    if grep -q '^font-family = MesloLGL Nerd Font Mono$' <<<"$effective_config"; then
+    for font_key in font-family font-family-bold font-family-italic font-family-bold-italic; do
+        font_stack="$(grep "^$font_key = " <<<"$effective_config" || true)"
+        expected_stack="$font_key = Monaco"$'\n'"$font_key = MesloLGL Nerd Font Mono"
+        [[ "$font_stack" == "$expected_stack" ]] || fonts_ready=0
+    done
+    if [[ "$fonts_ready" -eq 1 ]]; then
         report "Ghostty effective config" ready
     else
         report "Ghostty effective config" drift
@@ -181,7 +210,7 @@ reload_tmux() {
     exit 2
 }
 
-check_link "$ghostty_source" "$HOME/.config/ghostty"
+check_absent "$HOME/.config/ghostty" "$ghostty_source"
 check_link "$ghostty_config" "$HOME/Library/Application Support/com.mitchellh.ghostty/config.ghostty"
 check_link "$tmux_config" "$HOME/.tmux.conf"
 check_link "$tmux_local_config" "$HOME/.tmux.conf.local"
@@ -202,7 +231,7 @@ if [[ "$mode" == "apply" ]]; then
     while IFS= read -r cask; do
         brew list --cask "$cask" >/dev/null 2>&1 || failures=$((failures + 1))
     done < <(declared_font_casks)
-    [[ -L "$HOME/.config/ghostty" && "$(readlink "$HOME/.config/ghostty")" == "$ghostty_source" ]] || failures=$((failures + 1))
+    [[ ! -e "$HOME/.config/ghostty" && ! -L "$HOME/.config/ghostty" ]] || failures=$((failures + 1))
     [[ -L "$HOME/.tmux.conf" && "$(readlink "$HOME/.tmux.conf")" == "$tmux_config" ]] || failures=$((failures + 1))
     [[ "$failures" -eq 0 ]] || exit 1
     printf '\nterminal parity applied; open a new Ghostty window if an existing window cached the old font\n'

--- a/install.sh
+++ b/install.sh
@@ -826,11 +826,16 @@ setup_ghostty_config() {
     fi
 
     mkdir -p "$HOME/.config"
-    link_dotfile "$ghostty_config_dir" "$local_ghostty_dir"
-
     if [[ "$(uname)" == "Darwin" ]]; then
+        if [[ -L "$local_ghostty_dir" && "$(readlink "$local_ghostty_dir")" == "$ghostty_config_dir" ]]; then
+            unlink "$local_ghostty_dir"
+        elif [[ -e "$local_ghostty_dir" || -L "$local_ghostty_dir" ]]; then
+            warn "Ghostty XDG config can override the macOS config; run terminal-sync --apply to back it up"
+        fi
         mkdir -p "$macos_ghostty_dir"
         link_dotfile "$ghostty_config_file" "$macos_ghostty_config"
+    else
+        link_dotfile "$ghostty_config_dir" "$local_ghostty_dir"
     fi
 
     success "Ghostty config linked to $ghostty_config_dir"

--- a/tests/terminal-sync-test.sh
+++ b/tests/terminal-sync-test.sh
@@ -5,9 +5,17 @@ repo="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 bash -n "$repo/bin/terminal-sync"
 grep -q 'font-meslo-lg-nerd-font' "$repo/bin/terminal-sync"
 grep -q 'com.mitchellh.ghostty/config.ghostty' "$repo/bin/terminal-sync"
+grep -q 'check_absent.*HOME/.config/ghostty' "$repo/bin/terminal-sync"
 grep -q 'tmux source-file' "$repo/bin/terminal-sync"
 grep -q 'TERMINAL_SYNC_DOTFILES_DIR' "$repo/bin/terminal-sync"
 grep -q 'set font name of default settings' "$repo/bin/terminal-sync"
 grep -q 'declared_font_casks' "$repo/bin/terminal-sync"
 grep -q 'terminal font pack' "$repo/bin/terminal-sync"
+[[ "$(grep -c '^font-family = ' "$repo/.config/ghostty/config.ghostty")" -eq 2 ]]
+grep -qx 'font-family = Monaco' "$repo/.config/ghostty/config.ghostty"
+grep -qx 'font-family = MesloLGL Nerd Font Mono' "$repo/.config/ghostty/config.ghostty"
+if grep -q '^font-family-' "$repo/.config/ghostty/config.ghostty"; then
+    printf 'legacy Ghostty style-specific font override remains\n' >&2
+    exit 1
+fi
 printf 'terminal_sync_test=passed\n'


### PR DESCRIPTION
## Summary

- keep Ghostty's macOS Application Support config as the sole active config
- restore Monaco as the primary face with MesloLGL Nerd Font Mono as fallback
- teach `terminal-sync` to remove or preserve-and-back-up conflicting XDG config
- verify Ghostty's expanded font stack and reject legacy style-specific overrides

## Verification

- `bash tests/terminal-sync-test.sh`
- `bash -n install.sh bin/terminal-sync tests/terminal-sync-test.sh`
- `shellcheck bin/terminal-sync tests/terminal-sync-test.sh`
- `/Applications/Ghostty.app/Contents/MacOS/ghostty +show-config`
- `git diff HEAD^ --check`
