### PR TITLE
feat(gh): add opt-in Octopool public read routing

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -158,12 +158,15 @@ auth, config, `jq`, or binaries leaves the prior native/ghx route in use.
 Only literal relative `api repos/openclaw/openclaw/...` and
 `api repos/openclaw/octopool/...` GETs can use the relay:
 
-- Repository metadata; PR lists and numeric PR details, files, commits, reviews.
+- PR lists and numeric PR details, files, commits, reviews.
 - Issue lists and numeric issue details or comments.
 - Commit lists and single-segment commit refs, check runs/suites, status/statuses.
 - Numeric check runs or check-suite check-run lists.
 - Actions run lists, numeric runs, attempts and jobs; numeric jobs; workflow
   lists, numeric workflows and their runs. Logs and artifacts stay native.
+
+Repository-root metadata stays native because its permission fields depend on
+the authenticated caller.
 
 Supported flags are `--paginate`, `--slurp` (with pagination and without jq),
 `--jq <filter>`, `-q <filter>`, `--jq=<filter>`, `-X GET`, `--method GET`, and

--- a/bin/README.md
+++ b/bin/README.md
@@ -85,7 +85,7 @@ nor restarts an existing daemon. Without native `gh`, both wrappers fail clearly
 
 The proxy is reserved for `pr view`, `pr checks`, `issue view`, and `run view`
 with a numeric item ID, explicit repository, and `--json`. Management commands
-`xdaemon` and `xcache` still reach ghx. All API requests, writes, auth, implicit
+`xdaemon` and `xcache` still reach ghx. By default, API requests, writes, auth, implicit
 repository reads, `GH_REPO`-dependent calls, interactive modes, and unknown
 options go directly to native `gh`. This preserves stdin and avoids relying on
 the proxy's API method classification.
@@ -119,6 +119,72 @@ API jq filters compact actual object results through native `gh`'s formatter;
 scalars, arrays, and unfiltered responses retain native output. No external
 `jq` is required. The deployed low-data guard belongs at each entrypoint, once,
 before this helper; the helper never calls one entrypoint from the other.
