### PR TITLE
feat(codex): support optional native model catalogs

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -58,10 +58,11 @@ followed by the original forwarded arguments. It owns native catalog generation
 and must execute the same physical binary with its catalog override prepended.
 Helper failures stop the launch; there is no fallback to a different catalog.
 Explicit profiles, catalog or provider-route overrides, remote or local-provider
-selection, and `--ignore-user-config` bypass the helper. Help, version,
-authentication, installation, inspection, and other utility commands also stay
-native. Arguments after `--` are never inspected. The launcher does not write
-catalogs, configuration, or authentication files.
+selection, and `--ignore-user-config` bypass the helper. `debug models` uses the
+helper to inspect the effective CLI catalog; `debug models --bundled` stays
+native. Help, version, authentication, installation, and other utility commands
+also stay native. Arguments after `--` are never inspected. The launcher does
+not write catalogs, configuration, or authentication files.
 
 Scripts that need durable phase state can call `task-runtime phase` with an
 explicit artifact root. It retains one locked JSON receipt; bounds files, bytes,

--- a/bin/README.md
+++ b/bin/README.md
@@ -50,6 +50,19 @@ an exact failure timeout. For new work expected to write substantial data, use
 `codex --heavy-work`; tune `CODEX_DISK_RESERVE_GIB`,
 `CODEX_PLANNED_WRITE_BYTES`, or their matching command options.
 
+The launcher optionally delegates model workflows to the executable
+`${CODEX_HOME:-$HOME/.codex}/model-catalogs/render-cli-catalog`. Installing that
+helper is an explicit opt-in; without it, launch behavior is unchanged. The
+helper receives `--binary <resolved-launcher> --codex-home <directory> --exec --`
+followed by the original forwarded arguments. It owns native catalog generation
+and must execute the same physical binary with its catalog override prepended.
+Helper failures stop the launch; there is no fallback to a different catalog.
+Explicit profiles, catalog or provider-route overrides, remote or local-provider
+selection, and `--ignore-user-config` bypass the helper. Help, version,
+authentication, installation, inspection, and other utility commands also stay
+native. Arguments after `--` are never inspected. The launcher does not write
+catalogs, configuration, or authentication files.
+
 Scripts that need durable phase state can call `task-runtime phase` with an
 explicit artifact root. It retains one locked JSON receipt; bounds files, bytes,
 entries, directories, state reads, phases, and lock wait; and returns a small

--- a/bin/codex
+++ b/bin/codex
@@ -120,7 +120,8 @@ if (( heavy_work )); then
 fi
 
 if (( constrained_network )); then
-  forwarded=(--disable unbounded_connection_retries "${forwarded[@]}")
+  # Guard empty arrays for Bash 3.2 with nounset enabled.
+  forwarded=(--disable unbounded_connection_retries ${forwarded[@]+"${forwarded[@]}"})
 fi
 
 token="${GITHUB_PERSONAL_ACCESS_TOKEN:-${GITHUB_PAT_TOKEN:-}}"
@@ -136,4 +137,82 @@ if [[ -n "$token" ]]; then
 fi
 unset gh_bin token
 
