### PR TITLE
fix(codex): persist GitHub MCP authentication

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -7,6 +7,8 @@ Top-level wrappers:
 - `agent-worktree-clean`
 - `agent-worktree-maintain`
 - `agent-worktree-purge`
+- `codex` - launch the installed CLI, preserving inherited GitHub credentials and filling missing token variables from native `gh` when available
+- `codex-github-mcp` - start GitHub MCP over stdio with inherited credentials or native `gh` authentication; forwards extra server arguments
 - `discrawl` - preserve explicit remote auth or load `openclaw-crawl/remote.env` from the trusted XDG config location before dispatching to a real backend
 - `install-agent-worktree-ops`
 - `retire-agent-worktree-scheduler`
@@ -23,3 +25,23 @@ Tool folders:
   - bash completion scripts
 - `zsh-completion/`
   - zsh completion scripts
+
+## Codex MCP
+
+Register the stable launcher path after linking `~/bin`:
+
+```sh
+codex mcp add github -- "$HOME/bin/codex-github-mcp"
+```
+
+Add `env_vars = ["GITHUB_PERSONAL_ACCESS_TOKEN", "GITHUB_PAT_TOKEN"]` to the
+`[mcp_servers.github]` table in `~/.codex/config.toml` so both CLI and desktop
+launches can forward inherited credentials. The helper preserves each nonempty
+value, fills missing values from the canonical token then the legacy token, and
+only queries native `gh auth token` when both are empty. It never uses `ghx` or
+starts an interactive login. Missing authentication fails GitHub MCP clearly but
+does not prevent the general `codex` launcher from starting.
+
+Let enabled plugins own their MCP registrations, including Computer Use. Avoid
+duplicate `[mcp_servers.computer-use]` overrides and paths into versioned plugin
+caches; plugin launchers manage their binary location and working directory.

--- a/bin/codex
+++ b/bin/codex
@@ -71,16 +71,17 @@ if [[ "${CODEX_WRAPPER_DEBUG:-0}" == "1" ]]; then
   printf 'codex launcher: %s\n' "$real_codex" >&2
 fi
 
-if [[ -z "${GITHUB_PAT_TOKEN:-}" ]]; then
-  token=""
+token="${GITHUB_PERSONAL_ACCESS_TOKEN:-${GITHUB_PAT_TOKEN:-}}"
+if [[ -z "$token" ]]; then
   gh_bin="$(PATH="$lookup_path" command -v gh || true)"
   if [[ -n "$gh_bin" && -x "$gh_bin" ]]; then
-    token="$("$gh_bin" auth token 2>/dev/null || true)"
+    token="$("$gh_bin" auth token </dev/null 2>/dev/null)" || token=""
   fi
-  if [[ -n "$token" ]]; then
-    export GITHUB_PAT_TOKEN="$token"
-  fi
-  unset gh_bin token
 fi
+if [[ -n "$token" ]]; then
+  export GITHUB_PERSONAL_ACCESS_TOKEN="${GITHUB_PERSONAL_ACCESS_TOKEN:-$token}"
+  export GITHUB_PAT_TOKEN="${GITHUB_PAT_TOKEN:-$token}"
+fi
+unset gh_bin token
 
 exec "$real_codex" "$@"

--- a/bin/codex-github-mcp
+++ b/bin/codex-github-mcp
@@ -10,13 +10,43 @@ if [[ -z "$github_mcp_server" ]]; then
   exit 127
 fi
 
-github_token="$("$HOME/bin/ghx" auth token 2>/dev/null || true)"
+github_token="${GITHUB_PERSONAL_ACCESS_TOKEN:-${GITHUB_PAT_TOKEN:-}}"
 if [[ -z "$github_token" ]]; then
