### PR TITLE
fix(ghx): add guarded legacy auth shim repair

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -120,6 +120,48 @@ scalars, arrays, and unfiltered responses retain native output. No external
 `jq` is required. The deployed low-data guard belongs at each entrypoint, once,
 before this helper; the helper never calls one entrypoint from the other.
 
+### Legacy Inner-Shim Auth Repair
+
+`ghx-auth-repair` is an explicit Python 3.9+ migration for one legacy 349-byte
+inner shim, SHA-256
+`1c5c55becb3aaad20409892a3b3e40c18f15a6447efdffd067575346e292d420`.
+It adds only a leading `auth` bypass to independently verified native `gh`.
+It does not install or generate shims, change the shared router or PATH,
+authenticate, enroll an Octopool client, or start a daemon. Non-auth arguments,
+including `--no-cache`, keep their original behavior.
+
+Audit the target and native binary first. Supply absolute paths and their
+current lowercase SHA-256 digests; target and backup parent directories must
+be canonical, user-owned, and not group/world writable. Inspection is the default:
+
+```sh
+ghx-auth-repair --target /absolute/path/to/legacy/ghx \
+  --expected-sha256 TARGET_SHA256 --native-gh /absolute/path/to/native/gh \
+  --native-sha256 NATIVE_SHA256
+```
+
+To apply, append `--apply --backup /absolute/private-directory/ghx.before`.
+Create that private directory with mode `0700` beforehand. The backup must not
+exist; it retains the original bytes with mode `0600`. The helper rechecks the
+target identity and both digests before atomically replacing the target.
+Do not run it alongside another editor or installer. A failure can leave the
+private backup for inspection; there is no automatic rollback.
+
+The target must be a singly linked regular executable owned by the current
+user. Unknown bytes, a symlink target, native scripts/wrappers, changed pins,
+ACLs, file flags, and unsupported extended attributes are refused. On macOS,
+`com.apple.provenance` is preserved and verified; other attributes are refused.
+On Linux, all extended attributes (including ACLs) are refused. Mode, UID,
+GID, atime, and mtime are preserved; replacement necessarily changes inode and
+ctime/birth time. Supported platforms are macOS and Linux.
+
+The inserted command pins the supplied native **path**, not its digest at
+runtime. A symlink is allowed for native `gh`; its resolution and digest are
+verified during migration. Prefer a versioned binary path when later symlink
+updates must not change auth dispatch. An exact repaired shim with the same
+path is a no-op when supplied with its current digest and a verified native
+binary. A different path pin is not an automatic upgrade: audit it separately.
+
 ### Optional Octopool Reads
 
 Both entrypoints can send a narrow set of public REST reads to Octopool before