+
+### Optional Octopool Reads
+
+Both entrypoints can send a narrow set of public REST reads to Octopool before
+considering ghx. This is explicitly activated per host, never by finding a
+binary or login alone. Install the reviewed Octopool 0.6.3 binary at a stable
+versioned path, native `gh`, and `jq`. Keep existing entrypoints and their
+low-data hooks; the routing change is in `bin/gh-support/route.sh`. No daemon
+restart or ghx configuration change is needed.
+
+After independently verifying the binary and native CLI paths, create the
+private host-local `~/.config/gh-routing/octopool.json` with exactly these keys:
+
+```json
+{
+  "enabled": true,
+  "octopool_path": "/absolute/versioned/octopool",
+  "gh_path": "/absolute/native/gh"
+}
+```
+
+The file is parsed as JSON, not sourced. Unknown keys, relative paths, wrapper
+pins, missing executables, and symlinked configuration files disable activation.
+A valid configuration pins native `gh` for every route, including writes,
+`--no-cache`, and ghx's backend. This avoids PATH selecting another Octopool
+version or a wrapper. Existing `GHX_GH_PATH` and `OCTOPOOL_GH_PATH` cannot override
+the selected backend.
+
+Relay reads additionally require a regular, nonsymlink saved `auth.json` for
+exactly `https://octopool.dev`, pool `maintainers`, and a nonempty caller token.
+Octopool's native auth location is used: `~/Library/Application
+Support/octopool/auth.json` on macOS, or
+`${XDG_CONFIG_HOME:-$HOME/.config}/octopool/auth.json` on Linux. Keep caller
+credentials host-local; never copy auth files between hosts. Missing or invalid
+auth, config, `jq`, or binaries leaves the prior native/ghx route in use.
+
+Only literal relative `api repos/openclaw/openclaw/...` and
+`api repos/openclaw/octopool/...` GETs can use the relay:
+
+- Repository metadata; PR lists and numeric PR details, files, commits, reviews.
+- Issue lists and numeric issue details or comments.
+- Commit lists and single-segment commit refs, check runs/suites, status/statuses.
+- Numeric check runs or check-suite check-run lists.
+- Actions run lists, numeric runs, attempts and jobs; numeric jobs; workflow
+  lists, numeric workflows and their runs. Logs and artifacts stay native.
+
+Supported flags are `--paginate`, `--slurp` (with pagination and without jq),
+`--jq <filter>`, `-q <filter>`, `--jq=<filter>`, `-X GET`, `--method GET`, and
+`--method=GET`. Attached `-q...` and `-XGET` stay native. Allowed query parameters
+are positive `page`, `per_page` from 1 to 100, `state=open|closed|all`, and
+`filter=latest|all`. All other endpoints, options, headers, fields, input files,
+hosts, URL/path escapes, and placeholders stay native. Nonempty `GH_HOST` or
+`GH_REPO` disables relay routing. Top-level commands retain their prior routes.
+
+On the relay path, inherited Octopool caller/admin tokens and destination/backend
+overrides are removed. The service, pool, and native backend are pinned; native
+GitHub credentials remain available only for local fallback. API jq filters use
+the same object-to-JSONL transformation on both routes. No ghx cache surrounds
+Octopool. Relay failures retain Octopool's exit status and native-fallback policy;
+the wrapper neither retries failures nor performs login.
+
+Use `GH_OCTOPOOL=0` to disable relay routing immediately while retaining valid
+native pins. Remove the activation file (or set `enabled` to `false`) to restore
+legacy PATH discovery as well. `--no-cache` and `GHX_NO_CACHE=1` always bypass
+Octopool and ghx. `--ttl` never selects Octopool. `OCTOPOOL_FRESH=1` requests
+relay revalidation but is not the native escape hatch for exact-head decisions.
 
 ## Repo Fetch Policy
 

--- a/bin/gh-support/route.sh
+++ b/bin/gh-support/route.sh
@@ -91,18 +91,14 @@ gh_jq_filter() {
 gh_octopool_path() {
   local endpoint="$1" path query part key value
   local LC_ALL=C
-  [[ "$endpoint" =~ ^repos/openclaw/(openclaw|octopool)(/|\?|$) ]] || return 1
+  # Repository-root metadata includes caller-specific permission fields.
+  [[ "$endpoint" =~ ^repos/openclaw/(openclaw|octopool)/ ]] || return 1
   path="${endpoint%%\?*}"
   [[ "$path" =~ ^[a-zA-Z0-9_./-]+$ && "$path" != *..* && "$path" != *//* ]] || return 1
   path="${path#repos/openclaw/}"
   path="${path#*/}"
-  case "$endpoint" in
-    repos/openclaw/openclaw | repos/openclaw/octopool | repos/openclaw/openclaw\?* | repos/openclaw/octopool\?*)
-      path="" ;;
-  esac
   # Exclude permission-management endpoints, logs, and credential-bearing resources.
-  [[ -z "$path" ||
-    "$path" =~ ^pulls(/[0-9]+(/(files|commits|reviews))?)?$ ||
+  [[ "$path" =~ ^pulls(/[0-9]+(/(files|commits|reviews))?)?$ ||
     "$path" =~ ^issues(/[0-9]+(/comments)?)?$ ||
     "$path" =~ ^commits(/[a-zA-Z0-9_-]+(/(check-runs|check-suites|status|statuses))?)?$ ||
     "$path" =~ ^check-runs/[0-9]+$ ||

--- a/bin/gh-support/route.sh
+++ b/bin/gh-support/route.sh
@@ -2,20 +2,49 @@
 : "${wrapper_dir:?entrypoint must set wrapper_dir}"
 
 gh_backend() {
-  local name="$1" remaining="${PATH:-}" entry candidate done=""
+  local name="$1" remaining="${PATH:-}" entry candidate done="" octopool=""
+  if [[ "$name" == gh ]]; then
+    octopool="$(gh_backend octopool)" || true
+  fi
   while :; do
     case "$remaining" in
       *:*) entry="${remaining%%:*}"; remaining="${remaining#*:}" ;;
       *) entry="$remaining"; done=1 ;;
     esac
     candidate="${entry:-.}/$name"
-    if [[ -x "$candidate" && ! -d "$candidate" &&
-      ! "$candidate" -ef "$wrapper_dir/gh" && ! "$candidate" -ef "$wrapper_dir/ghx" ]]; then
+    if [[ -x "$candidate" && -f "$candidate" &&
+      ! "$candidate" -ef "$wrapper_dir/gh" && ! "$candidate" -ef "$wrapper_dir/ghx" ]] &&
+      { [[ "$name" == octopool ]] || ! gh_backend_shim "$candidate" "$octopool"; }; then
       printf '%s/%s\n' "$(cd -P -- "${entry:-.}" && pwd)" "$name"
       return 0
     fi
     [[ -z "$done" ]] || return 1
   done
+}
+
+gh_backend_shim() {
+  local target="$1" link count=0
+  [[ -z "$2" || ! "$1" -ef "$2" ]] || return 0
+  while [[ -L "$target" && $count -lt 40 ]]; do
+    link="$(readlink "$target")" || return 0
+    case "$link" in
+      /*) target="$link" ;;
+      *) target="${target%/*}/$link" ;;
+    esac
+    count=$((count + 1))
+  done
+  case "${target##*/}" in octopool | octopool-gh) return 0 ;; esac
+  gh_entrypoint_copy "$1"
+}
+
+gh_entrypoint_copy() {
+  local first="" second=""
+  # Copies of the wrappers are not necessarily the same inode as this entrypoint.
+  {
+    IFS= read -r -n 512 first || true
+    IFS= read -r -n 512 second || true
+  } <"$1"
+  [[ "$first" == '#!'* && ( "$second" == '# ghx-shim'* || "$second" == *'octopool gh'* ) ]]
 }
 
 gh_route_error() {
@@ -57,6 +86,117 @@ gh_jq_filter() {
   # only objects to JSONL; the newline also terminates trailing jq comments.
   [[ -n "$1" ]] || return 0
   printf '(%s\n) | if type == "object" then tojson else . end' "$1"
+}
+
+gh_octopool_path() {
+  local endpoint="$1" path query part key value
+  local LC_ALL=C
+  [[ "$endpoint" =~ ^repos/openclaw/(openclaw|octopool)(/|\?|$) ]] || return 1
+  path="${endpoint%%\?*}"
+  [[ "$path" =~ ^[a-zA-Z0-9_./-]+$ && "$path" != *..* && "$path" != *//* ]] || return 1
+  path="${path#repos/openclaw/}"
+  path="${path#*/}"
+  case "$endpoint" in
+    repos/openclaw/openclaw | repos/openclaw/octopool | repos/openclaw/openclaw\?* | repos/openclaw/octopool\?*)
+      path="" ;;
+  esac
+  # Exclude permission-management endpoints, logs, and credential-bearing resources.
+  [[ -z "$path" ||
+    "$path" =~ ^pulls(/[0-9]+(/(files|commits|reviews))?)?$ ||
+    "$path" =~ ^issues(/[0-9]+(/comments)?)?$ ||
+    "$path" =~ ^commits(/[a-zA-Z0-9_-]+(/(check-runs|check-suites|status|statuses))?)?$ ||
+    "$path" =~ ^check-runs/[0-9]+$ ||
+    "$path" =~ ^check-suites/[0-9]+/check-runs$ ||
+    "$path" =~ ^actions/runs(/[0-9]+(/jobs|/attempts/[0-9]+(/jobs)?)?)?$ ||
+    "$path" =~ ^actions/jobs/[0-9]+$ ||
+    "$path" =~ ^actions/workflows(/[0-9]+(/runs)?)?$ ]] || return 1
+  [[ "$endpoint" == *\?* ]] || return 0
+  query="${endpoint#*\?}"
+  [[ -n "$query" && "$query" != *'&' ]] || return 1
+  while [[ -n "$query" ]]; do
+    part="${query%%&*}"
+    [[ "$part" == *=* ]] || return 1
+    key="${part%%=*}"
+    value="${part#*=}"
+    case "$key" in
+      page) [[ "$value" =~ ^[1-9][0-9]*$ ]] || return 1 ;;
+      per_page) [[ "$value" =~ ^([1-9]|[1-9][0-9]|100)$ ]] || return 1 ;;
+      state) [[ "$value" == open || "$value" == closed || "$value" == all ]] || return 1 ;;
+      filter) [[ "$value" == latest || "$value" == all ]] || return 1 ;;
+      *) return 1 ;;
+    esac
+    [[ "$query" == *'&'* ]] || break
+    query="${query#*&}"
+  done
+}
+
+gh_octopool_read() {
+  local endpoint="" paginate=0 slurp=0 jq=0
+  [[ "${1:-}" == api ]] || return 1
+  shift
+  while (($#)); do
+    case "$1" in
+      --paginate) paginate=1; shift ;;
+      --slurp) slurp=1; shift ;;
+      --jq | -q)
+        [[ $# -ge 2 && -n "$2" ]] || return 1
+        jq=1
+        shift 2 ;;
+      --jq=?*) jq=1; shift ;;
+      --method | -X)
+        [[ $# -ge 2 && "$2" == GET ]] || return 1
+        shift 2 ;;
+      --method=GET) shift ;;
+      -* | "")
+        return 1 ;;
+      *)
+        [[ -z "$endpoint" ]] || return 1
+        endpoint="$1"
+        shift ;;
+    esac
+  done
+  [[ "$slurp" == 0 || ( "$paginate" == 1 && "$jq" == 0 ) ]] || return 1
+  gh_octopool_path "$endpoint"
+}
+
+gh_octopool_config() {
+  local activation="${HOME:?}/.config/gh-routing/octopool.json" config octopool native
+  [[ -f "$activation" && ! -L "$activation" ]] || return 1
+  gh_jq_bin="$(command -v jq)" || return 1
+  config="$("$gh_jq_bin" -ser '
+    def absolute_path: type == "string" and startswith("/") and (test("[[:cntrl:]]") | not);
+    select(length == 1) | .[0] |
+    select(type == "object" and keys == ["enabled", "gh_path", "octopool_path"]
+      and .enabled == true and (.octopool_path | absolute_path) and (.gh_path | absolute_path))
+    | .octopool_path, .gh_path
+  ' "$activation" 2>/dev/null)" || return 1
+  octopool="${config%%$'\n'*}"
+  native="${config#*$'\n'}"
+  [[ -x "$octopool" && -f "$octopool" && -x "$native" && -f "$native" &&
+    ! "$native" -ef "$wrapper_dir/gh" && ! "$native" -ef "$wrapper_dir/ghx" &&
+    ! "$octopool" -ef "$wrapper_dir/gh" && ! "$octopool" -ef "$wrapper_dir/ghx" ]] || return 1
+  ! gh_backend_shim "$native" "$octopool" || return 1
+  ! gh_entrypoint_copy "$octopool" || return 1
+  gh_bin="$native"
+  octopool_config_bin="$octopool"
+}
+
+gh_octopool_ready() {
+  local auth
+  [[ "${GH_OCTOPOOL:-}" != 0 && -z "${GH_HOST:-}" && -z "${GH_REPO:-}" &&
+    -n "$octopool_config_bin" ]] || return 1
+  case "$(uname -s)" in
+    Darwin) auth="$HOME/Library/Application Support/octopool/auth.json" ;;
+    Linux) auth="${XDG_CONFIG_HOME:-$HOME/.config}/octopool/auth.json" ;;
+    *) return 1 ;;
+  esac
+  [[ "$auth" == /* && -f "$auth" && ! -L "$auth" ]] || return 1
+  "$gh_jq_bin" -se '
+    length == 1 and (.[0] |
+    type == "object" and .url == "https://octopool.dev" and .pool == "maintainers"
+    and (.token | type == "string" and length > 0 and (test("[[:space:][:cntrl:]]") | not))
+    )
+  ' "$auth" >/dev/null 2>&1
 }
 
 gh_native() {
@@ -112,11 +252,18 @@ gh_native() {
       esac
     done
   fi
+  if [[ -n "${octopool_bin:-}" ]]; then
+    # Use only the saved host-local caller identity and the reviewed destination.
+    unset OCTOPOOL_TOKEN OCTOPOOL_ADMIN_TOKEN OCTOPOOL_URL OCTOPOOL_POOL OCTOPOOL_GH_PATH GHX_GH_PATH
+    export OCTOPOOL_URL=https://octopool.dev OCTOPOOL_POOL=maintainers OCTOPOOL_GH_PATH="$gh_bin"
+    exec "$octopool_bin" gh "${args[@]}"
+  fi
   exec "$gh_bin" "${args[@]}"
 }
 
 gh_route() {
-  local no_cache="${GHX_NO_CACHE:-0}" ttl="" gh_bin ghx_bin=""
+  local no_cache="${GHX_NO_CACHE:-0}" ttl="" gh_bin ghx_bin="" octopool_bin=""
+  local octopool_config_bin="" gh_jq_bin=""
   local controls=()
   while (($#)); do
     case "$1" in
@@ -136,10 +283,12 @@ gh_route() {
     gh_route_error "--ttl conflicts with an uncached request"
     return 2
   fi
-  gh_bin="$(gh_backend gh)" || {
-    printf '%s: native GitHub CLI is required; install gh before using this wrapper\n' "${0##*/}" >&2
-    return 127
-  }
+  if ! gh_octopool_config; then
+    gh_bin="$(gh_backend gh)" || {
+      printf '%s: native GitHub CLI is required; install gh before using this wrapper\n' "${0##*/}" >&2
+      return 127
+    }
+  fi
   ghx_bin="$(gh_backend ghx)" || true
   unset GH_FORCE_TTY
   export NO_COLOR=1 CLICOLOR=0 CLICOLOR_FORCE=0
@@ -152,6 +301,10 @@ gh_route() {
       [[ -z "$ttl" ]] || { gh_route_error "--ttl does not apply to proxy management"; return 2; }
       exec env GHX_GH_PATH="$gh_bin" "$ghx_bin" "$@" ;;
   esac
+  if [[ "$no_cache" != 1 && -z "$ttl" ]] && gh_octopool_read "$@" && gh_octopool_ready; then
+    octopool_bin="$octopool_config_bin"
+    gh_native "$@"
+  fi
   if [[ "$no_cache" != 1 && -z "${GH_REPO:-}" && -n "$ghx_bin" &&
     -f "${HOME:?}/.ghx/config.yaml" ]] && gh_cacheable_read "$@"; then
     [[ -z "$ttl" ]] || controls+=(--ttl "$ttl")

--- a/tests/gh-octopool-test.py
+++ b/tests/gh-octopool-test.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Hermetic gh/ghx routing proof: fake backends, real jq, no network or login."""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+JQ = shutil.which("jq")
+assert JQ, "jq is required for the opt-in Octopool routing tests"
+FIXTURE_AUTH = {
+    "url": "https://octopool.dev",
+    "pool": "maintainers",
+    "token": "fixture-caller-not-a-credential",
+}
+ENV_KEYS = (
+    "OCTOPOOL_TOKEN", "OCTOPOOL_ADMIN_TOKEN", "OCTOPOOL_URL", "OCTOPOOL_POOL",
+    "OCTOPOOL_GH_PATH", "GHX_GH_PATH", "GH_TOKEN", "GITHUB_TOKEN",
+    "OCTOPOOL_FRESH", "OCTOPOOL_NO_FALLBACK", "NO_COLOR", "GH_FORCE_TTY",
+)
+BACKEND = f"""#!{sys.executable}
+import json, os, pathlib, subprocess, sys
+args = sys.argv[1:]
+record = {{
+    "route": pathlib.Path(sys.argv[0]).name,
+    "args": args,
+    "env": {{key: os.environ.get(key) for key in {ENV_KEYS!r}}},
+    "stdin": sys.stdin.buffer.read().hex(),
+}}
+pathlib.Path(os.environ["TEST_RECORD"]).write_text(json.dumps(record))
+if os.environ.get("TEST_JQ_OUTPUT") == "1":
+    query = None
+    for index, arg in enumerate(args):
+        if arg in ("--jq", "-q"):
+            query = args[index + 1]
+        elif arg.startswith("--jq="):
+            query = arg[len("--jq="):]
+    payload = '{{"values":[{{"ok":true}},"{{",false,null,[1,2]]}}'
+    result = subprocess.run([{JQ!r}, "-r", "--", query],
+                            input=payload, text=True, capture_output=True)
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    sys.exit(result.returncode)
+sys.stdout.buffer.write(b'fixture output\\n')
+sys.stderr.write(os.environ.get("TEST_ERROR", ""))
+sys.exit(int(os.environ.get("TEST_STATUS", "0")))
+"""
+
+
+with tempfile.TemporaryDirectory(prefix="gh-octopool-test-") as temporary:
+    root = Path(temporary)
+    home, wrapper, backend, tools, shims = (root / name for name in (
+        "home", "wrapper", "backend", "tools", "shims",
+    ))
+    for directory in (home, wrapper, backend, tools, shims):
+        directory.mkdir()
+    shutil.copytree(ROOT / "bin" / "gh-support", wrapper / "gh-support")
+    for name in ("gh", "ghx"):
+        shutil.copy2(ROOT / "bin" / name, wrapper / name)
+    for name in ("gh", "ghx", "octopool"):
+        (backend / name).write_text(BACKEND)
+        (backend / name).chmod(0o755)
+    for name in ("bash", "dirname", "uname", "readlink", "jq", "env"):
+        (tools / name).symlink_to("/bin/bash" if name == "bash" else shutil.which(name))
+    (home / ".ghx").mkdir()
+    (home / ".ghx" / "config.yaml").write_text("{}\n")
+    activation = home / ".config" / "gh-routing" / "octopool.json"
+    activation.parent.mkdir(parents=True)
+    config = root / "config"
+    auth = (home / "Library" / "Application Support" if sys.platform == "darwin"
+            else config) / "octopool" / "auth.json"
+    auth.parent.mkdir(parents=True)
+    environment = {
+        "PATH": os.pathsep.join(map(str, (wrapper, shims, backend, tools))),
+        "HOME": str(home),
+        "XDG_CONFIG_HOME": str(config),
+        "TEST_RECORD": str(root / "record"),
+    }
+    calls = 0
+    configuration = {
+        "enabled": True, "octopool_path": str(backend / "octopool"),
+        "gh_path": str(backend / "gh"),
+    }
+    linked_entrypoints = root / "linked-entrypoints"
+    linked_entrypoints.mkdir()
+    for name in ("gh", "ghx", "gh-support"):
+        (linked_entrypoints / name).symlink_to(wrapper / name)
+
+    def activate():
+        activation.write_text(json.dumps(configuration))
+        auth.write_text(json.dumps(FIXTURE_AUTH))
+        auth.chmod(0o600)
+
+    def invoke(entry, *args, route="gh", status=0, env=None, payload=b""):
+        global calls
+        calls += 1
+        record_path = root / "record"
+        record_path.unlink(missing_ok=True)
+        result = subprocess.run(
+            [str(wrapper / entry), *args], env={**environment, **(env or {})},
+            input=payload, capture_output=True, timeout=10,
+        )
+        assert result.returncode == status, (entry, args, result.stderr, result.returncode)
+        if route is None:
+            assert not record_path.exists(), (args, record_path.read_text())
+            return result, None
+        record = json.loads(record_path.read_text())
+        assert record["route"] == route, (entry, args, record)
+        assert record["stdin"] == payload.hex(), (entry, args, record)
+        return result, record
+
+    accepted = (
+        "", "/pulls", "/pulls/123", "/pulls/123/files", "/pulls/123/commits",
+        "/pulls/123/reviews", "/issues", "/issues/123", "/issues/123/comments",
+        "/commits", "/commits/main", "/commits/abc123/check-runs",
+        "/commits/abc123/check-suites", "/commits/abc123/status",
+        "/commits/abc123/statuses", "/check-runs/123",
+        "/check-suites/123/check-runs", "/actions/runs", "/actions/runs/123",
+        "/actions/runs/123/jobs", "/actions/runs/123/attempts/2",
+        "/actions/runs/123/attempts/2/jobs", "/actions/jobs/123",
+        "/actions/workflows", "/actions/workflows/123",
+        "/actions/workflows/123/runs", "/pulls?state=open&per_page=100&page=2",
+        "/actions/runs/123/jobs?filter=all",
+    )
+    endpoint = "repos/openclaw/openclaw/pulls/123"
+    rejected_paths = (
+        "user", "rate_limit", "graphql", "/repos/openclaw/openclaw/pulls",
+        "https://api.github.com/" + endpoint,
+        "repos/openclaw/private/pulls", "repos/example/repo/pulls",
+        "repos/openclaw/openclaw-other/pulls", "repos/OPENCLAW/openclaw/pulls",
+        "repos/{owner}/{repo}/pulls", "repos/:owner/:repo/pulls",
+        "repos/openclaw/openclaw/../private/pulls",
+        "repos/openclaw/openclaw/./pulls", endpoint + "/.",
+        endpoint + "//", endpoint + "%2fcomments", endpoint + "%2E%2E",
+        endpoint + "%5C", endpoint + "\\comments", endpoint + "#fragment",
+        endpoint + "\n", endpoint + "\t", endpoint + "\x01",
+        endpoint + "?access_token=fixture", endpoint + "?token=fixture",
+        endpoint + "?per_page=10&secret=fixture", endpoint + "?",
+        endpoint + "?page=1&", endpoint + "?page=1&&state=open",
+        endpoint + "?page=0", endpoint + "?per_page=101",
+        endpoint + "?state=merged", endpoint + "?filter=unknown",
+        endpoint + "?page=%31", endpoint + "?page=1#fragment",
+        endpoint + "?page=1;access_token=fixture",
+        endpoint + "?page=1?token=fixture", endpoint + "?page=1=2",
+        "repos/openclaw/openclaw/actions/secrets",
+        "repos/openclaw/openclaw/collaborators",
+        "repos/openclaw/openclaw/rulesets",
+        "repos/openclaw/openclaw/branches/main/protection",
+        "repos/openclaw/openclaw/actions/runs/123/logs",
+        "repos/openclaw/openclaw/actions/runs/123/artifacts",
+    )
+    for entry in ("gh", "ghx"):
+        # An installed binary and saved login are not activation.
+        auth.write_text(json.dumps(FIXTURE_AUTH))
+        invoke(entry, "api", endpoint)
+        activate()
+        for repo in ("openclaw", "octopool"):
+            for suffix in accepted:
+                invoke(entry, "api", "repos/openclaw/" + repo + suffix, route="octopool")
+        for flags in (
+            [], ["--paginate"], ["--paginate", "--slurp"], ["-X", "GET"],
+            ["--method", "GET"], ["--method=GET"], ["--jq", ".number"],
+            ["-q", ".number"], ["--jq=.number"],
+        ):
+            _, record = invoke(entry, "api", endpoint, *flags, route="octopool")
+            assert record["args"][:3] == ["gh", "api", endpoint]
+        invoke(entry, "api", "--paginate", endpoint, route="octopool")
+        invoke(str(linked_entrypoints / entry), "api", endpoint, route="octopool")
+        invoke(str(linked_entrypoints / entry), "--no-cache", "api", endpoint)
+        for path in rejected_paths:
+            invoke(entry, "api", path)
+        for flags in (
+            ["-X", "POST"], ["--method=DELETE"], ["-X", "GET", "-f", "x=y"],
+            ["-f", "x=y"], ["-F", "x=y"], ["--field=x=y"], ["--raw-field", "x=y"],
+            ["--input", "-"], ["--input=-"], ["--input", "/dev/stdin"],
+            ["-H", "Authorization: token fixture"], ["--header=Accept: application/json"],
+            ["--hostname", "example.invalid"], ["--hostname=github.com"],
+            ["--include"], ["-i"], ["--cache", "15s"], ["--template", "{{.number}}"],
+            ["--unknown"], ["--"], ["--jq"], ["--jq", ""], ["--jq="],
+            ["-q.number"], ["-q=.number"], ["-XGET"],
+            ["--slurp"], ["--paginate", "--slurp", "--jq", "."],
+            ["--method", "get"], ["--method"], ["--paginate=true"],
+        ):
+            invoke(entry, "api", endpoint, *flags)
+        invoke(entry, "api", endpoint, endpoint)
+        for args in (
+            ["auth", "status"], ["api", "graphql", "-f", "query=fixture"],
+            ["issue", "edit", "123", "--body-file", "-"],
+            ["secret", "set", "FIXTURE"], ["pr", "create"],
+            ["--hostname", "example.invalid", "api", endpoint],
+        ):
+            invoke(entry, *args, payload=b"fixture\x00stdin\n")
+        invoke(entry, "api", endpoint, route="octopool", payload=b"unconsumed input\n")
+        for env in ({"GH_OCTOPOOL": "0"}, {"GHX_NO_CACHE": "1"},
+                    {"GH_HOST": "github.com"}, {"GH_HOST": "example.invalid"},
+                    {"GH_REPO": "openclaw/openclaw"}):
+            invoke(entry, "api", endpoint, env=env)
+        invoke(entry, "--no-cache", "api", endpoint)
+        invoke(entry, "--ttl", "15", "api", endpoint, status=2, route=None)
+        invoke(entry, "--ttl", "15", "--no-cache", "api", endpoint, status=2, route=None)
+        invoke(entry, "--no-cache", "api", endpoint, "--cache", "15s", status=2, route=None)
+        invoke(entry, "pr", "view", "123", "-R", "openclaw/openclaw",
+               "--json", "number", route="ghx")
+        invoke(entry, "--ttl", "15", "pr", "view", "123", "-R", "openclaw/openclaw",
+               "--json", "number", route="ghx")
+        invoke(entry, "xdaemon", "status", route="ghx")
+        overrides = {
+            "OCTOPOOL_TOKEN": "untrusted-token", "OCTOPOOL_ADMIN_TOKEN": "untrusted-admin",
+            "OCTOPOOL_URL": "https://example.invalid", "OCTOPOOL_POOL": "untrusted",
+            "OCTOPOOL_GH_PATH": str(wrapper / "gh"), "GHX_GH_PATH": str(wrapper / "ghx"),
+            "GH_TOKEN": "native-fixture", "GITHUB_TOKEN": "native-fixture-2",
+            "OCTOPOOL_FRESH": "1", "OCTOPOOL_NO_FALLBACK": "1", "GH_FORCE_TTY": "100",
+        }
+        result, record = invoke(entry, "api", endpoint, route="octopool", env=overrides)
+        assert result.stdout == b"fixture output\n" and not result.stderr
+        assert record["env"] == {
+            **{key: None for key in ENV_KEYS},
+            "OCTOPOOL_URL": "https://octopool.dev", "OCTOPOOL_POOL": "maintainers",
+            "OCTOPOOL_GH_PATH": str(backend / "gh"), "GH_TOKEN": "native-fixture",
+            "GITHUB_TOKEN": "native-fixture-2", "OCTOPOOL_FRESH": "1",
+            "OCTOPOOL_NO_FALLBACK": "1", "NO_COLOR": "1",
+        }
+        _, record = invoke(entry, "--no-cache", "api", endpoint, env=overrides)
+        assert record["env"]["OCTOPOOL_TOKEN"] == overrides["OCTOPOOL_TOKEN"]
+        result, _ = invoke(entry, "api", endpoint, route="octopool", status=7,
+                           env={"TEST_STATUS": "7", "TEST_ERROR": "fixture error"})
+        assert result.stdout == b"fixture output\n" and result.stderr == b"fixture error"
+        for flags in (["--jq", ".values[]"], ["-q", ".values[]"],
+                      ["--jq=.values[]"], ["--jq", ".values[] # trailing comment"]):
+            result, record = invoke(entry, "api", endpoint, *flags, route="octopool",
+                                    env={"TEST_JQ_OUTPUT": "1"})
+            assert result.stdout == b'{"ok":true}\n{\nfalse\nnull\n[\n  1,\n  2\n]\n'
+            native_result, native_record = invoke(
+                entry, "--no-cache", "api", endpoint, *flags, env={"TEST_JQ_OUTPUT": "1"})
+            assert native_record["args"] == record["args"][1:]
+            assert native_result.stdout == result.stdout
+        for data in (
+            {}, {**FIXTURE_AUTH, "url": "https://example.invalid"},
+            {**FIXTURE_AUTH, "pool": "other"}, {**FIXTURE_AUTH, "token": ""},
+            {**FIXTURE_AUTH, "token": None}, {**FIXTURE_AUTH, "token": " \n"},
+            {**FIXTURE_AUTH, "token": "fixture\n"}, ["not", "an", "object"],
+        ):
+            auth.write_text(json.dumps(data))
+            invoke(entry, "api", endpoint)
+        auth.write_text("invalid json")
+        invoke(entry, "api", endpoint)
+        auth.write_text(json.dumps(FIXTURE_AUTH) + "\n" + json.dumps(FIXTURE_AUTH))
+        invoke(entry, "api", endpoint)
+        auth.unlink()
+        invoke(entry, "api", endpoint)
+        activate()
+        saved_auth = root / "saved-auth"
+        auth.rename(saved_auth)
+        auth.symlink_to(saved_auth)
+        invoke(entry, "api", endpoint)
+        auth.unlink()
+        saved_auth.rename(auth)
+        for data in (
+            {}, {**configuration, "enabled": False},
+            {**configuration, "url": "https://example.invalid"},
+            {**configuration, "gh_path": str(wrapper / "gh")},
+            {**configuration, "gh_path": str(backend / "octopool")},
+            {**configuration, "gh_path": "gh"},
+            {**configuration, "octopool_path": "octopool"},
+            {**configuration, "octopool_path": str(wrapper / "gh")},
+            {**configuration, "gh_path": str(backend / "gh") + "\n"},
+            {**configuration, "octopool_path": str(root / "absent")},
+        ):
+            activation.write_text(json.dumps(data))
+            invoke(entry, "api", endpoint)
+        for contents in ("", "1", "https://octopool.dev other",
+                         json.dumps(configuration) + "\n{}",
+                         "$(touch " + str(root / "must-not-exist") + ")"):
+            activation.write_text(contents)
+            invoke(entry, "api", endpoint)
+        assert not (root / "must-not-exist").exists()
+        activation.unlink()
+        activation.symlink_to(auth)
+        invoke(entry, "api", endpoint)
+        activation.unlink()
+        activate()
+        for path in (backend / "octopool", tools / "jq"):
+            disabled = root / "disabled"
+            path.rename(disabled)
+            invoke(entry, "api", endpoint)
+            disabled.rename(path)
+        # The activation pin takes priority over a different PATH Octopool/native.
+        pinned = root / "pinned"
+        pinned.mkdir(exist_ok=True)
+        for name in ("gh", "octopool"):
+            shutil.copy2(backend / name, pinned / name)
+        activation.write_text(json.dumps({
+            "enabled": True, "octopool_path": str(pinned / "octopool"),
+            "gh_path": str(pinned / "gh"),
+        }))
+        _, record = invoke(entry, "api", endpoint, route="octopool")
+        assert record["env"]["OCTOPOOL_GH_PATH"] == str(pinned / "gh")
+        (backend / "gh").rename(root / "native-disabled")
+        (backend / "octopool").rename(root / "octopool-disabled")
+        invoke(entry, "api", endpoint, route="octopool")
+        invoke(entry, "--no-cache", "api", endpoint)
+        invoke(entry, "api", endpoint, env={"GH_OCTOPOOL": "0"})
+        invoke(entry, "api", endpoint, env={"GHX_NO_CACHE": "1"})
+        invoke(entry, "api", endpoint, env={"GH_HOST": "example.invalid"})
+        (root / "native-disabled").rename(backend / "gh")
+        (root / "octopool-disabled").rename(backend / "octopool")
+        activate()
+        # Skip Octopool symlinks and copied ghx wrappers during native discovery.
+        (shims / "gh").symlink_to(backend / "octopool")
+        invoke(entry, "api", endpoint, route="octopool")
+        invoke(entry, "--no-cache", "api", endpoint)
+        (shims / "gh").unlink()
+        shutil.copy2(wrapper / "gh", shims / "gh")
+        invoke(entry, "--no-cache", "api", endpoint)
+        (shims / "gh").unlink()
+        # A shim remains recognizable even when octopool is absent from PATH.
+        hidden = root / "hidden"
+        hidden.mkdir(exist_ok=True)
+        (backend / "octopool").rename(hidden / "octopool")
+        (shims / "gh").symlink_to(hidden / "octopool")
+        invoke(entry, "api", endpoint)
+        (hidden / "octopool").rename(backend / "octopool")
+        (shims / "gh").unlink()
+        (backend / "gh").rename(root / "native-disabled")
+        invoke(entry, "api", endpoint, status=127, route=None)
+        (root / "native-disabled").rename(backend / "gh")
+        activation.unlink()
+
+print(f"PASS: {calls} hermetic gh/ghx Octopool routing, auth, isolation, and parity cases")

--- a/tests/gh-octopool-test.py
+++ b/tests/gh-octopool-test.py
@@ -115,7 +115,7 @@ with tempfile.TemporaryDirectory(prefix="gh-octopool-test-") as temporary:
         return result, record
 
     accepted = (
-        "", "/pulls", "/pulls/123", "/pulls/123/files", "/pulls/123/commits",
+        "/pulls", "/pulls/123", "/pulls/123/files", "/pulls/123/commits",
         "/pulls/123/reviews", "/issues", "/issues/123", "/issues/123/comments",
         "/commits", "/commits/main", "/commits/abc123/check-runs",
         "/commits/abc123/check-suites", "/commits/abc123/status",
@@ -162,6 +162,8 @@ with tempfile.TemporaryDirectory(prefix="gh-octopool-test-") as temporary:
         for repo in ("openclaw", "octopool"):
             for suffix in accepted:
                 invoke(entry, "api", "repos/openclaw/" + repo + suffix, route="octopool")
+            for suffix in ("", "?", "?per_page=100", "/", "/?", "/?page=1&per_page=100"):
+                invoke(entry, "api", "repos/openclaw/" + repo + suffix)
         for flags in (
             [], ["--paginate"], ["--paginate", "--slurp"], ["-X", "GET"],
             ["--method", "GET"], ["--method=GET"], ["--jq", ".number"],

--- a/tests/ghx-native-cache-test.py
+++ b/tests/ghx-native-cache-test.py
@@ -52,6 +52,7 @@ with tempfile.TemporaryDirectory() as temporary:
     # Deliberately omit jq, including the system jq present on recent macOS.
     (backend / "bash").symlink_to("/bin/bash")
     (backend / "dirname").symlink_to(shutil.which("dirname"))
+    (backend / "readlink").symlink_to(shutil.which("readlink"))
     for directory in ("a", "b", "home", "config", "cache"):
         (root / directory).mkdir()
     for name in ("--cache", "--cache=15s"):


### PR DESCRIPTION
## Summary

- Add explicitly activated, pinned Octopool routing for a narrow set of public REST GETs in `openclaw/openclaw` and `openclaw/octopool`.
- Keep writes, repository-root permissions, private or unknown routes, and `--no-cache` requests native; preserve existing ghx routing and shared jq formatting.
- Require matching host-local authentication, validate activation as JSON, and provide `GH_OCTOPOOL=0` as the relay kill switch.

## Testing

- 452 hermetic routing, authentication, isolation, and formatting cases under Bash 3.2.
- Existing gh/ghx routing tests, including composed low-data guards.
- Real native-gh loopback cache and formatting tests.
- Bash syntax, ShellCheck, and diff checks.
- Independent review of the exact submitted head.

This change does not activate routing, install binaries, alter credentials, or restart daemons.
