### PR TITLE
feat(worktrees): harden external temp scratch

### DIFF
--- a/bin/external-tmp
+++ b/bin/external-tmp
@@ -4,6 +4,7 @@ import json
 import os
 import pathlib
 import secrets
+import signal
 import stat
 import subprocess
 import sys
@@ -345,6 +346,67 @@ def cleanup(scratch, guard):
     os.rmdir(scratch.name, dir_fd=scratch.tmp_fd)
 
 
+def run_child(command, environment):
+    watched = (signal.SIGHUP, signal.SIGINT, signal.SIGTERM)
+    pending = []
+    first_signal = [None]
+
+    def queue_signal(signum, _frame):
+        if first_signal[0] is None:
+            first_signal[0] = signum
+        pending.append(signum)
+
+    previous_mask = signal.pthread_sigmask(signal.SIG_BLOCK, watched)
+    previous_handlers = {}
+    child = None
+
+    def restore_child_mask():
+        signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
+
+    try:
+        for signum in watched:
+            previous_handlers[signum] = signal.signal(signum, queue_signal)
+        child = subprocess.Popen(
+            command,
+            env=environment,
+            preexec_fn=restore_child_mask,
+        )
+    finally:
+        if child is None:
+            for signum, handler in previous_handlers.items():
+                signal.signal(signum, handler)
+        signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
+
+    restored = [False]
+
+    def restore_handlers():
+        if restored[0]:
+            return
+        restored[0] = True
+        signal.pthread_sigmask(signal.SIG_BLOCK, watched)
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
+        signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
+
+    try:
+        while child.returncode is None:
+            while pending and child.poll() is None:
+                signum = pending.pop(0)
+                try:
+                    os.kill(child.pid, signum)
+                except ProcessLookupError:
+                    pass
+            if child.returncode is None:
+                try:
+                    child.wait(timeout=0.05)
+                except subprocess.TimeoutExpired:
+                    pass
+        return child.returncode, first_signal, restore_handlers
+    except BaseException:
+        restore_handlers()
+        raise
+
+
 def run_command(command):
     guard = guard_path()
     observed = run_guard(guard)
@@ -353,6 +415,8 @@ def run_command(command):
     mount = pathlib.Path(observed["mount_point"])
     scratch = create_scratch(mount)
     status = 78
+    wrapper_signal = None
+    restore_handlers = None
     try:
         current = run_guard(guard)
         if (
@@ -370,11 +434,14 @@ def run_command(command):
             }
         )
         try:
-            status = subprocess.run(
-                command, env=environment, check=False
-            ).returncode
-            if status < 0:
-                status = 128 - status
+            child_status, wrapper_signal, restore_handlers = run_child(
+                command, environment
+            )
+            status = (
+                128 - child_status
+                if child_status < 0
+                else child_status
+            )
         except FileNotFoundError:
             print(f"external-tmp: command not found: {command[0]}", file=sys.stderr)
             status = 127
@@ -387,6 +454,10 @@ def run_command(command):
         except (ExternalTmpError, OSError) as error:
             print(f"external-tmp: {error}", file=sys.stderr)
         scratch.close()
+        if restore_handlers is not None:
+            restore_handlers()
+    if wrapper_signal is not None and wrapper_signal[0] is not None:
+        return 128 + wrapper_signal[0]
     return status
 
 

--- a/bin/external-tmp
+++ b/bin/external-tmp
@@ -1,54 +1,418 @@
-#!/usr/bin/env bash
+#!/usr/bin/env python3
 
-set -euo pipefail
-umask 077
+import json
+import os
+import pathlib
+import secrets
+import stat
+import subprocess
+import sys
+from dataclasses import dataclass
 
-if (( $# == 0 )); then
-  printf 'Usage: external-tmp <command...>\n' >&2
-  exit 2
-fi
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-guard="${WORKTREE_STORAGE_GUARD:-$SCRIPT_DIR/agent-worktree-ops/worktree-storage-guard}"
-if [[ ! -x "$guard" ]]; then
-  guard="$HOME/Library/Application Support/agent-worktree-ops/worktree-storage-guard"
-fi
-if [[ ! -x "$guard" ]]; then
-  printf 'external-tmp: worktree storage guard is unavailable\n' >&2
-  exit 127
-fi
+CHECK_SCHEMA = "external-tmp-check.v1"
+STORAGE_SCHEMA = "external-worktree-storage.v2"
+DIRECTORY_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
 
-mount_point="$("$guard" --require-config --print-mount-point)"
-scratch_root="$mount_point/.scratch/tmp"
-temporary=""
 
-cleanup() {
-  local status=$?
-  trap - EXIT HUP INT TERM
-  if [[ -n "$temporary" && -e "$temporary" ]]; then
-    if "$guard" >/dev/null 2>&1; then
-      /bin/rm -rf -- "$temporary"
-    else
-      printf 'external-tmp: storage disappeared; refusing cleanup fallback: %s\n' \
-        "$temporary" >&2
-    fi
-  fi
-  exit "$status"
-}
+class ExternalTmpError(RuntimeError):
+    pass
 
-trap cleanup EXIT HUP INT TERM
-mkdir -p "$scratch_root"
-chmod 0700 "$mount_point/.scratch" "$scratch_root"
-temporary="$(mktemp -d "$scratch_root/external-tmp.XXXXXX")"
-"$guard"
 
-physical="$(cd "$temporary" && pwd -P)"
-case "$physical/" in
-  "$mount_point/.scratch/tmp/"*) ;;
-  *)
-    printf 'external-tmp: scratch path escaped configured storage: %s\n' "$physical" >&2
-    exit 78
-    ;;
-esac
+@dataclass(frozen=True)
+class Identity:
+    device: int
+    inode: int
+    uid: int
+    mode: int
 