--- a/bin/ghx-auth-repair
+++ b/bin/ghx-auth-repair
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+"""Repair one known legacy ghx shim; no discovery, installation, or login."""
+
+import argparse
+import ctypes
+import errno
+import hashlib
+import os
+from pathlib import Path
+import shlex
+import stat
+import sys
+import tempfile
+
+
+ORIGINAL = b"""#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${GHX_GH_PATH:-}" || ! -x "$GHX_GH_PATH" ]]; then
+  printf 'ghx: outer wrapper did not provide the real GitHub CLI path\\n' >&2
+  exit 127
+fi
+export OCTOPOOL_GH_PATH="$GHX_GH_PATH"
+
+if [[ "${1:-}" == "--no-cache" ]]; then
+  export OCTOPOOL_FRESH=1
+  shift
+fi
+
+exec "$HOME/.local/bin/octopool" gh "$@"
+"""
+ORIGINAL_SHA = "1c5c55becb3aaad20409892a3b3e40c18f15a6447efdffd067575346e292d420"
+PREFIX = b"#!/usr/bin/env bash\nset -euo pipefail\n\n"
+BINARY_MAGIC = {
+    b"\x7fELF", b"\xfe\xed\xfa\xce", b"\xce\xfa\xed\xfe",
+    b"\xfe\xed\xfa\xcf", b"\xcf\xfa\xed\xfe",
+    b"\xca\xfe\xba\xbe", b"\xbe\xba\xfe\xca",
+    b"\xca\xfe\xba\xbf", b"\xbf\xba\xfe\xca",
+}
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+def sha(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def absolute(value):
+    path = Path(value)
+    require(path.is_absolute() and ".." not in path.parts, "paths must be absolute without '..'")
+    require("\n" not in value and "\r" not in value, "paths must not contain newlines")
+    return path
+
+
+def identity(info):
+    return tuple(getattr(info, key, 0) for key in (
+        "st_dev", "st_ino", "st_mode", "st_uid", "st_gid", "st_nlink",
+        "st_size", "st_mtime_ns", "st_ctime_ns", "st_flags",
+    ))
+
+
+def plain_metadata(fd, restore=None):
+    """Preserve macOS provenance only; refuse other attributes, ACLs, and flags."""
+    require(not getattr(os.fstat(fd), "st_flags", 0), "file flags are unsupported")
+    if sys.platform == "darwin":
+        libc = ctypes.CDLL(None, use_errno=True)
+        libc.flistxattr.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_int]
+        libc.flistxattr.restype = ctypes.c_ssize_t
+        size = libc.flistxattr(fd, None, 0, 0)
+        require(size >= 0, "cannot inspect extended attributes")
+        names = ctypes.create_string_buffer(size)
+        require(libc.flistxattr(fd, names, size, 0) == size, "extended attributes changed")
+        names = set(names.raw.rstrip(b"\0").split(b"\0")) - {b""}
+        require(names <= {b"com.apple.provenance"}, "extended attributes are unsupported")
+        attributes = {}
+        libc.fgetxattr.argtypes = [
+            ctypes.c_int, ctypes.c_char_p, ctypes.c_void_p,
+            ctypes.c_size_t, ctypes.c_uint32, ctypes.c_int,
+        ]
+        libc.fgetxattr.restype = ctypes.c_ssize_t
+        for name in names:
+            size = libc.fgetxattr(fd, name, None, 0, 0, 0)
+            require(size >= 0, "cannot inspect provenance")
+            value = ctypes.create_string_buffer(size)
+            require(libc.fgetxattr(fd, name, value, size, 0, 0) == size, "provenance changed")
+            attributes[name] = value.raw
+        if restore is not None and attributes != restore:
+            require(set(attributes) <= set(restore), "candidate has unexpected provenance")
+            libc.fsetxattr.argtypes = libc.fgetxattr.argtypes
+            for name, value in restore.items():
+                require(libc.fsetxattr(fd, name, value, len(value), 0, 0) == 0,
+                        "cannot preserve provenance")
+            require(plain_metadata(fd) == restore, "provenance mismatch")
+        libc.acl_get_fd_np.argtypes = [ctypes.c_int, ctypes.c_int]
+        libc.acl_get_fd_np.restype = ctypes.c_void_p
+        libc.acl_get_entry.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p]
+        libc.acl_free.argtypes = [ctypes.c_void_p]
+        ctypes.set_errno(0)
+        acl = libc.acl_get_fd_np(fd, 0x100)  # ACL_TYPE_EXTENDED from sys/acl.h.
+        if not acl and ctypes.get_errno() == errno.ENOENT:
+            # Darwin's filesec ACL property is absent; the open fd still exists.
+            os.fstat(fd)
+            return attributes if restore is None else restore
+        require(acl, "cannot inspect ACL")
+        try:
+            entry = ctypes.c_void_p()
+            # Darwin returns -1 with EINVAL when the ACL has no entries.
+            ctypes.set_errno(0)
+            result = libc.acl_get_entry(acl, 0, ctypes.byref(entry))
+            require(result == -1 and ctypes.get_errno() == errno.EINVAL, "ACLs are unsupported")
+        finally:
+            libc.acl_free(acl)
+        return attributes if restore is None else restore
+    elif sys.platform.startswith("linux") and hasattr(os, "listxattr"):
+        require(not os.listxattr(fd), "extended attributes and ACLs are unsupported")
+        return {}
+    else:
+        raise ValueError("metadata inspection is supported only on macOS and Linux")
+
+
+def read_file(path, target=False):
+    fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+    with os.fdopen(fd, "rb") as stream:
+        info = os.fstat(stream.fileno())
+        require(stat.S_ISREG(info.st_mode), "not a regular file")
+        attributes = None
+        if target:
+            require(info.st_uid == os.geteuid(), "target has foreign ownership")
+            require(info.st_nlink == 1, "target has hard links")
+            require(info.st_mode & 0o7000 == 0 and info.st_mode & stat.S_IXUSR,
+                    "target has unsupported permissions")
+            require(info.st_size <= 4096, "unknown target content")
+            attributes = plain_metadata(stream.fileno())
+        digest = hashlib.sha256()
+        data = bytearray()
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+            if target or not data:
+                data.extend(chunk if target else chunk[:4])
+        require(identity(info) == identity(os.fstat(stream.fileno())), "file changed while reading")
+    return info, digest.hexdigest(), bytes(data), attributes
+
+
+def native_state(path, expected):
+    resolved = path.resolve(strict=True)
+    info, digest, magic, _ = read_file(resolved)
+    require(info.st_mode & 0o111 and os.access(resolved, os.X_OK), "native gh is not executable")
+    require(magic in BINARY_MAGIC, "native gh must be a preverified binary, not a script or wrapper")
+    require(digest == expected, "native gh digest mismatch")
+    require(path.resolve(strict=True) == resolved, "native gh resolution changed")
+    return str(resolved), identity(info), digest
+
+
+def repaired(native):
+    block = ('if [[ "${1:-}" == auth ]]; then\n'
+             '  exec ' + shlex.quote(str(native)) + ' "$@"\nfi\n\n').encode()
+    return PREFIX + block + ORIGINAL[len(PREFIX):]
+
+
+def directory_state(path, private=False):
+    require(path.resolve(strict=True) == path, "parent directories must be canonical, without symlinks")
+    fd = os.open(path, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+    try:
+        info = os.fstat(fd)
+        plain_metadata(fd)
+    finally:
+        os.close(fd)
+    require(stat.S_ISDIR(info.st_mode) and info.st_uid == os.geteuid(),
+            "parent directory must be owned by the current user")
+    require(not info.st_mode & 0o022, "parent directory must not be group/world writable")
+    if private:
+        require(stat.S_IMODE(info.st_mode) == 0o700, "backup directory must have mode 0700")
+    return info.st_dev, info.st_ino, info.st_mode, info.st_uid, info.st_gid
+
+
+def repair(target, expected, native, native_sha, backup=None, apply=False):
+    require(sha(ORIGINAL) == ORIGINAL_SHA, "internal signature mismatch")
+    parent = directory_state(target.parent)
+    initial_native = native_state(native, native_sha)
+    info, digest, before, attributes = read_file(target, target=True)
+    require(digest == expected, "target digest mismatch")
+    after = repaired(native)
+    require(before in (ORIGINAL, after), "unknown target content or a different native path pin")
+    if before == after:
+        return "already repaired; unchanged"
+    if not apply:
+        return "dry run; would insert auth bypass (sha256 " + sha(after) + ")"
+    require(backup is not None, "--apply requires --backup")
+    backup_parent = directory_state(backup.parent, private=True)
+    require(not os.path.lexists(backup), "backup destination already exists")
+    temporary = None
+    try:
+        fd, temporary = tempfile.mkstemp(prefix=".ghx-auth-repair-", dir=target.parent)
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(after)
+            stream.flush()
+            os.fchown(stream.fileno(), info.st_uid, info.st_gid)
+            os.fchmod(stream.fileno(), stat.S_IMODE(info.st_mode))
+            plain_metadata(stream.fileno(), restore=attributes)
+            os.utime(stream.fileno(), ns=(info.st_atime_ns, info.st_mtime_ns))
+            os.fsync(stream.fileno())
+        candidate_info, candidate_sha, _, candidate_attributes = read_file(Path(temporary), target=True)
+        require(candidate_sha == sha(after), "candidate digest mismatch")
+        require(candidate_attributes == attributes, "candidate attributes mismatch")
+        require((candidate_info.st_mode, candidate_info.st_uid, candidate_info.st_gid,
+                 candidate_info.st_mtime_ns) ==
+                (info.st_mode, info.st_uid, info.st_gid, info.st_mtime_ns),
+                "candidate metadata mismatch")
+        require(directory_state(backup.parent, private=True) == backup_parent,
+                "backup directory changed")
+        fd = os.open(backup, os.O_WRONLY | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW, 0o600)
+        with os.fdopen(fd, "wb") as stream:
+            stream.write(before)
+            stream.flush()
+            os.fchmod(stream.fileno(), 0o600)
+            plain_metadata(stream.fileno())
+            os.fsync(stream.fileno())
+        # Recheck both pins and target identity immediately before replacement.
+        require(native_state(native, native_sha) == initial_native, "native gh changed")
+        current, current_sha, _, current_attributes = read_file(target, target=True)
+        require(identity(current) == identity(info) and current_sha == digest
+                and current_attributes == attributes, "target changed")
+        require(directory_state(target.parent) == parent, "target directory changed")
+        os.utime(temporary, ns=(info.st_atime_ns, info.st_mtime_ns))
+        os.replace(temporary, target)
+        temporary = None
+        return "repaired; sha256 " + sha(after) + "; private backup retained"
+    finally:
+        if temporary is not None:
+            os.unlink(temporary)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", required=True, help="absolute legacy shim path")
+    parser.add_argument("--expected-sha256", required=True, help="audited current target digest")
+    parser.add_argument("--native-gh", required=True, help="absolute independently verified native gh path")
+    parser.add_argument("--native-sha256", required=True, help="audited native binary digest")
+    parser.add_argument("--backup", help="absent file in an existing private 0700 directory")
+    parser.add_argument("--apply", action="store_true", help="apply the repair; otherwise only inspect")
+    args = parser.parse_args()
+    try:
+        require(not args.apply or args.backup, "--apply requires --backup")
+        for digest in (args.expected_sha256, args.native_sha256):
+            require(len(digest) == 64 and all(c in "0123456789abcdef" for c in digest),
+                    "digests must be lowercase SHA-256 hex")
+        result = repair(absolute(args.target), args.expected_sha256,
+                        absolute(args.native_gh), args.native_sha256,
+                        absolute(args.backup) if args.backup else None, args.apply)
+        print("ghx-auth-repair: " + result)
+    except (OSError, ValueError) as error:
+        print("ghx-auth-repair: refusing: " + str(error), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/ghx-auth-repair-test.py
+++ b/tests/ghx-auth-repair-test.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Offline migration and exec-parity fixtures; never invoke real gh or auth."""
+
+import json
+import os
+from pathlib import Path
+import pty
+import runpy
+import select
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+import tty
+import unittest
+from unittest import mock
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "bin" / "ghx-auth-repair"
+REPAIR = runpy.run_path(str(SCRIPT))
+ORIGINAL = REPAIR["ORIGINAL"]
+SHA = REPAIR["sha"]
+GLOBALS = REPAIR["repair"].__globals__
+ERROR = b"ghx: outer wrapper did not provide the real GitHub CLI path\n"
+FAKE = """#!{python}
+import json, os, sys
+data = sys.stdin.buffer.read(int(os.environ.get("INPUT_SIZE", "0")))
+print(json.dumps({{"argv": sys.argv[1:], "stdin": data.hex(), "pid": os.getpid(),
+ "tty": [os.isatty(i) for i in range(3)],
+ "env": {{key: os.environ.get(key) for key in (
+  "GHX_GH_PATH", "OCTOPOOL_GH_PATH", "OCTOPOOL_FRESH", "OCTOPOOL_URL",
+  "GH_PROMPT_DISABLED", "GH_PAGER", "SENTINEL")}}}}), flush=True)
+sys.stderr.write("fixture stderr\\n")
+sys.exit(int(os.environ.get("EXIT", "0")))
+"""
+
+
+class RepairTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory(prefix="ghx-auth-repair-test-")
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name).resolve()
+        self.target = self.root / "ghx"
+        self.target.write_bytes(ORIGINAL)
+        self.target.chmod(0o751)
+        self.native = self.root / "native binary"
+        shutil.copyfile("/bin/echo", self.native)
+        self.native.chmod(0o755)
+        self.native_sha = SHA(self.native.read_bytes())
+        self.backup_dir = self.root / "backup"
+        self.backup_dir.mkdir(mode=0o700)
+        self.backup = self.backup_dir / "ghx.before"
+
+    def repair(self, apply=False, **changes):
+        args = dict(target=self.target, expected=SHA(ORIGINAL), native=self.native,
+                    native_sha=self.native_sha, backup=self.backup, apply=apply)
+        args.update(changes)
+        return REPAIR["repair"](**args)
+
+    def cli(self, *extra):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--target", str(self.target),
+             "--expected-sha256", SHA(self.target.read_bytes()),
+             "--native-gh", str(self.native), "--native-sha256", self.native_sha, *extra],
+            capture_output=True, timeout=10,
+        )
+
+    def test_exact_signature_and_insertion(self):
+        self.assertEqual(len(ORIGINAL), 349)
+        self.assertEqual(SHA(ORIGINAL), REPAIR["ORIGINAL_SHA"])
+        after = REPAIR["repaired"](Path("/opt/homebrew/bin/gh"))
+        self.assertEqual(SHA(after), "624c261a7bbe98556548597eed0c532543734c1c0c11e653461462c80f3bb094")
+        self.assertEqual(after.replace(
+            b'if [[ "${1:-}" == auth ]]; then\n  exec /opt/homebrew/bin/gh "$@"\nfi\n\n',
+            b"", 1), ORIGINAL)
+
+    def test_dry_run_apply_metadata_and_idempotency(self):
+        os.utime(self.target, ns=(1600000000000000000, 1600000000000000000))
+        before = self.target.stat()
+        result = self.cli()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(b"dry run", result.stdout)
+        self.assertEqual(self.target.stat().st_ino, before.st_ino)
+        self.assertFalse(self.backup.exists())
+        before = self.target.stat()
+        attributes = REPAIR["read_file"](self.target, target=True)[3]
+        result = self.cli("--apply", "--backup", str(self.backup))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        after = self.target.stat()
+        self.assertNotEqual(before.st_ino, after.st_ino)
+        for field in ("st_mode", "st_uid", "st_gid", "st_mtime_ns"):
+            self.assertEqual(getattr(before, field), getattr(after, field))
+        self.assertEqual(REPAIR["read_file"](self.target, target=True)[3], attributes)
+        self.assertEqual(self.backup.read_bytes(), ORIGINAL)
+        self.assertEqual(stat.S_IMODE(self.backup.stat().st_mode), 0o600)
+        self.assertEqual(self.target.read_bytes(), REPAIR["repaired"](self.native))
+        result = self.cli("--apply", "--backup", str(self.backup))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(b"already repaired", result.stdout)
+        self.assertEqual(self.target.stat().st_ino, after.st_ino)
+
+    def test_arguments_and_private_backup_required(self):
+        result = self.cli("--apply")
+        self.assertNotEqual(result.returncode, 0)
+        self.backup_dir.chmod(0o755)
+        with self.assertRaisesRegex(ValueError, "0700"):
+            self.repair(apply=True)
+        self.backup_dir.chmod(0o700)
+        self.backup.write_bytes(b"existing")
+        with self.assertRaisesRegex(ValueError, "already exists"):
+            self.repair(apply=True)
+        self.assertEqual(self.backup.read_bytes(), b"existing")
+        for path in ("relative", "/tmp/../ghx", "/tmp/line\nbreak"):
+            with self.assertRaises(ValueError):
+                REPAIR["absolute"](path)
+
+    def test_atime_preserved(self):
+        timestamp = 1600000000000000000
+        os.utime(self.target, ns=(timestamp, timestamp))
+        self.repair(apply=True)
+        self.assertEqual(self.target.stat().st_atime_ns, timestamp)
+        self.assertEqual(self.target.stat().st_mtime_ns, timestamp)
+
+    def test_unknown_binary_and_digest_refused(self):
+        for content in (b"#!/bin/sh\nexit 0\n", self.native.read_bytes()):
+            self.target.write_bytes(content)
+            with self.assertRaises(ValueError):
+                self.repair(apply=True, expected=SHA(content))
+        self.target.write_bytes(ORIGINAL)
+        with self.assertRaisesRegex(ValueError, "target digest"):
+            self.repair(expected="0" * 64)
+        with self.assertRaisesRegex(ValueError, "native gh digest"):
+            self.repair(native_sha="0" * 64)
+        self.assertFalse(self.backup.exists())
+
+    def test_symlink_hardlink_foreign_owner_and_mode_refused(self):
+        saved = self.root / "saved"
+        self.target.rename(saved)
+        self.target.symlink_to(saved)
+        with self.assertRaises(OSError):
+            self.repair(apply=True)
+        self.target.unlink()
+        os.link(saved, self.target)
+        with self.assertRaisesRegex(ValueError, "hard links"):
+            self.repair(apply=True)
+        saved.unlink()
+        with mock.patch.object(os, "geteuid", return_value=os.geteuid() + 1):
+            with self.assertRaisesRegex(ValueError, "foreign ownership"):
+                REPAIR["read_file"](self.target, target=True)
+        self.target.chmod(0o4751)
+        with self.assertRaisesRegex(ValueError, "permissions"):
+            self.repair(apply=True)
+
+    def test_native_script_refusal_symlink_and_pin_semantics(self):
+        wrapper = self.root / "wrapper"
+        wrapper.write_bytes(b"#!/bin/sh\nexit 0\n")
+        wrapper.chmod(0o755)
+        with self.assertRaisesRegex(ValueError, "binary"):
+            self.repair(native=wrapper, native_sha=SHA(wrapper.read_bytes()))
+        link = self.root / "native-link"
+        link.symlink_to(self.native)
+        self.repair(apply=True, native=link)
+        post_sha = SHA(self.target.read_bytes())
+        self.assertIn("already repaired", self.repair(native=link, expected=post_sha))
+        with self.assertRaisesRegex(ValueError, "different native path pin"):
+            self.repair(native=self.native, expected=post_sha)
+
+    def test_target_and_native_drift_preserve_backup(self):
+        original_native_state = REPAIR["native_state"]
+        for drift in ("target", "inode", "mode", "native"):
+            with self.subTest(drift=drift):
+                self.target.write_bytes(ORIGINAL)
+                self.target.chmod(0o751)
+                if self.backup.exists():
+                    self.backup.unlink()
+                calls = 0
+
+                def changing_native(*args):
+                    nonlocal calls
+                    calls += 1
+                    if calls == 2:
+                        if drift == "target":
+                            self.target.write_bytes(ORIGINAL + b"# concurrent edit\n")
+                        elif drift == "inode":
+                            replacement = self.root / "concurrent"
+                            replacement.write_bytes(ORIGINAL)
+                            replacement.chmod(0o751)
+                            replacement.replace(self.target)
+                        elif drift == "mode":
+                            self.target.chmod(0o700)
+                        else:
+                            self.native.write_bytes(self.native.read_bytes() + b"changed")
+                    return original_native_state(*args)
+
+                with mock.patch.dict(GLOBALS, native_state=changing_native):
+                    with self.assertRaises(ValueError):
+                        self.repair(apply=True)
+                self.assertEqual(self.backup.read_bytes(), ORIGINAL)
+                self.assertNotEqual(self.target.read_bytes(), REPAIR["repaired"](self.native))
+                self.assertFalse(list(self.root.glob(".ghx-auth-repair-*")))
+
+    def test_native_symlink_resolution_drift(self):
+        link = self.root / "native-link"
+        link.symlink_to(self.native)
+        other = self.root / "same-bytes"
+        shutil.copyfile(self.native, other)
+        other.chmod(0o755)
+        original_native_state = REPAIR["native_state"]
+        calls = 0
+
+        def changing_native(*args):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                link.unlink()
+                link.symlink_to(other)
+            return original_native_state(*args)
+
+        with mock.patch.dict(GLOBALS, native_state=changing_native):
+            with self.assertRaisesRegex(ValueError, "native gh changed"):
+                self.repair(apply=True, native=link)
+        self.assertEqual(self.target.read_bytes(), ORIGINAL)
+        self.assertEqual(self.backup.read_bytes(), ORIGINAL)
+
+    @unittest.skipUnless(sys.platform == "darwin", "Darwin ACL fixture")
+    def test_acl_and_private_directory_acl_refused(self):
+        for path in (self.target, self.backup_dir):
+            with self.subTest(path=path.name):
+                subprocess.run(["/bin/chmod", "+a", "everyone allow read", str(path)],
+                               check=True, capture_output=True)
+                try:
+                    with self.assertRaisesRegex(ValueError, "ACL"):
+                        self.repair(apply=True)
+                finally:
+                    subprocess.run(["/bin/chmod", "-N", str(path)], check=True)
+
+    def test_unsupported_metadata_refused(self):
+        if sys.platform == "darwin":
+            os.chflags(self.target, stat.UF_HIDDEN)
+            try:
+                with self.assertRaisesRegex(ValueError, "flags"):
+                    self.repair(apply=True)
+            finally:
+                os.chflags(self.target, 0)
+            subprocess.run(
+                ["/usr/bin/xattr", "-w", "user.fixture", "fixture", str(self.target)],
+                capture_output=True, check=True,
+            )
+        else:
+            os.setxattr(self.target, "user.fixture", b"fixture")
+        with self.assertRaisesRegex(ValueError, "attributes"):
+            self.repair(apply=True)
+
+    def runtime_fixture(self):
+        fake = self.root / "native 'quoted' $; binary"
+        fake.write_text(FAKE.format(python=sys.executable))
+        fake.chmod(0o755)
+        candidate = self.root / "candidate"
+        candidate.write_bytes(REPAIR["repaired"](fake))
+        subprocess.run(["/bin/bash", "-n", str(candidate)], check=True)
+        home = self.root / "home"
+        (home / ".local/bin").mkdir(parents=True)
+        (home / ".local/bin/octopool").symlink_to(fake)
+        env = {"PATH": os.defpath, "HOME": str(home), "SENTINEL": "untouched",
+               "GH_PROMPT_DISABLED": "custom", "GH_PAGER": "custom",
+               "OCTOPOOL_GH_PATH": "inherited", "OCTOPOOL_FRESH": "inherited",
+               "OCTOPOOL_URL": "https://fixture.invalid"}
+        return fake, candidate, env
+
+    def test_auth_binary_io_environment_exit_and_exec_pid(self):
+        fake, candidate, env = self.runtime_fixture()
+        args = ["auth", "login", "--hostname", "fixture.invalid", "two words", "", "*"]
+        data = b"stdin\x00bytes\xff\n"
+        env.update(INPUT_SIZE=str(len(data)), EXIT="37")
+        with subprocess.Popen(["/bin/bash", str(candidate), *args], env=env,
+                              stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE) as child:
+            stdout, stderr = child.communicate(data, timeout=5)
+        observed = json.loads(stdout)
+        self.assertEqual(child.returncode, 37)
+        self.assertEqual(observed["pid"], child.pid)
+        self.assertEqual(observed["argv"], args)
+        self.assertEqual(observed["stdin"], data.hex())
+        self.assertEqual(stderr, b"fixture stderr\n")
+        self.assertEqual(observed["tty"], [False] * 3)
+        self.assertEqual(observed["env"], {key: env.get(key) for key in observed["env"]})
+
+    def test_non_auth_guard_and_octopool_parity(self):
+        fake, candidate, env = self.runtime_fixture()
+        env["EXIT"] = "29"
+        cases = [[], ["api", "user"], ["--no-cache", "api", "user"],
+                 ["--no-cache", "auth", "status"], ["xcache", "stats"],
+                 ["xdaemon", "status"], ["--ttl", "15", "pr", "view", "1"]]
+        for backend in (None, str(self.root / "missing"), str(fake)):
+            for args in cases:
+                with self.subTest(backend=backend, args=args):
+                    current_env = dict(env)
+                    if backend is not None:
+                        current_env["GHX_GH_PATH"] = backend
+                    outputs = [subprocess.run(
+                        ["/bin/bash", str(path), *args], env=current_env,
+                        capture_output=True, timeout=5,
+                    ) for path in (self.target, candidate)]
+                    if backend != str(fake):
+                        self.assertEqual([(r.returncode, r.stdout, r.stderr) for r in outputs],
+                                         [(127, b"", ERROR)] * 2)
+                    else:
+                        self.assertEqual([r.returncode for r in outputs], [29, 29])
+                        self.assertEqual([r.stderr for r in outputs], [b"fixture stderr\n"] * 2)
+                        values = [json.loads(r.stdout) for r in outputs]
+                        for value in values:
+                            value.pop("pid")
+                        self.assertEqual(values[0], values[1])
+                        self.assertEqual(values[0]["argv"], ["gh"] + (
+                            args[1:] if args[:1] == ["--no-cache"] else args))
+                        self.assertEqual(values[0]["env"]["OCTOPOOL_GH_PATH"], str(fake))
+                        self.assertEqual(values[0]["env"]["OCTOPOOL_FRESH"],
+                                         "1" if args[:1] == ["--no-cache"] else "inherited")
+
+    def test_auth_pty(self):
+        _, candidate, env = self.runtime_fixture()
+        env.update(INPUT_SIZE="4", EXIT="23")
+        master, slave = pty.openpty()
+        tty.setraw(slave)
+        child = subprocess.Popen(["/bin/bash", str(candidate), "auth", "status", ""],
+                                 env=env, stdin=slave, stdout=slave, stderr=slave)
+        os.close(slave)
+        try:
+            os.write(master, b"pty\n")
+            received = bytearray()
+            deadline = time.monotonic() + 5
+            while b"\n" not in received:
+                self.assertLess(time.monotonic(), deadline, "PTY fixture timed out")
+                if select.select([master], [], [], 0.1)[0]:
+                    received.extend(os.read(master, 8192))
+            observed = json.loads(received.split(b"\n", 1)[0])
+            self.assertEqual(child.wait(timeout=5), 23)
+            self.assertEqual(observed["argv"], ["auth", "status", ""])
+            self.assertEqual(observed["stdin"], b"pty\n".hex())
+            self.assertEqual(observed["tty"], [True] * 3)
+            self.assertEqual(observed["pid"], child.pid)
+        finally:
+            os.close(master)
+            if child.poll() is None:
+                child.kill()
+                child.wait()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `ghx-auth-repair`, an explicit migration for one known legacy inner shim whose auth dispatch incorrectly requires the outer wrapper's backend environment.
- Require audited absolute target/native paths and SHA-256 pins. Default to inspection; applying requires a private, absent backup destination.
- Preserve the exact original non-auth behavior and recognize the existing repaired postimage as a no-op. Refuse unknown content, link/ownership drift, native scripts, and unsupported metadata.
- Document the path-pin contract and supported metadata. No router, entrypoint, bootstrap, default installation, authentication, or service changes.

## Validation

- Independent exact-diff review completed for signed commit `dc8c99e81ecaa3f28ae702cf60a05112a2dfe911`.
- Repair fixtures: 14 tests pass on macOS with Python 3.9.6 and Python 3.14.6.
- Linux fixture-only qualification: 14 tests pass with Python 3.14.4, with the macOS-only ACL case skipped. The two committed files were checksum-verified in a private temporary stage; the stage was removed afterward.
- `bash tests/ghx-test.sh`: pass.
- `python3 tests/gh-octopool-test.py`: 452 hermetic routing cases pass.
- `tests/ghx-native-cache-test.py`: pass against a verified native CLI using only a loopback fixture.
- `git diff --check`: pass.

Fixtures cover exact signature/postimage bytes, dry run/apply, idempotency, private backups, metadata, target/native drift, quoting, symlink/hardlink/native-wrapper refusal, binary stdin, stdout/stderr, exit status, PTYs, exec PID, environment, and unchanged non-auth/cache-control dispatch. No real login or service writes were used.