-exec "$real_codex" "${forwarded[@]}"
+cli_catalog_eligible() {
+  local command_seen=0 value key
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --)
+        break
+        ;;
+      -p|--profile|-p?*|--profile=*|--ignore-user-config|--ignore-user-config=*|\
+      -h|--help|-V|--version|--bundled|--oss|--local-provider|--local-provider=*|\
+      --remote|--remote=*)
+        return 1
+        ;;
+      -c|--config)
+        [[ $# -ge 2 ]] || return 1
+        value="$2"
+        shift 2
+        ;;
+      -c?*)
+        value="${1#-c}"
+        value="${value#=}"
+        shift
+        ;;
+      --config=*)
+        value="${1#--config=}"
+        shift
+        ;;
+      -m|--model|-i|--image|-s|--sandbox|-a|--ask-for-approval|-C|--cd|\
+      --enable|--disable|--add-dir|--color|--output-schema|-o|--output-last-message|\
+      --listen|--remote-auth-token-env)
+        [[ $# -ge 2 ]] || return 1
+        [[ "$2" != -- ]] || return 1
+        shift 2
+        continue
+        ;;
+      -*)
+        shift
+        continue
+        ;;
+      *)
+        if (( command_seen == 0 )); then
+          case "$1" in
+            agents|login|logout|mcp|plugin|mcp-server|remote-control|app|completion|\
+            install|update|upgrade|doctor|sandbox|debug|apply|a|queue|archive|delete|\
+            migrate-rollouts|unarchive|cloud|exec-server|features|help)
+              return 1
+              ;;
+            app-server) command_seen=2 ;;
+            *) command_seen=1 ;;
+          esac
+        elif (( command_seen == 2 )); then
+          # App-server subcommands generate artifacts instead of serving models.
+          return 1
+        fi
+        shift
+        continue
+        ;;
+    esac
+    [[ "$value" == *=* ]] || return 1
+    key="${value%%=*}"
+    key="${key//[[:space:]]/}"
+    key="${key//\"/}"
+    key="${key//\'/}"
+    case "$key" in
+      model_catalog_json|profile|profiles|profiles.*|model_provider|model_providers|\
+      model_providers.*|oss_provider)
+        return 1
+        ;;
+    esac
+  done
+  return 0
+}
+
+catalog_helper="$codex_home/model-catalogs/render-cli-catalog"
+if [[ -x "$catalog_helper" ]] && cli_catalog_eligible ${forwarded[@]+"${forwarded[@]}"}; then
+  exec "$catalog_helper" --binary "$real_codex" --codex-home "$codex_home" \
+    --exec -- ${forwarded[@]+"${forwarded[@]}"}
+fi
+
+exec "$real_codex" ${forwarded[@]+"${forwarded[@]}"}

--- a/bin/codex
+++ b/bin/codex
@@ -179,15 +179,21 @@ cli_catalog_eligible() {
         if (( command_seen == 0 )); then
           case "$1" in
             agents|login|logout|mcp|plugin|mcp-server|remote-control|app|completion|\
-            install|update|upgrade|doctor|sandbox|debug|apply|a|queue|archive|delete|\
+            install|update|upgrade|doctor|sandbox|apply|a|queue|archive|delete|\
             migrate-rollouts|unarchive|cloud|exec-server|features|help)
               return 1
               ;;
             app-server) command_seen=2 ;;
+            debug) command_seen=3 ;;
             *) command_seen=1 ;;
           esac
         elif (( command_seen == 2 )); then
           # App-server subcommands generate artifacts instead of serving models.
+          return 1
+        elif (( command_seen == 3 )); then
+          [[ "$1" == models ]] || return 1
+          command_seen=4
+        elif (( command_seen == 4 )); then
           return 1
         fi
         shift
@@ -206,7 +212,7 @@ cli_catalog_eligible() {
         ;;
     esac
   done
-  return 0
+  (( command_seen != 3 ))
 }
 
 catalog_helper="$codex_home/model-catalogs/render-cli-catalog"

--- a/tests/codex-wrapper-test.sh
+++ b/tests/codex-wrapper-test.sh
@@ -227,6 +227,9 @@ assert_catalog_route helper exec "" "two words" $'line\nbreak' '*' -- \
   --profile explicit --config model_catalog_json=explicit --heavy-work
 assert_catalog_route helper -- login --version --ignore-user-config
 assert_catalog_route helper exec "a prompt mentioning --profile and --config"
+assert_catalog_route helper debug models
+assert_catalog_route helper --config features.example=true debug models
+assert_catalog_route helper debug models -- --bundled
 
 for option in -p --profile; do
   assert_catalog_route native "$option" explicit exec
@@ -256,6 +259,9 @@ for command in agents login logout mcp plugin mcp-server remote-control app comp
   assert_catalog_route native --config features.example=true "$command"
 done
 assert_catalog_route native debug models --bundled
+assert_catalog_route native debug models --help
+assert_catalog_route native debug other-utility
+assert_catalog_route native debug -- models
 assert_catalog_route native app-server generate-ts
 assert_catalog_route native app-server generate-json-schema
 assert_catalog_route native --config

--- a/tests/codex-wrapper-test.sh
+++ b/tests/codex-wrapper-test.sh
@@ -142,6 +142,155 @@ heavy_output="$(
 [[ "$heavy_output" == "standalone:run" ]]
 grep -Fx "admit --path $PWD --reserve-gib 12 --planned-bytes 4096" "$admission_log"
 