-TMPDIR="$temporary/" TMP="$temporary" TEMP="$temporary" "$@"
+
+@dataclass
+class Scratch:
+    mount: pathlib.Path
+    mount_fd: int
+    mount_id: Identity
+    scratch_fd: int
+    scratch_id: Identity
+    tmp_fd: int
+    tmp_id: Identity
+    name: str
+    fd: int
+    identity: Identity
+
+    @property
+    def path(self):
+        return self.mount / ".scratch" / "tmp" / self.name
+
+    def close(self):
+        for descriptor in (self.fd, self.tmp_fd, self.scratch_fd, self.mount_fd):
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+
+
+def fail(message):
+    raise ExternalTmpError(message)
+
+
+def directory_identity(metadata, label, device=None):
+    if not stat.S_ISDIR(metadata.st_mode):
+        fail(f"{label} is not a real directory")
+    identity = Identity(
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_uid,
+        stat.S_IMODE(metadata.st_mode),
+    )
+    if identity.uid != os.getuid():
+        fail(f"{label} has the wrong owner")
+    if identity.mode != 0o700:
+        fail(f"{label} must use mode 0700")
+    if device is not None and identity.device != device:
+        fail(f"{label} crosses filesystems")
+    return identity
+
+
+def open_path_no_follow(path):
+    descriptor = os.open(path.anchor, DIRECTORY_FLAGS)
+    try:
+        for component in path.parts[1:]:
+            child = os.open(component, DIRECTORY_FLAGS, dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = child
+        return descriptor
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def open_root(path):
+    path = pathlib.Path(path)
+    raw = str(path)
+    if not path.is_absolute() or os.path.normpath(raw) != raw:
+        fail("configured storage path is not canonical")
+    if pathlib.Path(os.path.realpath(path)) != path:
+        fail("configured storage path has a symlinked component")
+    try:
+        descriptor = open_path_no_follow(path)
+    except OSError as error:
+        raise ExternalTmpError("configured storage is unavailable") from error
+    try:
+        opened = directory_identity(os.fstat(descriptor), "configured storage")
+        named = directory_identity(
+            os.stat(path, follow_symlinks=False),
+            "configured storage",
+        )
+        if opened != named:
+            fail("configured storage identity changed while opening")
+        return descriptor, opened
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def open_child(parent_fd, name, label, device, create):
+    try:
+        metadata = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        if not create:
+            return None, None
+        os.mkdir(name, 0o700, dir_fd=parent_fd)
+        metadata = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    identity = directory_identity(metadata, label, device)
+    try:
+        descriptor = os.open(name, DIRECTORY_FLAGS, dir_fd=parent_fd)
+    except OSError as error:
+        raise ExternalTmpError(f"{label} cannot be opened safely") from error
+    if directory_identity(os.fstat(descriptor), label, device) != identity:
+        os.close(descriptor)
+        fail(f"{label} identity changed while opening")
+    return descriptor, identity
+
+
+def guard_path():
+    override = os.environ.get("WORKTREE_STORAGE_GUARD")
+    candidates = (
+        [pathlib.Path(override)]
+        if override
+        else [
+            pathlib.Path(__file__).resolve().parent
+            / "agent-worktree-ops"
+            / "worktree-storage-guard",
+            pathlib.Path.home()
+            / "Library"
+            / "Application Support"
+            / "agent-worktree-ops"
+            / "worktree-storage-guard",
+        ]
+    )
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+    fail("worktree storage guard is unavailable")
+
+
+def run_guard(path):
+    try:
+        result = subprocess.run(
+            [str(path), "--json"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        )
+    except OSError as error:
+        raise ExternalTmpError("worktree storage guard cannot be executed") from error
+    if result.returncode:
+        fail(
+            "worktree storage guard failed"
+            + (f": {result.stderr.strip()}" if result.stderr.strip() else "")
+        )
+    try:
+        value = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise ExternalTmpError(
+            "worktree storage guard returned malformed JSON"
+        ) from error
+    configured = value.get("configured") if isinstance(value, dict) else None
+    if (
+        type(configured) is not bool
+        or value.get("schema_version") != STORAGE_SCHEMA
+    ):
+        fail("worktree storage guard returned an invalid attestation")
+    if configured:
+        mount = value.get("mount_point")
+        if not isinstance(mount, str) or not os.path.isabs(mount):
+            fail("worktree storage guard returned an invalid mount point")
+    return value
+
+
+def open_namespace(mount, create):
+    mount_fd, mount_id = open_root(mount)
+    scratch_fd = tmp_fd = None
+    try:
+        scratch_fd, scratch_id = open_child(
+            mount_fd, ".scratch", "scratch namespace", mount_id.device, create
+        )
+        if scratch_fd is None:
+            return mount_fd, mount_id, None, None, None, None
+        tmp_fd, tmp_id = open_child(
+            scratch_fd, "tmp", "temporary namespace", mount_id.device, create
+        )
+        return mount_fd, mount_id, scratch_fd, scratch_id, tmp_fd, tmp_id
+    except Exception:
+        for descriptor in (tmp_fd, scratch_fd, mount_fd):
+            if descriptor is not None:
+                os.close(descriptor)
+        raise
+
+
+def close_namespace(values):
+    for descriptor in (values[4], values[2], values[0]):
+        if descriptor is not None:
+            os.close(descriptor)
+
+
+def check():
+    observed = run_guard(guard_path())
+    configured = observed["configured"]
+    mount = observed.get("mount_point") if configured else None
+    if configured:
+        close_namespace(open_namespace(pathlib.Path(mount), False))
+    print(
+        json.dumps(
+            {
+                "configured": configured,
+                "mount_point": mount,
+                "ready": configured,
+                "schema_version": CHECK_SCHEMA,
+                "scratch_namespace": ".scratch/tmp",
+                "storage_schema": STORAGE_SCHEMA,
+                "tmpdir_scope": "invocation",
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+    return 0
+
+
+def create_scratch(mount):
+    values = open_namespace(mount, True)
+    mount_fd, mount_id, scratch_fd, scratch_id, tmp_fd, tmp_id = values
+    if scratch_fd is None or tmp_fd is None:
+        close_namespace(values)
+        fail("temporary namespace creation was incomplete")
+    for _ in range(128):
+        name = "external-tmp." + secrets.token_hex(12)
+        try:
+            os.mkdir(name, 0o700, dir_fd=tmp_fd)
+        except FileExistsError:
+            continue
+        except OSError:
+            close_namespace(values)
+            raise
+        try:
+            descriptor, identity = open_child(
+                tmp_fd, name, "invocation scratch", mount_id.device, False
+            )
+        except Exception:
+            close_namespace(values)
+            raise
+        return Scratch(
+            mount,
+            mount_fd,
+            mount_id,
+            scratch_fd,
+            scratch_id,
+            tmp_fd,
+            tmp_id,
+            name,
+            descriptor,
+            identity,
+        )
+    close_namespace(values)
+    fail("invocation scratch name allocation failed")
+
+
+def require_identity(descriptor, expected, label):
+    if directory_identity(
+        os.fstat(descriptor), label, expected.device
+    ) != expected:
+        fail(f"{label} identity changed")
+
+
+def revalidate(scratch):
+    fresh_fd, fresh_id = open_root(scratch.mount)
+    os.close(fresh_fd)
+    if fresh_id != scratch.mount_id:
+        fail("configured storage identity changed")
+    for descriptor, expected, label in (
+        (scratch.mount_fd, scratch.mount_id, "configured storage"),
+        (scratch.scratch_fd, scratch.scratch_id, "scratch namespace"),
+        (scratch.tmp_fd, scratch.tmp_id, "temporary namespace"),
+        (scratch.fd, scratch.identity, "invocation scratch"),
+    ):
+        require_identity(descriptor, expected, label)
+    named = directory_identity(
+        os.stat(scratch.name, dir_fd=scratch.tmp_fd, follow_symlinks=False),
+        "invocation scratch",
+        scratch.mount_id.device,
+    )
+    if named != scratch.identity:
+        fail("invocation scratch identity changed")
+    expected_parent = scratch.mount / ".scratch" / "tmp"
+    if scratch.path.parent != expected_parent:
+        fail("invocation scratch escaped lexically")
+    if pathlib.Path(os.path.realpath(scratch.path)) != scratch.path:
+        fail("invocation scratch escaped physically")
+
+
+def remove_contents(directory_fd, device):
+    for name in os.listdir(directory_fd):
+        metadata = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+        if metadata.st_dev != device:
+            fail("invocation scratch entry crosses filesystems")
+        if stat.S_ISDIR(metadata.st_mode):
+            child_fd = os.open(name, DIRECTORY_FLAGS, dir_fd=directory_fd)
+            try:
+                opened = os.fstat(child_fd)
+                if (opened.st_dev, opened.st_ino) != (
+                    metadata.st_dev,
+                    metadata.st_ino,
+                ):
+                    fail("invocation scratch entry identity changed")
+                remove_contents(child_fd, device)
+            finally:
+                os.close(child_fd)
+            os.rmdir(name, dir_fd=directory_fd)
+        else:
+            os.unlink(name, dir_fd=directory_fd)
+
+
+def cleanup(scratch, guard):
+    observed = run_guard(guard)
+    if (
+        observed["configured"] is not True
+        or observed.get("mount_point") != str(scratch.mount)
+    ):
+        fail("storage changed; refusing cleanup fallback")
+    revalidate(scratch)
+    remove_contents(scratch.fd, scratch.mount_id.device)
+    revalidate(scratch)
+    os.rmdir(scratch.name, dir_fd=scratch.tmp_fd)
+
+
+def run_command(command):
+    guard = guard_path()
+    observed = run_guard(guard)
+    if observed["configured"] is not True:
+        fail("required external worktree storage is not configured")
+    mount = pathlib.Path(observed["mount_point"])
+    scratch = create_scratch(mount)
+    status = 78
+    try:
+        current = run_guard(guard)
+        if (
+            current["configured"] is not True
+            or current.get("mount_point") != str(mount)
+        ):
+            fail("storage changed before child execution")
+        revalidate(scratch)
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "TMPDIR": str(scratch.path) + "/",
+                "TMP": str(scratch.path),
+                "TEMP": str(scratch.path),
+            }
+        )
+        try:
+            status = subprocess.run(
+                command, env=environment, check=False
+            ).returncode
+            if status < 0:
+                status = 128 - status
+        except FileNotFoundError:
+            print(f"external-tmp: command not found: {command[0]}", file=sys.stderr)
+            status = 127
+        except OSError as error:
+            print(f"external-tmp: child execution failed: {error}", file=sys.stderr)
+            status = 126
+    finally:
+        try:
+            cleanup(scratch, guard)
+        except (ExternalTmpError, OSError) as error:
+            print(f"external-tmp: {error}", file=sys.stderr)
+        scratch.close()
+    return status
+
+
+def main(argv):
+    os.umask(0o077)
+    try:
+        if argv == ["--check", "--json"]:
+            return check()
+        if "--check" in argv or "--json" in argv:
+            print(
+                "external-tmp: --check requires --json and cannot be combined "
+                "with a command",
+                file=sys.stderr,
+            )
+            return 2
+        if not argv:
+            print(
+                "Usage: external-tmp --check --json | external-tmp <command...>",
+                file=sys.stderr,
+            )
+            return 2
+        return run_command(argv)
+    except (ExternalTmpError, OSError, ValueError) as error:
+        print(f"external-tmp: {error}", file=sys.stderr)
+        return 78
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/bin/external-tmp
+++ b/bin/external-tmp
@@ -357,11 +357,12 @@ def run_child(command, environment):
         pending.append(signum)
 
     previous_mask = signal.pthread_sigmask(signal.SIG_BLOCK, watched)
+    active_mask = previous_mask.difference(watched)
     previous_handlers = {}
     child = None
 
-    def restore_child_mask():
-        signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
+    def activate_child_mask():
+        signal.pthread_sigmask(signal.SIG_SETMASK, active_mask)
 
     try:
         for signum in watched:
@@ -369,13 +370,16 @@ def run_child(command, environment):
         child = subprocess.Popen(
             command,
             env=environment,
-            preexec_fn=restore_child_mask,
+            preexec_fn=activate_child_mask,
         )
     finally:
         if child is None:
             for signum, handler in previous_handlers.items():
                 signal.signal(signum, handler)
-        signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
+        signal.pthread_sigmask(
+            signal.SIG_SETMASK,
+            active_mask if child is not None else previous_mask,
+        )
 
     restored = [False]
 

--- a/functions/gwt/README.md
+++ b/functions/gwt/README.md
@@ -53,7 +53,12 @@ External storage behavior:
 - Raw `git worktree prune` is unsafe while required storage is absent because
   Git can mistake temporarily unavailable registrations for stale worktrees.
 - Global `TMPDIR`, Codex sessions/databases/logs, tmux state, and package caches
-  remain internal. Use `external-tmp <command...>` for opt-in per-process scratch.
+  remain internal. Use `external-tmp <command...>` for opt-in per-process
+  scratch. The wrapper creates one mode-`0700`, current-user directory beneath
+  `.scratch/tmp`, revalidates the storage guard and mount identity immediately
+  before child execution, and removes only that exact inode while the same
+  mount remains valid. `external-tmp --check --json` performs a non-mutating
+  readiness check.
 
 Cleanup behavior:
 

--- a/tests/external-tmp-test.sh
+++ b/tests/external-tmp-test.sh
@@ -9,36 +9,102 @@ trap 'rm -rf "$temporary"' EXIT
 
 home="$temporary/home"
 mount_point="$home/.codex/worktrees"
-config="$temporary/config.json"
-observed="$temporary/observed.json"
-probe="$temporary/probe.sh"
+fake_guard="$temporary/fake-guard"
+guard_state="$temporary/guard-state"
 result="$temporary/result"
-volume_uuid="$(printf '%s-%s-%s-%s-%s' 11111111 2222 3333 4444 555555555555)"
-marker_id="studio-a.external-worktree-storage.v2"
-mkdir -p "$mount_point/openclaw-managed" "$mount_point/.pnpm-store/openclaw"
-chmod 0700 "$mount_point" "$mount_point/openclaw-managed" \
-  "$mount_point/.pnpm-store" "$mount_point/.pnpm-store/openclaw"
-cat >"$config" <<EOF
-{"backing_directory_mode":"0000","case_sensitive":false,"children":{"openclaw_managed":{"cleanup_authority":"openclaw_registered_worktrees","mode":"0700","ownership":"home_owner","relative_path":"openclaw-managed"},"openclaw_pnpm_store":{"cleanup_authority":"dotfiles-private","disposable":true,"mode":"0700","ownership":"home_owner","relative_path":".pnpm-store/openclaw"}},"device_location":"External","encrypted":true,"filesystem":"apfs","marker_id":"$marker_id","minimum_free_gib":200,"minimum_free_percent":10,"mount_point":"$mount_point","owners":true,"required":true,"schema_version":"external-worktree-storage.v2","spotlight":"disabled","time_machine_excluded":true,"volume_uuid":"$volume_uuid"}
+child_marker="$temporary/child-ran"
+mkdir -p "$mount_point"
+chmod 0700 "$home" "$home/.codex" "$mount_point"
+
+write_guard() {
+  cat >"$fake_guard" <<'EOF'
+#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+
+mount = pathlib.Path(os.environ["TEST_MOUNT_POINT"])
+state_path = pathlib.Path(os.environ["TEST_GUARD_STATE"])
+state = json.loads(state_path.read_text()) if state_path.exists() else {}
+count = int(state.get("count", 0)) + 1
+state["count"] = count
+state_path.write_text(json.dumps(state))
+scenario = os.environ.get("TEST_GUARD_SCENARIO", "ready")
+if scenario == "malformed":
+    print("{")
+    raise SystemExit(0)
+if scenario == "unconfigured":
+    print(json.dumps({
+        "configured": False,
+        "schema_version": "external-worktree-storage.v2",
+    }, sort_keys=True))
+    raise SystemExit(0)
+if scenario == "fail-second" and count >= 2:
+    print("simulated hot disappearance", file=sys.stderr)
+    raise SystemExit(78)
+if scenario == "replace-mount-second" and count == 2:
+    moved = pathlib.Path(str(mount) + ".moved")
+    mount.rename(moved)
+    mount.mkdir(mode=0o700)
+    state["moved"] = str(moved)
+    state_path.write_text(json.dumps(state))
+attestation = {
+    "configured": True,
+    "mount_point": str(mount),
+    "schema_version": "external-worktree-storage.v2",
+}
+print(json.dumps(attestation, sort_keys=True))
 EOF
-chmod 0600 "$config"
-cat >"$observed" <<EOF
-{"case_sensitive":false,"device":200,"device_location":"External","encrypted":true,"filesystem":"apfs","free_gib":1000,"free_percent":50,"marker_id":"$marker_id","mode":"0700","mount_point":"$mount_point","mounted":true,"owner_gid":$(id -g),"owner_uid":$(id -u),"ownership_enabled":true,"parent_device":100,"spotlight":"disabled","time_machine_excluded":true,"volume_uuid":"$volume_uuid"}
-EOF
-cat >"$probe" <<'EOF'
+  chmod 0755 "$fake_guard"
+}
+
+reset_fixture() {
+  rm -f "$guard_state" "$child_marker" "$result"
+  rm -rf "$mount_point" "$mount_point.moved"
+  mkdir -p "$mount_point"
+  chmod 0700 "$mount_point"
+}
+
+run_external_tmp() {
+  HOME="$home" \
+    WORKTREE_STORAGE_GUARD="$fake_guard" \
+    TEST_MOUNT_POINT="$mount_point" \
+    TEST_GUARD_STATE="$guard_state" \
+    "$command_path" "$@"
+}
+
+write_guard
+
+check_json="$(run_external_tmp --check --json)"
+[[ "$check_json" == \
+'{"configured":true,"mount_point":"'"$mount_point"'","ready":true,"schema_version":"external-tmp-check.v1","scratch_namespace":".scratch/tmp","storage_schema":"external-worktree-storage.v2","tmpdir_scope":"invocation"}' ]]
+[[ ! -e "$mount_point/.scratch" ]]
+
+if run_external_tmp --check >"$temporary/check-args.out" 2>&1; then
+  echo "check without JSON must fail" >&2
+  exit 1
+fi
+grep -Fq -- "--check requires --json" "$temporary/check-args.out"
+
+reset_fixture
+TEST_GUARD_SCENARIO=unconfigured run_external_tmp --check --json \
+  >"$temporary/unconfigured.json"
+[[ "$(cat "$temporary/unconfigured.json")" == \
+'{"configured":false,"mount_point":null,"ready":false,"schema_version":"external-tmp-check.v1","scratch_namespace":".scratch/tmp","storage_schema":"external-worktree-storage.v2","tmpdir_scope":"invocation"}' ]]
+[[ ! -e "$mount_point/.scratch" ]]
+
+reset_fixture
+cat >"$temporary/probe.sh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n%s\n%s\n' "$TMPDIR" "$TMP" "$TEMP" >"$1"
-touch "$TMPDIR/child-created"
+mkdir "$TMPDIR/nested"
+touch "$TMPDIR/child-created" "$TMPDIR/nested/child-created"
+ln -s / "$TMPDIR/nested/root-link"
 EOF
-chmod 0755 "$probe"
-
-HOME="$home" \
-  WORKTREE_STORAGE_CONFIG="$config" \
-  WORKTREE_STORAGE_GUARD_TESTING=1 \
-  WORKTREE_STORAGE_GUARD_OBSERVED="$observed" \
-  "$command_path" "$probe" "$result"
-
+chmod 0755 "$temporary/probe.sh"
+run_external_tmp "$temporary/probe.sh" "$result"
 tmpdir_path="$(sed -n '1p' "$result")"
 tmp_path="$(sed -n '2p' "$result")"
 temp_path="$(sed -n '3p' "$result")"
@@ -46,42 +112,148 @@ temp_path="$(sed -n '3p' "$result")"
 [[ "$tmp_path" == "${tmpdir_path%/}" ]]
 [[ "$temp_path" == "${tmpdir_path%/}" ]]
 [[ -z "$(find "$mount_point/.scratch/tmp" -mindepth 1 -print -quit)" ]]
+[[ "$(stat -f '%u %Lp' "$mount_point/.scratch")" == "$(id -u) 700" ]]
+[[ "$(stat -f '%u %Lp' "$mount_point/.scratch/tmp")" == "$(id -u) 700" ]]
 
-fake_guard="$temporary/fake-guard"
-counter="$temporary/guard-counter"
-child_marker="$temporary/child-ran"
-cat >"$fake_guard" <<EOF
-#!/usr/bin/env bash
-set -euo pipefail
-count=0
-[[ ! -f "$counter" ]] || count="\$(cat "$counter")"
-count=\$((count + 1))
-printf '%s\n' "\$count" >"$counter"
-if [[ "\${1:-}" == "--require-config" ]]; then
-  printf '%s\n' "$mount_point"
-  exit 0
+reset_fixture
+mkdir "$mount_point/.scratch"
+chmod 0755 "$mount_point/.scratch"
+if run_external_tmp /usr/bin/touch "$child_marker" \
+  >"$temporary/mode.out" 2>&1; then
+  echo "mode drift must fail" >&2
+  exit 1
 fi
-if (( count >= 2 )); then
-  printf 'simulated hot disappearance\n' >&2
-  exit 78
+[[ ! -e "$child_marker" ]]
+grep -Fq "scratch namespace must use mode 0700" "$temporary/mode.out"
+
+reset_fixture
+ln -s "$temporary" "$mount_point/.scratch"
+if run_external_tmp /usr/bin/touch "$child_marker" \
+  >"$temporary/symlink.out" 2>&1; then
+  echo "symlinked scratch namespace must fail" >&2
+  exit 1
 fi
-EOF
-chmod 0755 "$fake_guard"
-if HOME="$home" WORKTREE_STORAGE_GUARD="$fake_guard" \
-  "$command_path" /usr/bin/touch "$child_marker" >"$temporary/hot.out" 2>&1; then
-  echo "external-tmp must stop when storage disappears before child execution" >&2
+[[ ! -e "$child_marker" ]]
+grep -Fq "scratch namespace is not a real directory" "$temporary/symlink.out"
+
+reset_fixture
+mv "$home/.codex" "$home/.codex-real"
+ln -s .codex-real "$home/.codex"
+if run_external_tmp /usr/bin/touch "$child_marker" \
+  >"$temporary/component-symlink.out" 2>&1; then
+  echo "symlinked storage component must fail" >&2
+  exit 1
+fi
+[[ ! -e "$child_marker" ]]
+grep -Fq "symlinked component" "$temporary/component-symlink.out"
+rm "$home/.codex"
+mv "$home/.codex-real" "$home/.codex"
+
+reset_fixture
+if TEST_GUARD_SCENARIO=fail-second run_external_tmp \
+  /usr/bin/touch "$child_marker" >"$temporary/hot.out" 2>&1; then
+  echo "hot guard failure must stop before child execution" >&2
   exit 1
 fi
 [[ ! -e "$child_marker" ]]
 grep -Fq "simulated hot disappearance" "$temporary/hot.out"
 
-if HOME="$home" WORKTREE_STORAGE_CONFIG="$temporary/missing" \
-  WORKTREE_STORAGE_GUARD_TESTING=1 \
-  WORKTREE_STORAGE_GUARD_OBSERVED="$observed" \
-  "$command_path" /usr/bin/true >"$temporary/missing.out" 2>&1; then
-  echo "external-tmp must require configured storage" >&2
+reset_fixture
+if TEST_GUARD_SCENARIO=replace-mount-second run_external_tmp \
+  /usr/bin/touch "$child_marker" >"$temporary/identity.out" 2>&1; then
+  echo "mount identity drift must stop before child execution" >&2
   exit 1
 fi
-grep -Fq "required config missing" "$temporary/missing.out"
+[[ ! -e "$child_marker" ]]
+grep -Fq "configured storage identity changed" "$temporary/identity.out"
+
+reset_fixture
+cat >"$temporary/replace-scratch.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+path="${TMPDIR%/}"
+printf '%s\n' "$path" >"$1"
+mv "$path" "$path.moved"
+mkdir -m 0700 "$path"
+touch "$path/replacement"
+EOF
+chmod 0755 "$temporary/replace-scratch.sh"
+run_external_tmp "$temporary/replace-scratch.sh" "$result" \
+  >"$temporary/replacement.out" 2>&1
+created_path="$(cat "$result")"
+[[ -f "$created_path/replacement" ]]
+[[ -d "$created_path.moved" ]]
+grep -Fq "invocation scratch identity changed" "$temporary/replacement.out"
+
+reset_fixture
+cat >"$temporary/status.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 37
+EOF
+chmod 0755 "$temporary/status.sh"
+set +e
+run_external_tmp "$temporary/status.sh"
+status=$?
+set -e
+[[ "$status" -eq 37 ]]
+[[ -z "$(find "$mount_point/.scratch/tmp" -mindepth 1 -print -quit)" ]]
+
+reset_fixture
+if TEST_GUARD_SCENARIO=malformed run_external_tmp --check --json \
+  >"$temporary/malformed.out" 2>&1; then
+  echo "malformed guard output must fail" >&2
+  exit 1
+fi
+grep -Fq "malformed JSON" "$temporary/malformed.out"
+
+python3 - "$command_path" <<'PY'
+import importlib.machinery
+import importlib.util
+import os
+import stat
+import sys
+from unittest import mock
+
+loader = importlib.machinery.SourceFileLoader("external_tmp", sys.argv[1])
+spec = importlib.util.spec_from_loader("external_tmp", loader)
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+assert spec.loader
+spec.loader.exec_module(module)
+
+metadata = os.stat(".")
+cross_device = list(metadata)
+cross_device[0] = (metadata.st_mode & ~0o777) | 0o700
+cross_device[2] = metadata.st_dev + 1
+cross_device[4] = os.getuid()
+with mock.patch.object(module.os, "stat", return_value=os.stat_result(cross_device)):
+    try:
+        module.open_child(
+            1,
+            "fixture",
+            "fixture",
+            metadata.st_dev,
+            False,
+        )
+    except module.ExternalTmpError as error:
+        assert "crosses filesystems" in str(error)
+    else:
+        raise AssertionError("cross-device namespace must fail")
+
+wrong_owner = list(metadata)
+wrong_owner[0] = (metadata.st_mode & ~0o777) | 0o700
+wrong_owner[4] = os.getuid() + 1
+try:
+    module.directory_identity(
+        os.stat_result(wrong_owner),
+        "fixture",
+    )
+except module.ExternalTmpError as error:
+    assert "wrong owner" in str(error)
+else:
+    raise AssertionError("wrong ownership must fail")
+
+assert stat.S_IMODE(metadata.st_mode) != 0
+PY
 
 printf 'external tmp tests passed\n'

--- a/tests/external-tmp-test.sh
+++ b/tests/external-tmp-test.sh
@@ -199,6 +199,82 @@ set -e
 [[ -z "$(find "$mount_point/.scratch/tmp" -mindepth 1 -print -quit)" ]]
 
 reset_fixture
+cat >"$temporary/signal-child.py" <<'PY'
+#!/usr/bin/env python3
+import os
+import pathlib
+import signal
+import sys
+
+ready, received = map(pathlib.Path, sys.argv[1:])
+
+def stop(signum, _frame):
+    received.write_text(str(signum))
+    raise SystemExit(128 + signum)
+
+for watched in (signal.SIGHUP, signal.SIGINT, signal.SIGTERM):
+    signal.signal(watched, stop)
+ready.write_text(f"{os.getpid()} {os.environ['TMPDIR']}")
+while True:
+    signal.pause()
+PY
+chmod 0755 "$temporary/signal-child.py"
+
+for signal_case in HUP:1 INT:2 TERM:15; do
+  signal_name="${signal_case%%:*}"
+  signal_number="${signal_case##*:}"
+  ready="$temporary/$signal_name.ready"
+  received="$temporary/$signal_name.received"
+  reset_fixture
+  rm -f "$ready" "$received"
+  HOME="$home" \
+    WORKTREE_STORAGE_GUARD="$fake_guard" \
+    TEST_MOUNT_POINT="$mount_point" \
+    TEST_GUARD_STATE="$guard_state" \
+    "$command_path" "$temporary/signal-child.py" "$ready" "$received" &
+  wrapper_pid=$!
+  for _ in {1..100}; do
+    [[ -f "$ready" ]] && break
+    sleep 0.02
+  done
+  [[ -f "$ready" ]]
+  child_pid="$(cut -d' ' -f1 "$ready")"
+  child_tmpdir="$(cut -d' ' -f2- "$ready")"
+  kill -s "$signal_name" "$wrapper_pid"
+  set +e
+  wait "$wrapper_pid"
+  status=$?
+  set -e
+  [[ "$status" -eq $((128 + signal_number)) ]]
+  if [[ ! -f "$received" ]]; then
+    echo "child did not receive $signal_name" >&2
+    exit 1
+  fi
+  [[ "$(cat "$received")" == "$signal_number" ]]
+  if kill -0 "$child_pid" 2>/dev/null; then
+    echo "forwarded child was not reaped for $signal_name" >&2
+    exit 1
+  fi
+  [[ ! -e "${child_tmpdir%/}" ]]
+  [[ -z "$(find "$mount_point/.scratch/tmp" -mindepth 1 -print -quit)" ]]
+done
+
+reset_fixture
+cat >"$temporary/natural-signal.py" <<'PY'
+#!/usr/bin/env python3
+import os
+import signal
+os.kill(os.getpid(), signal.SIGTERM)
+PY
+chmod 0755 "$temporary/natural-signal.py"
+set +e
+run_external_tmp "$temporary/natural-signal.py"
+status=$?
+set -e
+[[ "$status" -eq 143 ]]
+[[ -z "$(find "$mount_point/.scratch/tmp" -mindepth 1 -print -quit)" ]]
+
+reset_fixture
 if TEST_GUARD_SCENARIO=malformed run_external_tmp --check --json \
   >"$temporary/malformed.out" 2>&1; then
   echo "malformed guard output must fail" >&2

--- a/tests/external-tmp-test.sh
+++ b/tests/external-tmp-test.sh
@@ -260,6 +260,47 @@ for signal_case in HUP:1 INT:2 TERM:15; do
 done
 
 reset_fixture
+cat >"$temporary/blocked-signal-launcher.py" <<'PY'
+#!/usr/bin/env python3
+import os
+import signal
+import sys
+
+signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGHUP})
+os.execve(sys.argv[1], sys.argv[1:], os.environ)
+PY
+chmod 0755 "$temporary/blocked-signal-launcher.py"
+ready="$temporary/blocked-HUP.ready"
+received="$temporary/blocked-HUP.received"
+HOME="$home" \
+  WORKTREE_STORAGE_GUARD="$fake_guard" \
+  TEST_MOUNT_POINT="$mount_point" \
+  TEST_GUARD_STATE="$guard_state" \
+  "$temporary/blocked-signal-launcher.py" \
+  "$command_path" "$temporary/signal-child.py" "$ready" "$received" &
+wrapper_pid=$!
+for _ in {1..100}; do
+  [[ -f "$ready" ]] && break
+  sleep 0.02
+done
+[[ -f "$ready" ]]
+child_pid="$(cut -d' ' -f1 "$ready")"
+child_tmpdir="$(cut -d' ' -f2- "$ready")"
+kill -HUP "$wrapper_pid"
+set +e
+wait "$wrapper_pid"
+status=$?
+set -e
+[[ "$status" -eq 129 ]]
+[[ "$(cat "$received")" == "1" ]]
+if kill -0 "$child_pid" 2>/dev/null; then
+  echo "blocked-mask child was not reaped" >&2
+  exit 1
+fi
+[[ ! -e "${child_tmpdir%/}" ]]
+[[ -z "$(find "$mount_point/.scratch/tmp" -mindepth 1 -print -quit)" ]]
+
+reset_fixture
 cat >"$temporary/natural-signal.py" <<'PY'
 #!/usr/bin/env python3
 import os


### PR DESCRIPTION
## Summary
- add a non-mutating `external-tmp --check --json` attestation
- harden scratch creation, revalidation, and exact-inode cleanup
- preserve exact-child signal forwarding and cleanup, including inherited blocked signals

## Tests
- Python 3.9.6 compile check for `bin/external-tmp`
- `bash -n tests/external-tmp-test.sh`
- `bash tests/external-tmp-test.sh`
- `git diff --check origin/master...HEAD`

## Notes
- ShellCheck was unavailable in the execution environment.