-  echo "codex-github-mcp: GitHub CLI authentication is unavailable" >&2
+  wrapper_dir="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+  lookup_path=""
+  path_remaining="${PATH:-}"
+  path_done=""
+  while :; do
+    case "$path_remaining" in
+      *:*)
+        path_entry="${path_remaining%%:*}"
+        path_remaining="${path_remaining#*:}"
+        ;;
+      *)
+        path_entry="$path_remaining"
+        path_done=1
+        ;;
+    esac
+    path_entry="${path_entry:-.}"
+    if [[ ! -d "$path_entry" || ! "$path_entry" -ef "$wrapper_dir" ]]; then
+      lookup_path+="${lookup_path:+:}$path_entry"
+    fi
+    [[ -z "${path_done:-}" ]] || break
+  done
+  unset path_done path_entry path_remaining
+
+  gh_bin="$(PATH="$lookup_path" command -v gh || true)"
+  if [[ -n "$gh_bin" && -x "$gh_bin" ]]; then
+    github_token="$("$gh_bin" auth token </dev/null 2>/dev/null)" || github_token=""
+  fi
+fi
+if [[ -z "$github_token" ]]; then
+  echo "codex-github-mcp: set GITHUB_PERSONAL_ACCESS_TOKEN or GITHUB_PAT_TOKEN, or authenticate the native GitHub CLI" >&2
   exit 1
 fi
 
-export GITHUB_PERSONAL_ACCESS_TOKEN="$github_token"
-unset github_token
+export GITHUB_PERSONAL_ACCESS_TOKEN="${GITHUB_PERSONAL_ACCESS_TOKEN:-$github_token}"
+export GITHUB_PAT_TOKEN="${GITHUB_PAT_TOKEN:-$github_token}"
+unset gh_bin github_token
 
-exec "$github_mcp_server" stdio
+exec "$github_mcp_server" stdio "$@"