+catalog_home="$temporary/catalog home"
+catalog_binary="$catalog_home/packages/standalone/current/bin/codex"
+catalog_helper="$catalog_home/model-catalogs/render-cli-catalog"
+native_args="$temporary/native.args"
+helper_args="$temporary/helper.args"
+order_log="$temporary/order.log"
+mkdir -p "$(dirname "$catalog_binary")" "$(dirname "$catalog_helper")"
+cat >"$catalog_binary" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\0' "$#" "$@" >"$CODEX_TEST_NATIVE_ARGS"
+printf 'native\n' >>"$CODEX_TEST_ORDER_LOG"
+[[ "$GITHUB_PERSONAL_ACCESS_TOKEN" == native-token ]]
+[[ "$GITHUB_PAT_TOKEN" == native-token ]]
+[[ "$CODEX_TEST_SENTINEL" == preserved ]]
+printf 'native\n'
+EOF
+chmod +x "$catalog_binary"
+
+catalog_run() {
+  env -u GITHUB_PERSONAL_ACCESS_TOKEN -u GITHUB_PAT_TOKEN \
+    HOME="$temporary/unused-home" CODEX_HOME="$catalog_home" PATH="$long_path" \
+    CODEX_TEST_NATIVE_ARGS="$native_args" CODEX_TEST_HELPER_ARGS="$helper_args" \
+    CODEX_TEST_ORDER_LOG="$order_log" CODEX_TEST_SENTINEL=preserved \
+    CODEX_TEST_HELPER_EXIT="${CODEX_TEST_HELPER_EXIT:-0}" \
+    CODEX_TASK_RUNTIME_BIN="$temporary/catalog-admission" \
+    "$symlink_dir/codex" "$@"
+}
+
+assert_argv() {
+  local actual="$1"
+  shift
+  printf '%s\0' "$#" "$@" >"$temporary/expected.args"
+  cmp "$temporary/expected.args" "$actual"
+}
+
+assert_catalog_route() {
+  local expected="$1" output
+  shift
+  : >"$native_args"
+  : >"$helper_args"
+  : >"$order_log"
+  output="$(catalog_run "$@")"
+  [[ "$output" == "$expected" ]]
+  [[ "$(cat "$order_log")" == "$expected" ]]
+  if [[ "$expected" == helper ]]; then
+    assert_argv "$helper_args" --binary "$catalog_binary" \
+      --codex-home "$catalog_home" --exec -- "$@"
+    [[ ! -s "$native_args" ]]
+  else
+    assert_argv "$native_args" "$@"
+    [[ ! -s "$helper_args" ]]
+  fi
+}
+
+# No helper, or a non-executable opt-in, preserves the native launch.
+assert_catalog_route native
+assert_catalog_route native exec "two words"
+cat >"$catalog_helper" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\0' "$#" "$@" >"$CODEX_TEST_HELPER_ARGS"
+printf 'helper\n' >>"$CODEX_TEST_ORDER_LOG"
+[[ "$GITHUB_PERSONAL_ACCESS_TOKEN" == native-token ]]
+[[ "$GITHUB_PAT_TOKEN" == native-token ]]
+[[ "$CODEX_TEST_SENTINEL" == preserved ]]
+printf 'helper\n'
+exit "${CODEX_TEST_HELPER_EXIT:-0}"
+EOF
+chmod 644 "$catalog_helper"
+assert_catalog_route native review
+chmod 755 "$catalog_helper"
+
+assert_catalog_route helper
+assert_catalog_route helper "two words"
+for command in exec e review resume fork app-server; do
+  assert_catalog_route helper "$command"
+done
+assert_catalog_route helper --no-alt-screen --model test-model exec --json "two words"
+assert_catalog_route helper -m help -C login -i image.png review
+assert_catalog_route helper -c 'model="test-model"' --config features.example=true exec
+assert_catalog_route helper --config=features.example=true -cfeatures.other=false resume --last
+assert_catalog_route helper app-server --listen unix://example
+assert_catalog_route helper exec "" "two words" $'line\nbreak' '*' -- \
+  --profile explicit --config model_catalog_json=explicit --heavy-work
+assert_catalog_route helper -- login --version --ignore-user-config
+assert_catalog_route helper exec "a prompt mentioning --profile and --config"
+
+for option in -p --profile; do
+  assert_catalog_route native "$option" explicit exec
+done
+for option in -pexplicit -p=explicit --profile=explicit; do
+  assert_catalog_route native exec "$option"
+done
+for key in model_catalog_json profile profiles profiles.team.model_provider \
+  model_provider model_providers model_providers.custom.base_url oss_provider \
+  '"model_catalog_json"' "model_providers.'custom'.base_url"; do
+  for option in -c --config; do
+    assert_catalog_route native "$option" "$key = \"explicit\"" exec
+  done
+  for option in "-c$key=explicit" "-c=$key=explicit" "--config=$key=explicit"; do
+    assert_catalog_route native exec "$option"
+  done
+done
+for option in --ignore-user-config --ignore-user-config=true -h --help -V --version \
+  --bundled --oss --local-provider=custom --remote=unix://example; do
+  assert_catalog_route native exec "$option"
+done
+assert_catalog_route native --local-provider custom exec
+assert_catalog_route native --remote unix://example
+for command in agents login logout mcp plugin mcp-server remote-control app completion \
+  install update upgrade doctor sandbox debug apply a queue archive delete \
+  migrate-rollouts unarchive cloud exec-server features help; do
+  assert_catalog_route native --config features.example=true "$command"
+done
+assert_catalog_route native debug models --bundled
+assert_catalog_route native app-server generate-ts
+assert_catalog_route native app-server generate-json-schema
+assert_catalog_route native --config
+assert_catalog_route native -c malformed
+assert_catalog_route native -m -- --profile explicit
+
+cat >"$temporary/catalog-admission" <<'EOF'
+#!/usr/bin/env bash
+printf 'admission\n' >>"$CODEX_TEST_ORDER_LOG"
+printf '%s\0' "$#" "$@" >"$CODEX_TEST_ORDER_LOG.args"
+EOF
+chmod +x "$temporary/catalog-admission"
+: >"$native_args"
+: >"$helper_args"
+: >"$order_log"
+[[ "$(catalog_run --heavy-work --disk-reserve-gib 12 --planned-write-bytes 4096 \
+  --constrained-network exec "two words")" == helper ]]
+[[ "$(cat "$order_log")" == $'admission\nhelper' ]]
+assert_argv "$order_log.args" admit --path "$PWD" --reserve-gib 12 --planned-bytes 4096
+assert_argv "$helper_args" --binary "$catalog_binary" --codex-home "$catalog_home" \
+  --exec -- --disable unbounded_connection_retries exec "two words"
+[[ ! -s "$native_args" ]]
+
+: >"$native_args"
+: >"$helper_args"
+: >"$order_log"
+if failure_output="$(CODEX_TEST_HELPER_EXIT=73 catalog_run exec "two words")"; then
+  printf 'catalog helper failure must not fall back to the native CLI\n' >&2
+  exit 1
+else
+  [[ $? -eq 73 ]]
+fi
+[[ "$failure_output" == helper && "$(cat "$order_log")" == helper ]]
+[[ ! -s "$native_args" && -s "$helper_args" ]]
+
 if grep -Fq 'gh auth token' "$repo_root/.zshrc"; then
   printf '.zshrc must not fetch GitHub credentials during startup\n' >&2
   exit 1


### PR DESCRIPTION
## Summary

- Add an optional CLI catalog-helper handoff after existing launcher setup, without changing behavior when no executable helper is installed.
- Preserve explicit profiles and provider/catalog overrides, utility commands, argument boundaries, and helper failures without fallback.
- Route effective model inspection through the helper while keeping bundled inspection native, and preserve empty interactive arguments on Bash 3.2.

## Validation

- `bash tests/codex-wrapper-test.sh`
- `shellcheck bin/codex tests/codex-wrapper-test.sh`
- `bash -n bin/codex tests/codex-wrapper-test.sh`
- `git diff --check`
- Isolated native 0.153.4 integration with network denied, including full catalog equality and fail-closed cache corruption handling.

The update adds no model catalog, model-specific policy, installer, network call, or authentication/configuration write to the public launcher.