--- a/tests/codex-github-mcp-test.sh
+++ b/tests/codex-github-mcp-test.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+temporary="$(mktemp -d)"
+trap 'rm -rf "$temporary"' EXIT
+unset GITHUB_PERSONAL_ACCESS_TOKEN GITHUB_PAT_TOKEN
+
+wrapper_dir="$temporary/wrapper space"
+backend_dir="$temporary/backend"
+test_home="$temporary/home"
+mkdir -p "$wrapper_dir" "$backend_dir" "$test_home"
+ln -s "$wrapper_dir" "$test_home/bin"
+cp "$repo_root/bin/codex" "$repo_root/bin/codex-github-mcp" "$wrapper_dir/"
+
+cat >"$backend_dir/uname" <<'EOF'
+#!/usr/bin/env bash
+printf 'TestOS\n'
+EOF
+
+cat >"$backend_dir/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ $# -eq 2 && "$1" == auth && "$2" == token ]]
+printf 'lookup\n' >>"$TEST_LOOKUP_LOG"
+if IFS= read -r input; then
+  printf 'authentication consumed stdin\n' >&2
+  exit 64
+fi
+printf 'synthetic-stderr-secret\n' >&2
+case "$TEST_AUTH_MODE" in
+  success) printf 'synthetic-native-secret\n' ;;
+  failed)
+    printf 'synthetic-native-secret\n'
+    exit 1
+    ;;
+  empty) ;;
+  *) exit 65 ;;
+esac
+EOF
+
+cat >"$wrapper_dir/gh" <<'EOF'
+#!/usr/bin/env bash
+printf 'forbidden wrapper invoked\n' >>"$TEST_FORBIDDEN_LOG"
+exit 66
+EOF
+cp "$wrapper_dir/gh" "$wrapper_dir/ghx"
+cp "$wrapper_dir/gh" "$backend_dir/ghx"
+
+cat >"$backend_dir/codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "${GITHUB_PERSONAL_ACCESS_TOKEN:-}" == "$TEST_EXPECTED_MODERN" ]]
+[[ "${GITHUB_PAT_TOKEN:-}" == "$TEST_EXPECTED_LEGACY" ]]
+if [[ "$TEST_LAUNCHER" == codex-github-mcp ]]; then
+  [[ "$1" == stdio ]]
+  shift
+fi
+[[ $# -eq 2 && "$1" == run && "$2" == "two words" ]]
+IFS= read -r input
+[[ "$input" == "request on stdin" ]]
+printf 'backend:ok\n'
+EOF
+cp "$backend_dir/codex" "$backend_dir/github-mcp-server"
+chmod +x "$wrapper_dir/"* "$backend_dir/"*
+
+# The helper adds system paths. Restrict these two lookups to fixtures so tests
+# cannot reach an installed server, native gh credentials, or a real keychain.
+command() {
+  if [[ $# -eq 2 && "$1" == -v && ( "$2" == gh || "$2" == github-mcp-server ) ]]; then
+    local entry
+    local -a entries
+    IFS=: read -r -a entries <<<"$PATH"
+    for entry in "${entries[@]}"; do
+      case "$entry" in
+        "$TEST_ROOT"/*)
+          if [[ "$2" == gh && "$TEST_NO_GH" == 1 && "$entry" -ef "$TEST_BACKEND" ]]; then
+            continue
+          fi
+          if [[ "$2" == github-mcp-server && "$TEST_NO_SERVER" == 1 ]]; then
+            continue
+          fi
+          if [[ -x "$entry/$2" ]]; then
+            printf '%s\n' "$entry/$2"
+            return 0
+          fi
+          ;;
+      esac
+    done
+    return 1
+  fi
+  builtin command "$@"
+}
+export -f command
+
+run_case() {
+  local name="$1" modern="$2" legacy="$3" lookups="$4" auth_mode="$5"
+  shift 5
+  local expected_status=0 actual_status=0
+  if [[ "$launcher" == codex-github-mcp ]]; then
+    if [[ "${TEST_NO_SERVER:-0}" == 1 ]]; then
+      expected_status=127
+    elif [[ -z "$modern" ]]; then
+      expected_status=1
+    fi
+  fi
+  : >"$temporary/lookups"
+  : >"$temporary/forbidden"
+  printf 'case: %s/%s\n' "$launcher" "$name"
+  printf 'request on stdin\n' |
+    env -u GITHUB_PERSONAL_ACCESS_TOKEN -u GITHUB_PAT_TOKEN -u CODEX_HOME \
+      -u BASH_ENV -u ENV HOME="$test_home" PATH="$test_home/bin:$backend_dir:/usr/bin:/bin" \
+      TEST_ROOT="$temporary" TEST_BACKEND="$backend_dir" \
+      TEST_LAUNCHER="$launcher" TEST_AUTH_MODE="$auth_mode" \
+      TEST_NO_GH="${TEST_NO_GH:-0}" TEST_NO_SERVER="${TEST_NO_SERVER:-0}" \
+      TEST_EXPECTED_MODERN="$modern" TEST_EXPECTED_LEGACY="$legacy" \
+      TEST_LOOKUP_LOG="$temporary/lookups" TEST_FORBIDDEN_LOG="$temporary/forbidden" \
+      "$@" "$test_home/bin/$launcher" run "two words" \
+      >"$temporary/stdout" 2>"$temporary/stderr" || actual_status=$?
+  [[ "$actual_status" -eq "$expected_status" ]]
+  [[ "$(wc -l <"$temporary/lookups")" -eq "$lookups" ]]
+  [[ ! -s "$temporary/forbidden" ]]
+  if grep -Eq 'synthetic-(modern|legacy|native|stderr)-secret' "$temporary/stdout" "$temporary/stderr"; then
+    printf 'credential leaked to launcher output\n' >&2
+    exit 1
+  fi
+  if [[ "$expected_status" -eq 0 ]]; then
+    [[ "$(<"$temporary/stdout")" == backend:ok ]]
+    [[ ! -s "$temporary/stderr" ]]
+  else
+    [[ ! -s "$temporary/stdout" ]]
+    if [[ "$expected_status" -eq 127 ]]; then
+      grep -Fx 'codex-github-mcp: install github-mcp-server with Homebrew' "$temporary/stderr" >/dev/null
+    else
+      grep -Fx 'codex-github-mcp: set GITHUB_PERSONAL_ACCESS_TOKEN or GITHUB_PAT_TOKEN, or authenticate the native GitHub CLI' "$temporary/stderr" >/dev/null
+    fi
+  fi
+}
+
+for launcher in codex codex-github-mcp; do
+  run_case modern synthetic-modern-secret synthetic-modern-secret 0 failed \
+    GITHUB_PERSONAL_ACCESS_TOKEN=synthetic-modern-secret
+  run_case legacy synthetic-legacy-secret synthetic-legacy-secret 0 failed \
+    GITHUB_PAT_TOKEN=synthetic-legacy-secret
+  run_case conflicting synthetic-modern-secret synthetic-legacy-secret 0 failed \
+    GITHUB_PERSONAL_ACCESS_TOKEN=synthetic-modern-secret GITHUB_PAT_TOKEN=synthetic-legacy-secret
+  run_case empty-modern synthetic-legacy-secret synthetic-legacy-secret 0 failed \
+    GITHUB_PERSONAL_ACCESS_TOKEN= GITHUB_PAT_TOKEN=synthetic-legacy-secret
+  run_case empty-legacy synthetic-modern-secret synthetic-modern-secret 0 failed \
+    GITHUB_PERSONAL_ACCESS_TOKEN=synthetic-modern-secret GITHUB_PAT_TOKEN=
+  run_case empty-both synthetic-native-secret synthetic-native-secret 1 success \
+    GITHUB_PERSONAL_ACCESS_TOKEN= GITHUB_PAT_TOKEN=
+  run_case native synthetic-native-secret synthetic-native-secret 1 success
+  TEST_NO_GH=1 run_case no-gh "" "" 0 success
+  run_case failed-lookup "" "" 1 failed
+  run_case empty-lookup "" "" 1 empty
+  TEST_NO_SERVER=1 run_case missing-mcp synthetic-modern-secret synthetic-modern-secret 0 failed \
+    GITHUB_PERSONAL_ACCESS_TOKEN=synthetic-modern-secret
+done
+
+printf 'codex GitHub MCP authentication tests passed\n'

--- a/tests/codex-wrapper-test.sh
+++ b/tests/codex-wrapper-test.sh
@@ -57,7 +57,10 @@ long_path="$long_path:$backend_dir:/usr/bin:/bin"
 path_entry_count=$((path_entry_count + 3))
 [[ "$path_entry_count" -eq 45 ]]
 
-output="$(env -u GITHUB_PAT_TOKEN PATH="$long_path" "$symlink_dir/codex" --version)"
+output="$(
+  env -u GITHUB_PERSONAL_ACCESS_TOKEN -u GITHUB_PAT_TOKEN -u CODEX_HOME \
+    PATH="$long_path" "$symlink_dir/codex" --version
+)"
 [[ "$output" == *"version:--version"* ]]
 [[ "$output" == *"token:injected"* ]]
 
@@ -73,7 +76,8 @@ cat >"$backend_dir/uname" <<'EOF'
 printf 'Darwin\n'
 EOF
 darwin_output="$(
-  GITHUB_PAT_TOKEN=test HOME="$darwin_home" PATH="$long_path" \
+  env -u GITHUB_PERSONAL_ACCESS_TOKEN -u CODEX_HOME \
+    GITHUB_PAT_TOKEN=test HOME="$darwin_home" PATH="$long_path" \
     "$symlink_dir/codex" run "two words"
 )"
 [[ "$darwin_output" == "standalone:run two words" ]]
@@ -81,7 +85,8 @@ darwin_output="$(
 missing_home="$temporary/darwin-missing"
 mkdir -p "$missing_home"
 set +e
-GITHUB_PAT_TOKEN=test HOME="$missing_home" PATH="$long_path" \
+env -u GITHUB_PERSONAL_ACCESS_TOKEN -u CODEX_HOME \
+  GITHUB_PAT_TOKEN=test HOME="$missing_home" PATH="$long_path" \
   "$symlink_dir/codex" --version \
   >"$temporary/darwin-missing.stdout" 2>"$temporary/darwin-missing.stderr"
 missing_status=$?
@@ -105,7 +110,8 @@ cat >"$backend_dir/uname" <<'EOF'
 printf 'Linux\n'
 EOF
 linux_output="$(
-  env -u GITHUB_PAT_TOKEN HOME="$linux_home" PATH="$long_path" \
+  env -u GITHUB_PERSONAL_ACCESS_TOKEN -u GITHUB_PAT_TOKEN -u CODEX_HOME \
+    HOME="$linux_home" PATH="$long_path" \
     "$symlink_dir/codex" run "two words"
 )"
 [[ "$linux_output" == "standalone:run two words" ]]


### PR DESCRIPTION
## Summary

- Preserve explicit GitHub token values in both launchers, fill only missing values, and use native `gh` authentication only when neither token is available.
- Protect MCP stdin and credential output; remove the helper's dependency on proxy authentication.
- Document stable GitHub MCP launcher registration and plugin ownership of MCP servers.

## Validation

- `bash tests/codex-wrapper-test.sh`
- `bash tests/codex-github-mcp-test.sh` (22 cases)
- `python3.13 tests/codebase-memory-policy-test.py`
- ShellCheck on both launchers and both shell tests
- Fresh Codex app-server discovery of GitHub, Computer Use, and `node_repl`, with and without inherited tokens
