### PR TITLE
fix(tmux): add fixed-size single-pane mobile mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,45 @@ Apply receipts and profile backups live under
 
 ## Headless Linux servers
 
+### Single-pane mobile mirror
+
+`mtt cockpit:2.1` (or `mtt %12`) mirrors exactly one existing pane at its
+source dimensions. `mtt` opens a metadata-only picker; `mtt --check %12`
+prints the resolved ID and dimensions without capturing or sending input.
+Use `--socket /path/to/socket` for an explicit existing server.
+Python 3.9+ with curses and a UTF-8 terminal are required.
+
+For a full-phone single-pane view, run from plain SSH or a local terminal outside
+tmux. Detach the old mobile tmux client first, without closing any panes. Inside
+an already attached multi-pane cockpit, the outer grid still confines `mtt` to
+the calling pane; `mtt` never automatically detaches clients or zooms panes.
+
+The local viewport crops/pans the fixed-size screen and follows the source
+cursor. Resizing the phone never resizes the source; only source-side changes
+update the pad dimensions. No sessions are created or attached, and desktop
+focus, zoom, layouts and sibling panes are left alone.
+
+Input starts after the first validated frame. `Ctrl-] p` disarms input and
+enables local arrows, PageUp/PageDown and Home; `Ctrl-] f` resumes follow/input.
+`--read-only` never forwards input. `Ctrl-] q` exits only the viewer;
+`Ctrl-] Ctrl-]` sends a literal prefix when interactive. Ctrl-C, arrows,
+backspace and ordinary keys go to the source application. Complete bracketed
+paste frames are forwarded literally, up to 4096 bytes including delimiters;
+incomplete or oversized frames close the viewer without sending that paste.
+Typed/pasted newlines retain their normal application behavior; no Enter or
+shell command is generated.
+
+This is a monochrome, current-screen mirror, not a full terminal replica:
+no tmux history, colors/attributes, mouse forwarding or copy-mode navigation.
+Curses handles wide/combining glyphs; terminal/font width differences can
+still affect rendering. The viewer closes on copy/other pane modes, synchronized
+input, capture/send hooks, identity changes or uncertain delivery. Socket and
+process births are checked locally, not atomically inside tmux; each send has a
+separate non-yielding server-side identity/mode guard and acknowledgement.
+Timed-out input is never retried.
+
+### Server Profile
+
 Use the guarded server profile instead of the full desktop installer:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -92,16 +92,20 @@ For a full-phone single-pane view, run from plain SSH or a local terminal outsid
 tmux. Detach the old mobile tmux client first, without closing any panes. Inside
 an already attached multi-pane cockpit, the outer grid still confines `mtt` to
 the calling pane; `mtt` never automatically detaches clients or zooms panes.
+An outer tmux also intercepts `Ctrl-b`, so use the shortcuts below from plain SSH.
 
 The local viewport crops/pans the fixed-size screen and follows the source
 cursor. Resizing the phone never resizes the source; only source-side changes
 update the pad dimensions. No sessions are created or attached, and desktop
 focus, zoom, layouts and sibling panes are left alone.
 
-Input starts after the first validated frame. `Ctrl-] p` disarms input and
-enables local arrows, PageUp/PageDown and Home; `Ctrl-] f` resumes follow/input.
-`--read-only` never forwards input. `Ctrl-] q` exits only the viewer;
-`Ctrl-] Ctrl-]` sends a literal prefix when interactive. Ctrl-C, arrows,
+Input starts after the first validated frame. `Ctrl-b p` disarms input and
+enables local arrows, PageUp/PageDown and Home; `Ctrl-b f` resumes follow/input.
+`--read-only` never forwards input. `Ctrl-b d` or `Ctrl-b q` exits only the viewer,
+leaving the source running. `Ctrl-b Ctrl-b` sends a literal Ctrl-b when interactive.
+The legacy `Ctrl-]` prefix supports the same `d`, `q`, `p` and `f` actions;
+`Ctrl-] Ctrl-]` sends a literal Ctrl-]. Mixed prefixes and unknown prefixed
+actions are consumed locally. Ctrl-C, arrows,
 backspace and ordinary keys go to the source application. Complete bracketed
 paste frames are forwarded literally, up to 4096 bytes including delimiters;
 incomplete or oversized frames close the viewer without sending that paste.

--- a/bin/linux-server-bootstrap
+++ b/bin/linux-server-bootstrap
@@ -871,7 +871,8 @@ refresh_user_source_files() {
   printf '%s\n' \
     "$repo_root/bin/codex" \
     "$repo_root/bin/dotfiles-audit" \
-    "$repo_root/bin/linux-server-bootstrap"
+    "$repo_root/bin/linux-server-bootstrap" \
+    "$repo_root/bin/mtt"
 }
 
 preflight_dotfiles_source_file() {
@@ -1163,6 +1164,7 @@ bin/dotfiles-platform .local/bin/dotfiles-platform
 bin/gh .local/bin/gh
 bin/ghx .local/bin/ghx
 bin/linux-server-bootstrap .local/bin/linux-server-bootstrap
+bin/mtt .local/bin/mtt
 bin/tt .local/bin/tt
 EOF
 

--- a/bin/mtt
+++ b/bin/mtt
@@ -20,7 +20,7 @@ TIMEOUT = 2.0
 OUTPUT_LIMIT = 2 * 1024 * 1024
 INPUT_LIMIT = 4096
 SNAPSHOT_INTERVAL = 0.2
-PREFIX = "\x1d"
+PREFIXES = ("\x02", "\x1d")
 PASTE_START = "\x1b[200~"
 PASTE_END = "\x1b[201~"
 FIELDS = (
@@ -394,7 +394,7 @@ class Controls:
     def __init__(self, read_only=False):
         self.read_only = read_only
         self.view = Viewport()
-        self.prefix = False
+        self.prefix = ""
         self.escape = ""
         self.escape_at = 0.0
         self.paste = ""
@@ -437,7 +437,7 @@ class Controls:
                     self.escape = candidate
                     if candidate == PASTE_START:
                         self.escape = ""
-                        self.prefix = False
+                        self.prefix = ""
                         self.pasting, self.paste_at = True, now
                         self.paste_size = 0
                     return []
@@ -448,18 +448,18 @@ class Controls:
             self.escape, self.escape_at = key, now
             return []
         if self.prefix:
-            self.prefix = False
-            if key == "q":
+            prefix, self.prefix = self.prefix, ""
+            if key in ("d", "q"):
                 self.quit = True
             elif key == "p":
                 self.view.follow = False
             elif key == "f":
                 self.view.follow = True
-            elif key == PREFIX and self.interactive:
-                return [PREFIX.encode()]
+            elif key == prefix and self.interactive:
+                return [prefix.encode()]
             return []
-        if key == PREFIX:
-            self.prefix = True
+        if key in PREFIXES:
+            self.prefix = key
             return []
         if not self.view.follow:
             self.view.pan(key, rows)
@@ -590,8 +590,11 @@ def picker(screen, panes):
 def main():
     parser = argparse.ArgumentParser(
         description=__doc__,
-        epilog=("Ctrl-] p: pan (input off); arrows/PageUp/PageDown/Home pan locally. "
-                "Ctrl-] f: follow/resume; Ctrl-] q: quit viewer; Ctrl-] Ctrl-]: literal prefix. "
+        epilog=("Ctrl-b p: pan (input off); arrows/PageUp/PageDown/Home pan locally. "
+                "Ctrl-b f: follow/resume; Ctrl-b d or q: quit only the viewer. "
+                "Ctrl-b Ctrl-b sends literal Ctrl-b when interactive. "
+                "Legacy Ctrl-] supports the same actions; Ctrl-] Ctrl-] sends literal Ctrl-]. "
+                "Run from plain SSH outside tmux: an outer tmux intercepts Ctrl-b. "
                 "Ctrl-C and normal keys go to the source. Bracketed pastes up to 4096 bytes "
                 "are sent as complete literal frames; incomplete/oversize pastes close the viewer. "
                 "Newlines in typed or pasted input retain their normal behavior; no Enter is added. "

--- a/bin/mtt
+++ b/bin/mtt
@@ -1,31 +1,638 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env python3
+"""A fixed-size, current-screen mirror of one existing tmux pane."""
 
-usage() {
-  cat <<'EOF'
-usage: mtt [session]
+import argparse
+import curses
+import locale
+import os
+from pathlib import Path
+import re
+import selectors
+import signal
+import stat
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
 
-mobile tmux helper for this machine:
-- with no args, open the mobile pane picker (`tt mobile`)
-- with a session arg, attach or create that explicit mobile session
 
-examples:
-  mtt
-  mtt mobile
-EOF
+TIMEOUT = 2.0
+OUTPUT_LIMIT = 2 * 1024 * 1024
+INPUT_LIMIT = 4096
+SNAPSHOT_INTERVAL = 0.2
+PREFIX = "\x1d"
+PASTE_START = "\x1b[200~"
+PASTE_END = "\x1b[201~"
+FIELDS = (
+    "pid", "session_id", "window_id", "pane_id", "pane_pid", "pane_tty",
+    "session_name", "window_index", "pane_index", "pane_width", "pane_height",
+    "cursor_x", "cursor_y", "cursor_flag", "pane_dead", "pane_in_mode",
+    "synchronize-panes",
+)
+META_FORMAT = "\t".join("#{" + field + "}" for field in FIELDS)
+NAMED_KEYS = {
+    curses.KEY_UP: "Up", curses.KEY_DOWN: "Down",
+    curses.KEY_LEFT: "Left", curses.KEY_RIGHT: "Right",
+    curses.KEY_PPAGE: "PPage", curses.KEY_NPAGE: "NPage",
+    curses.KEY_HOME: "Home", curses.KEY_END: "End",
+    curses.KEY_BACKSPACE: "BSpace", curses.KEY_DC: "DC",
+    curses.KEY_IC: "IC", curses.KEY_BTAB: "BTab", curses.KEY_ENTER: "Enter",
 }
+NAMED_KEYS.update({curses.KEY_F0 + n: "F" + str(n) for n in range(1, 13)})
+ALLOWED_KEYS = frozenset(NAMED_KEYS.values())
 
-case "${1:-}" in
-  -h|--help)
-    usage
-    ;;
-  "")
-    exec tt mobile
-    ;;
-  restore)
-    exec tt restore "${@:2}"
-    ;;
-  *)
-    exec tt mobile "$@"
-    ;;
-esac
+
+class Refused(Exception):
+    pass
+
+
+def bounded_run(argv, timeout=TIMEOUT, limit=OUTPUT_LIMIT, env=None):
+    """Bound both elapsed time and pipe memory; never retry a command."""
+    deadline = time.monotonic() + timeout
+    with subprocess.Popen(
+        argv, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT, env=env,
+    ) as process:
+        output = bytearray()
+        try:
+            with selectors.DefaultSelector() as selector:
+                selector.register(process.stdout, selectors.EVENT_READ)
+                while selector.get_map():
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise Refused("command timed out")
+                    for key, _ in selector.select(remaining):
+                        chunk = os.read(key.fd, min(65536, limit + 1 - len(output)))
+                        if not chunk:
+                            selector.unregister(key.fileobj)
+                            continue
+                        output.extend(chunk)
+                        if len(output) > limit:
+                            raise Refused("command output exceeded limit")
+            process.wait(timeout=max(0.001, deadline - time.monotonic()))
+            if process.returncode:
+                # Server output is untrusted terminal text; do not print it.
+                raise Refused("command failed (status {})".format(process.returncode))
+        except BaseException:
+            if process.poll() is None:
+                process.kill()  # Only this invocation's client, never the server.
+            process.wait()
+            raise
+    return bytes(output)
+
+
+def process_identity(pid):
+    if not isinstance(pid, int) or pid <= 0:
+        raise Refused("invalid process ID")
+    try:
+        if sys.platform.startswith("linux"):
+            record = Path("/proc/{}/stat".format(pid)).read_text()
+            fields = record[record.rindex(")") + 2:].split()
+            if fields[0] in ("Z", "X"):
+                raise Refused("process is no longer live")
+            return fields[19], int(fields[1])
+        record = bounded_run(
+            ["ps", "-p", str(pid), "-o", "ppid=", "-o", "lstart="],
+            limit=1024, env=dict(os.environ, LC_ALL="C"),
+        ).decode("ascii").strip().split(None, 1)
+        if len(record) != 2:
+            raise Refused("process birth unavailable")
+        return record[1], int(record[0])
+    except (OSError, ValueError, IndexError) as exc:
+        raise Refused("process birth unavailable") from exc
+
+
+def socket_identity(path):
+    try:
+        info = os.stat(path, follow_symlinks=False)
+    except OSError as exc:
+        raise Refused("socket disappeared") from exc
+    if not stat.S_ISSOCK(info.st_mode) or info.st_uid != os.getuid():
+        raise Refused("socket must be owned by this user")
+    return info.st_uid, info.st_dev, info.st_ino
+
+
+def decimal(value, minimum=0, maximum=2**31 - 1):
+    if not re.fullmatch(r"[0-9]+", value):
+        raise Refused("invalid numeric metadata")
+    number = int(value)
+    if not minimum <= number <= maximum:
+        raise Refused("metadata outside bounds")
+    return number
+
+
+@dataclass(frozen=True)
+class Pane:
+    server: int
+    session: str
+    window: str
+    pane: str
+    root: int
+    tty: str
+    name: str
+    window_index: int
+    pane_index: int
+    width: int
+    height: int
+    x: int
+    y: int
+    cursor: int
+    dead: int
+    mode: int
+    sync: int
+
+    @classmethod
+    def parse(cls, line):
+        values = line.split("\t")
+        if len(values) != len(FIELDS):
+            raise Refused("malformed pane inventory")
+        server, session, window, pane, root, tty, name = values[:7]
+        for value, pattern in (
+            (session, r"\$[0-9]+"), (window, r"@[0-9]+"), (pane, r"%[0-9]+"),
+            (tty, r"/dev/(?:pts/[0-9]+|tty[A-Za-z0-9]+)"),
+        ):
+            if not re.fullmatch(pattern, value):
+                raise Refused("invalid pane identity")
+        if not name or any(ord(c) < 32 or ord(c) == 127 for c in name):
+            raise Refused("invalid session name")
+        wi, pi = (decimal(v) for v in values[7:9])
+        width, height = (decimal(v, 1, 1000) for v in values[9:11])
+        if width * height > 200000:
+            raise Refused("pane exceeds mirror size limit")
+        x = decimal(values[11], 0, width)  # tmux may report wrap-pending x == width.
+        y = decimal(values[12], 0, height - 1)
+        cursor, dead = (decimal(v, 0, 1) for v in values[13:15])
+        mode = decimal(values[15])
+        sync = decimal(values[16], 0, 1)
+        return cls(decimal(server, 1), session, window, pane, decimal(root, 1),
+                   tty, name, wi, pi, width, height, min(x, width - 1), y,
+                   cursor, dead, mode, sync)
+
+    @property
+    def label(self):
+        return "{}:{}.{}".format(self.name, self.window_index, self.pane_index)
+
+    @property
+    def target(self):
+        return "{}:{}.{}".format(self.session, self.window, self.pane)
+
+    @property
+    def identity(self):
+        return self.server, self.session, self.window, self.pane, self.root, self.tty
+
+    def safe(self):
+        if self.dead or self.mode or self.sync:
+            raise Refused("source dead, in a mode, or synchronize-panes enabled")
+
+
+def resolve(panes, target):
+    matches = [pane for pane in panes if target in (pane.pane, pane.label)]
+    if len(matches) != 1:
+        raise Refused("target must exactly match one inventory pane ID or session:window.pane")
+    return matches[0]
+
+
+def refuse_self(pane, socket_path):
+    inherited = os.environ.get("TMUX", "").rsplit(",", 2)
+    if len(inherited) == 3:
+        same = (os.path.realpath(inherited[0]) == socket_path
+                and inherited[1] == str(pane.server))
+        if same and os.environ.get("TMUX_PANE") == pane.pane:
+            raise Refused("cannot mirror this viewer's pane")
+    for fd in (0, 1, 2):
+        if os.isatty(fd) and os.path.realpath(os.ttyname(fd)) == pane.tty:
+            raise Refused("cannot mirror this viewer's TTY")
+    pid = os.getpid()
+    for _ in range(128):
+        if pid == pane.root:
+            raise Refused("cannot mirror an ancestor pane")
+        if pid <= 1:
+            return
+        _, parent = process_identity(pid)
+        if parent == pid:
+            break
+        pid = parent
+    raise Refused("cannot verify viewer ancestry")
+
+
+def condition(pane):
+    # Only validated IDs, numbers and a restricted /dev path enter tmux syntax.
+    expected = {
+        "pid": pane.server, "session_id": pane.session, "window_id": pane.window,
+        "pane_id": pane.pane, "pane_pid": pane.root, "pane_tty": pane.tty,
+        "pane_dead": 0, "pane_in_mode": 0, "synchronize-panes": 0,
+        "after-capture-pane": "", "after-send-keys": "",
+    }
+    checks = ["#{==:#{%s},%s}" % (key, value) for key, value in expected.items()]
+    result = checks.pop()
+    for check in reversed(checks):
+        result = "#{&&:" + check + "," + result + "}"
+    return result
+
+
+def guarded(pane, body):
+    return ["if-shell", "-F", "-t", pane.target, condition(pane), body,
+            "display-message -p MTT_REFUSED"]
+
+
+def input_command(pane, events):
+    if not events or len(events) > 64:
+        raise Refused("input batch outside bounds")
+    commands = []
+    size = 0
+    for event in events:
+        if isinstance(event, bytes) and event:
+            size += len(event)
+            command = "send-keys -H -t {} {}".format(
+                pane.target, " ".join("{:02x}".format(b) for b in event))
+        elif isinstance(event, str) and event in ALLOWED_KEYS:
+            size += 1
+            command = "send-keys -t {} {}".format(pane.target, event)
+        else:
+            raise Refused("unsupported input")
+        commands.append(command)
+    if size > INPUT_LIMIT:
+        raise Refused("input batch outside bounds")
+    commands.append("display-message -p MTT_SENT")
+    return guarded(pane, " ; ".join(commands))
+
+
+class Mirror:
+    def __init__(self, socket_path, read_only=False):
+        self.socket = os.path.realpath(socket_path)
+        self.socket_stamp = socket_identity(self.socket)
+        self.server = None
+        self.server_birth = None
+        self.pane = None
+        self.root_birth = None
+        self.read_only = read_only
+        self.failed = False
+        self.inflight = False
+        self.last_snapshot = 0.0
+        self.env = dict(os.environ)
+        self.env.pop("TMUX", None)
+        self.env.pop("TMUX_PANE", None)
+
+    def preflight(self):
+        if socket_identity(self.socket) != self.socket_stamp:
+            raise Refused("socket replaced")
+        if self.server is not None:
+            if process_identity(self.server)[0] != self.server_birth:
+                raise Refused("server identity changed")
+        if self.pane is not None:
+            if process_identity(self.pane.root)[0] != self.root_birth:
+                raise Refused("pane process identity changed")
+
+    def call(self, command, sending=False):
+        if self.failed or self.inflight:
+            raise Refused("mirror is closed; input is not retried")
+        self.inflight = True
+        try:
+            self.preflight()
+            output = bounded_run(["tmux", "-N", "-u", "-S", self.socket] + command,
+                                 env=self.env)
+            self.preflight()
+            if output == b"MTT_REFUSED\n":
+                raise Refused("source identity, mode, sync, or capture/send hook guard refused")
+            return output.decode("utf-8", errors="strict")
+        except (Refused, OSError, UnicodeError, subprocess.TimeoutExpired) as exc:
+            self.failed = True
+            if sending:
+                raise Refused("delivery uncertain or refused; forwarding stopped, never retried") from exc
+            raise Refused(str(exc)) from exc
+        finally:
+            self.inflight = False
+
+    def inventory(self):
+        if self.server is not None:
+            raise Refused("inventory may only be resolved once")
+        result = self.call(["list-panes", "-a", "-F", META_FORMAT])
+        panes = [Pane.parse(line) for line in result.splitlines()]
+        if not panes or len({pane.server for pane in panes}) != 1:
+            raise Refused("no unambiguous existing server")
+        self.server = panes[0].server
+        self.server_birth = process_identity(self.server)[0]
+        self.preflight()
+        return panes
+
+    def pin(self, pane):
+        if self.pane is not None or pane.server != self.server:
+            raise Refused("target cannot be changed")
+        pane.safe()
+        refuse_self(pane, self.socket)
+        self.pane = pane
+        self.root_birth = process_identity(pane.root)[0]
+        return self.metadata()
+
+    def metadata(self):
+        body = 'display-message -p -t {} "{}"'.format(self.pane.target, META_FORMAT)
+        value = self.call(guarded(self.pane, body))
+        pane = Pane.parse(value.rstrip("\n"))
+        if pane.identity != self.pane.identity:
+            raise Refused("pane identity changed")
+        pane.safe()
+        return pane
+
+    def snapshot(self):
+        delay = self.last_snapshot + SNAPSHOT_INTERVAL - time.monotonic()
+        if delay > 0:
+            time.sleep(delay)
+        self.last_snapshot = time.monotonic()
+        body = ('display-message -p -t {0} "{1}" ; '
+                'capture-pane -p -N -t {0} ; display-message -p MTT_FRAME').format(
+                    self.pane.target, META_FORMAT)
+        output = self.call(guarded(self.pane, body))
+        lines = output.split("\n")
+        pane = Pane.parse(lines[0])
+        if pane.identity != self.pane.identity:
+            raise Refused("pane identity changed")
+        pane.safe()
+        if len(lines) != pane.height + 3 or lines[-2:] != ["MTT_FRAME", ""]:
+            raise Refused("incomplete frame")
+        rows = lines[1:-2]
+        if any(ord(c) < 32 or ord(c) == 127 for row in rows for c in row):
+            raise Refused("unsupported control character in frame")
+        return pane, rows
+
+    def send(self, events):
+        if self.read_only:
+            raise Refused("read-only mirror cannot send input")
+        command = input_command(self.pane, events)
+        if self.call(command, sending=True) != "MTT_SENT\n":
+            self.failed = True
+            raise Refused("no delivery acknowledgement; forwarding stopped, never retried")
+
+
+@dataclass
+class Viewport:
+    top: int = 0
+    left: int = 0
+    follow: bool = True
+
+    def fit(self, pane, rows, cols):
+        rows, cols = max(1, rows), max(1, cols)
+        if self.follow:
+            self.top = min(self.top, pane.y)
+            self.left = min(self.left, pane.x)
+            self.top = max(self.top, pane.y - rows + 1)
+            self.left = max(self.left, pane.x - cols + 1)
+        self.top = max(0, min(self.top, pane.height - rows))
+        self.left = max(0, min(self.left, pane.width - cols))
+
+    def pan(self, key, rows):
+        if key == curses.KEY_HOME:
+            self.top = self.left = 0
+        elif key in (curses.KEY_UP, curses.KEY_DOWN):
+            self.top += -1 if key == curses.KEY_UP else 1
+        elif key in (curses.KEY_LEFT, curses.KEY_RIGHT):
+            self.left += -1 if key == curses.KEY_LEFT else 1
+        elif key in (curses.KEY_PPAGE, curses.KEY_NPAGE):
+            self.top += (-1 if key == curses.KEY_PPAGE else 1) * max(1, rows)
+
+
+class Controls:
+    def __init__(self, read_only=False):
+        self.read_only = read_only
+        self.view = Viewport()
+        self.prefix = False
+        self.escape = ""
+        self.escape_at = 0.0
+        self.paste = ""
+        self.paste_size = 0
+        self.pasting = False
+        self.paste_at = 0.0
+        self.quit = False
+
+    @property
+    def interactive(self):
+        return self.view.follow and not self.read_only
+
+    def tick(self, now):
+        if self.pasting and now - self.paste_at > TIMEOUT:
+            raise Refused("incomplete bracketed paste; nothing from this paste was sent")
+        if self.escape and now - self.escape_at > 0.05:
+            if self.escape != "\x1b":
+                raise Refused("incomplete paste delimiter; forwarding stopped")
+            pending, self.escape = self.escape, ""
+            return [pending.encode("utf-8")] if self.interactive else []
+        return []
+
+    def key(self, key, rows, now):
+        if self.pasting:
+            if not isinstance(key, str):
+                raise Refused("unsupported bracketed paste; nothing from this paste was sent")
+            self.paste += key
+            self.paste_size += len(key.encode("utf-8"))
+            if self.paste_size + len(PASTE_START) > INPUT_LIMIT:
+                raise Refused("paste exceeds 4096 bytes; nothing from this paste was sent")
+            if self.paste.endswith(PASTE_END):
+                frame = (PASTE_START + self.paste).encode("utf-8")
+                self.pasting, self.paste = False, ""
+                return [frame] if self.interactive else []
+            return []
+        if self.escape:
+            if isinstance(key, str):
+                candidate = self.escape + key
+                if PASTE_START.startswith(candidate):
+                    self.escape = candidate
+                    if candidate == PASTE_START:
+                        self.escape = ""
+                        self.prefix = False
+                        self.pasting, self.paste_at = True, now
+                        self.paste_size = 0
+                    return []
+            pending, self.escape = self.escape, ""
+            result = [pending.encode("utf-8")] if self.interactive else []
+            return result + self.key(key, rows, now)
+        if key == "\x1b":
+            self.escape, self.escape_at = key, now
+            return []
+        if self.prefix:
+            self.prefix = False
+            if key == "q":
+                self.quit = True
+            elif key == "p":
+                self.view.follow = False
+            elif key == "f":
+                self.view.follow = True
+            elif key == PREFIX and self.interactive:
+                return [PREFIX.encode()]
+            return []
+        if key == PREFIX:
+            self.prefix = True
+            return []
+        if not self.view.follow:
+            self.view.pan(key, rows)
+            return []
+        if not self.interactive:
+            return []
+        if isinstance(key, str):
+            return [key.encode("utf-8")]
+        if key in NAMED_KEYS:
+            return [NAMED_KEYS[key]]
+        return []
+
+
+def make_pad(pane, rows):
+    pad = curses.newpad(pane.height, pane.width)
+    pad.erase()
+    for y, row in enumerate(rows):
+        try:
+            # Curses, not Python string offsets, owns cell width and combining.
+            pad.addstr(y, 0, row)
+        except curses.error:
+            # Writing the bottom-right cell succeeds but cannot advance.
+            if y != pane.height - 1 or pad.getyx() != (y, pane.width - 1):
+                raise Refused("terminal cannot render source row")
+    return pad
+
+
+def draw(screen, pad, pane, controls):
+    height, width = screen.getmaxyx()
+    if height < 2 or width < 2:
+        raise Refused("viewer terminal must be at least 2x2")
+    rows = height - 1
+    view = controls.view
+    view.fit(pane, rows, width)
+    screen.erase()
+    state = "pan" if not view.follow else ("read-only" if controls.read_only else "input")
+    status = "mtt {} {}x{} {} {},{}".format(
+        pane.pane, pane.width, pane.height, state, view.left, view.top)
+    screen.addnstr(height - 1, 0, status, width - 1, curses.A_REVERSE)
+    screen.noutrefresh()
+    visible = (view.top <= pane.y < view.top + rows
+               and view.left <= pane.x < view.left + width)
+    pad.move(pane.y, pane.x)
+    pad.leaveok(not visible)
+    try:
+        curses.curs_set(1 if pane.cursor and visible else 0)
+    except curses.error:
+        pass
+    pad.noutrefresh(view.top, view.left, 0, 0,
+                    min(rows, pane.height - view.top) - 1,
+                    min(width, pane.width - view.left) - 1)
+    curses.doupdate()
+
+
+def viewer(screen, mirror):
+    curses.raw()
+    curses.noecho()
+    curses.nonl()
+    curses.set_escdelay(25)
+    screen.keypad(True)
+    screen.timeout(20)
+    controls = Controls(mirror.read_only)
+    pane, rows = mirror.snapshot()
+    pad = make_pad(pane, rows)
+    draw(screen, pad, pane, controls)
+    curses.flushinp()
+    next_frame = time.monotonic() + SNAPSHOT_INTERVAL
+    # Only local terminal modes. The complete bounded frame is sent as bytes.
+    sys.stdout.write("\x1b[?2004h")
+    sys.stdout.flush()
+    try:
+        while not controls.quit:
+            now = time.monotonic()
+            if now >= next_frame:
+                pane, rows = mirror.snapshot()
+                pad = make_pad(pane, rows)
+                next_frame = time.monotonic() + SNAPSHOT_INTERVAL
+            events = controls.tick(now)
+            for _ in range(64):
+                screen.keypad(not controls.pasting)
+                try:
+                    key = screen.get_wch()
+                except curses.error:
+                    break
+                if key == curses.KEY_RESIZE:
+                    break
+                was_follow = controls.view.follow
+                events.extend(controls.key(key, screen.getmaxyx()[0] - 1, time.monotonic()))
+                if controls.quit or controls.view.follow != was_follow:
+                    events.clear()
+                    curses.flushinp()
+                    break
+                if events:
+                    # One decoded key or one complete paste frame per batch.
+                    break
+            if events and controls.interactive and not controls.quit:
+                mirror.send(events)
+            draw(screen, pad, pane, controls)
+    finally:
+        curses.flushinp()
+        sys.stdout.write("\x1b[?2004l")
+        sys.stdout.flush()
+
+
+def picker(screen, panes):
+    screen.keypad(True)
+    selected = 0
+    while True:
+        height, width = screen.getmaxyx()
+        screen.erase()
+        first = max(0, selected - max(1, height - 2))
+        for y, pane in enumerate(panes[first:first + max(1, height - 1)]):
+            label = "{}  {}  {}x{}".format(pane.pane, pane.label, pane.width, pane.height)
+            screen.addnstr(y, 0, label, max(0, width - 1),
+                           curses.A_REVERSE if first + y == selected else 0)
+        screen.refresh()
+        key = screen.get_wch()
+        if key in ("q", "\x1b"):
+            return None
+        if key in ("\n", "\r", curses.KEY_ENTER):
+            return panes[selected]
+        if key == curses.KEY_UP:
+            selected = max(0, selected - 1)
+        elif key == curses.KEY_DOWN:
+            selected = min(len(panes) - 1, selected + 1)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        epilog=("Ctrl-] p: pan (input off); arrows/PageUp/PageDown/Home pan locally. "
+                "Ctrl-] f: follow/resume; Ctrl-] q: quit viewer; Ctrl-] Ctrl-]: literal prefix. "
+                "Ctrl-C and normal keys go to the source. Bracketed pastes up to 4096 bytes "
+                "are sent as complete literal frames; incomplete/oversize pastes close the viewer. "
+                "Newlines in typed or pasted input retain their normal behavior; no Enter is added. "
+                "Monochrome current screen only, no history, mouse, or color fidelity."),
+    )
+    parser.add_argument("target", nargs="?", help="exact pane ID or session:window.pane")
+    parser.add_argument("--socket", help="existing tmux socket (default: TMUX or default socket)")
+    parser.add_argument("--read-only", action="store_true")
+    parser.add_argument("--check", action="store_true", help="metadata-only check; requires an exact target")
+    args = parser.parse_args()
+    if args.check and not args.target:
+        parser.error("--check requires an exact target")
+    if not args.check and not (sys.stdin.isatty() and sys.stdout.isatty()):
+        parser.error("viewer/picker requires a terminal; use --check for metadata")
+    try:
+        locale.setlocale(locale.LC_ALL, "")
+        if not args.check and locale.getpreferredencoding(False).lower().replace("-", "") != "utf8":
+            raise Refused("viewer requires a UTF-8 locale")
+        inherited = os.environ.get("TMUX", "").rsplit(",", 2)
+        socket_path = args.socket or (inherited[0] if len(inherited) == 3 else
+            os.path.join(os.environ.get("TMUX_TMPDIR", "/tmp"),
+                         "tmux-{}".format(os.getuid()), "default"))
+        mirror = Mirror(socket_path, args.read_only)
+        panes = mirror.inventory()
+        pane = resolve(panes, args.target) if args.target else curses.wrapper(picker, panes)
+        if pane is None:
+            return 0
+        pane = mirror.pin(pane)
+        if args.check:
+            print("{} {}x{}".format(pane.pane, pane.width, pane.height))
+            return 0
+        def stop(_signum, _frame):
+            raise Refused("viewer interrupted")
+        for signum in (signal.SIGTERM, signal.SIGHUP):
+            signal.signal(signum, stop)
+        curses.wrapper(viewer, mirror)
+        return 0
+    except (Refused, OSError, curses.error, ValueError, KeyboardInterrupt) as exc:
+        print("mtt: {}".format(exc), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/linux-server-refresh-user-test.sh
+++ b/tests/linux-server-refresh-user-test.sh
@@ -27,6 +27,7 @@ create_test_repo() {
       bin/gh \
       bin/ghx \
       bin/linux-server-bootstrap \
+      bin/mtt \
       bin/tt
   ) | (
     cd "$destination"
@@ -318,6 +319,10 @@ done
 [[ -x "$home/.local/share/pnpm/pnpx" ]]
 [[ ! -e "$home/.local/share/pnpm/bin" ]]
 [[ "$(readlink "$home/.local/bin/codex")" == "$test_repo/bin/codex" ]]
+[[ "$(readlink "$home/.local/bin/mtt")" == "$test_repo/bin/mtt" ]]
+[[ -x "$home/.local/bin/mtt" ]]
+mtt_help="$(HOME="$home" PATH=/usr/bin:/bin "$home/.local/bin/mtt" --help)"
+[[ "$mtt_help" == *--check* && "$mtt_help" == *--read-only* ]]
 for absent in \
   "$home/.local/bin/quickssh" \
   "$home/.local/bin/op" \
@@ -534,6 +539,12 @@ case "$DRIFT_CASE" in
   source-world-mode)
     chmod 0777 "$repo_root/bin/dotfiles-audit"
     ;;
+  mtt-source-missing)
+    rm "$repo_root/bin/mtt"
+    ;;
+  mtt-source-world-mode)
+    chmod 0777 "$repo_root/bin/mtt"
+    ;;
   source-symlink)
     rm "$repo_root/bin/dotfiles-audit"
     ln -s "$OUTSIDE_ROOT/marker" "$repo_root/bin/dotfiles-audit"
@@ -621,7 +632,7 @@ for case_name in \
   home terminal-parent outside \
   nested-symlink nested-type nested-owner world-mode repo-world-mode non-traversable \
   source-parent-symlink source-parent-file source-parent-owner source-parent-world-mode \
-  source-world-mode source-symlink source-hardlink \
+  source-world-mode source-symlink source-hardlink mtt-source-missing mtt-source-world-mode \
   chmod-failure-root chmod-failure-bin chmod-failure-first-source \
   pnpm-file pnpx-symlink pnpm-owner; do
   case_home="$temporary/drift-$case_name"
@@ -790,6 +801,12 @@ for case_name in \
       ;;
     source-world-mode)
       [[ "$(mode "$case_repo/bin/dotfiles-audit")" == 777 ]]
+      ;;
+    mtt-source-missing)
+      [[ ! -e "$case_repo/bin/mtt" ]]
+      ;;
+    mtt-source-world-mode)
+      [[ "$(mode "$case_repo/bin/mtt")" == 777 ]]
       ;;
     source-symlink)
       [[ "$(readlink "$case_repo/bin/dotfiles-audit")" == \

--- a/tests/mtt-test.py
+++ b/tests/mtt-test.py
@@ -223,33 +223,78 @@ class ControlsAndCells(unittest.TestCase):
         return result
 
     def test_local_controls(self):
-        controls = mtt.Controls()
-        self.assertEqual(self.feed(controls, "\x1dp"), [])
-        self.assertFalse(controls.interactive)
-        self.assertEqual(self.feed(controls, "not sent"), [])
-        self.feed(controls, "\x1df")
-        self.assertTrue(controls.interactive)
-        self.assertEqual(self.feed(controls, "\x1d\x1d"), [b"\x1d"])
-        self.feed(controls, "\x1dq")
-        self.assertTrue(controls.quit)
+        for prefix in ("\x02", "\x1d"):
+            with self.subTest(prefix=repr(prefix)):
+                controls = mtt.Controls()
+                self.assertEqual(self.feed(controls, prefix + "p"), [])
+                self.assertFalse(controls.interactive)
+                self.assertEqual(self.feed(controls, "not sent" + prefix * 2), [])
+                self.assertEqual(controls.key(curses.KEY_RIGHT, 9, 1), [])
+                self.assertEqual(controls.view.left, 1)
+                self.assertEqual(self.feed(controls, prefix + "f"), [])
+                self.assertTrue(controls.interactive)
+                self.assertEqual(self.feed(controls, prefix * 2), [prefix.encode()])
+
+    def test_exit_aliases(self):
+        for prefix in ("\x02", "\x1d"):
+            for action in ("d", "q"):
+                for read_only in (False, True):
+                    with self.subTest(prefix=repr(prefix), action=action, read_only=read_only):
+                        controls = mtt.Controls(read_only)
+                        self.assertEqual(self.feed(controls, prefix + action), [])
+                        self.assertTrue(controls.quit)
+                        self.assertFalse(controls.prefix)
+
+    def test_mixed_prefixes_and_unknown_actions_are_consumed(self):
+        for prefix, other in (("\x02", "\x1d"), ("\x1d", "\x02")):
+            for action in (other, "x", curses.KEY_UP):
+                with self.subTest(prefix=repr(prefix), action=repr(action)):
+                    controls = mtt.Controls()
+                    self.assertEqual(self.feed(controls, prefix), [])
+                    self.assertEqual(controls.prefix, prefix)
+                    self.assertEqual(controls.key(action, 9, 1), [])
+                    self.assertFalse(controls.prefix)
+                    self.assertFalse(controls.quit)
+                    self.assertTrue(controls.interactive)
+                    self.assertEqual(self.feed(controls, "q"), [b"q"])
 
     def test_readonly_cannot_resume_input(self):
-        controls = mtt.Controls(True)
-        self.feed(controls, "\x1dp\x1df")
-        self.assertFalse(controls.interactive)
-        self.assertEqual(self.feed(controls, "a\x03"), [])
+        for prefix in ("\x02", "\x1d"):
+            with self.subTest(prefix=repr(prefix)):
+                controls = mtt.Controls(True)
+                self.feed(controls, prefix + "p" + prefix + "f")
+                self.assertTrue(controls.read_only)
+                self.assertFalse(controls.interactive)
+                self.assertEqual(self.feed(controls, "a\x03" + prefix * 2), [])
 
     def test_normal_keys(self):
         controls = mtt.Controls()
         self.assertEqual(self.feed(controls, "\x03\x7f\r"), [b"\x03", b"\x7f", b"\r"])
+        self.assertEqual(self.feed(controls, "dqpf"), [b"d", b"q", b"p", b"f"])
+        self.assertFalse(controls.quit)
+        self.assertTrue(controls.interactive)
         self.assertEqual(controls.key(curses.KEY_UP, 9, 1), ["Up"])
 
     def test_paste_preserves_prefix_and_newlines(self):
         controls = mtt.Controls()
-        frame = mtt.PASTE_START + "a\x1dq\nb\x1b[A" + mtt.PASTE_END
+        frame = mtt.PASTE_START + "a\x02d\x02p\x1dq\x1dp\nb\x1b[A" + mtt.PASTE_END
         self.assertEqual(self.feed(controls, frame), [frame.encode()])
         self.assertFalse(controls.quit)
         self.assertFalse(controls.prefix)
+        self.assertTrue(controls.interactive)
+
+    def test_paste_clears_pending_prefix(self):
+        for prefix in ("\x02", "\x1d"):
+            with self.subTest(prefix=repr(prefix)):
+                controls = mtt.Controls()
+                frame = mtt.PASTE_START + "\x02q\x1dd\n" + mtt.PASTE_END
+                self.assertEqual(self.feed(controls, prefix + mtt.PASTE_START), [])
+                self.assertFalse(controls.prefix)
+                self.assertTrue(controls.pasting)
+                self.assertEqual(self.feed(controls, "\x02q\x1dd\n" + mtt.PASTE_END),
+                                 [frame.encode()])
+                self.assertFalse(controls.quit)
+                self.assertEqual(self.feed(controls, "d"), [b"d"])
 
     def test_paste_bound_and_timeout(self):
         for suffix in ("x" * 4091,):
@@ -262,9 +307,17 @@ class ControlsAndCells(unittest.TestCase):
             controls.tick(4)
 
     def test_paste_readonly_discard(self):
-        controls = mtt.Controls(True)
-        self.assertEqual(self.feed(controls, mtt.PASTE_START + "\x1dq" + mtt.PASTE_END), [])
-        self.assertFalse(controls.quit)
+        for prefix in ("\x02", "\x1d"):
+            for read_only in (False, True):
+                with self.subTest(prefix=repr(prefix), read_only=read_only):
+                    controls = mtt.Controls(read_only)
+                    if not read_only:
+                        self.feed(controls, prefix + "p")
+                    frame = mtt.PASTE_START + "\x02q\x1dd" + mtt.PASTE_END
+                    self.assertEqual(self.feed(controls, prefix + frame), [])
+                    self.assertFalse(controls.quit)
+                    self.assertFalse(controls.prefix)
+                    self.assertFalse(controls.interactive)
 
     def test_escape_timeout(self):
         controls = mtt.Controls()

--- a/tests/mtt-test.py
+++ b/tests/mtt-test.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Focused unit tests; no tmux server is contacted."""
+
+import curses
+from dataclasses import replace
+import importlib.machinery
+import importlib.util
+import os
+from pathlib import Path
+import stat
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+loader = importlib.machinery.SourceFileLoader("mtt_unit", str(ROOT / "bin/mtt"))
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mtt = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = mtt
+loader.exec_module(mtt)
+REAL_SOCKET_IDENTITY = mtt.socket_identity
+REAL_PROCESS_IDENTITY = mtt.process_identity
+LINE = "100\t$0\t@2\t%4\t200\t/dev/pts/3\tcockpit\t2\t1\t85\t30\t84\t29\t1\t0\t0\t0"
+PANE = mtt.Pane.parse(LINE)
+
+
+class Guards(unittest.TestCase):
+    def setUp(self):
+        self.socket = patch.object(mtt, "socket_identity", return_value=(1000, 1, 2))
+        self.birth = patch.object(mtt, "process_identity", return_value=("birth", 1))
+        self.socket.start()
+        self.birth.start()
+        self.addCleanup(self.socket.stop)
+        self.addCleanup(self.birth.stop)
+        self.mirror = mtt.Mirror("/tmp/fixture/socket")
+        self.mirror.server, self.mirror.server_birth = 100, "birth"
+        self.mirror.pane, self.mirror.root_birth = PANE, "birth"
+
+    def test_exact_targets(self):
+        for target in ("%4", "cockpit:2.1"):
+            self.assertEqual(mtt.resolve([PANE], target), PANE)
+        for target in ("cock", "cockpit", "2.1", "%04", "%4;send-keys Enter"):
+            with self.subTest(target=target), self.assertRaises(mtt.Refused):
+                mtt.resolve([PANE], target)
+
+    def test_ambiguous_linked_pane(self):
+        other = replace(PANE, session="$1", name="other")
+        with self.assertRaises(mtt.Refused):
+            mtt.resolve([PANE, other], "%4")
+        self.assertEqual(mtt.resolve([PANE, other], "other:2.1"), other)
+
+    def test_strict_metadata(self):
+        for index, bad in ((0, "-1"), (1, "$0;"), (2, "@x"), (3, "%-1"),
+                           (4, "2x"), (5, "/tmp/tty"), (9, "0"), (10, "1001"),
+                           (11, "86"), (12, "30"), (13, "2"), (16, "on")):
+            fields = LINE.split("\t")
+            fields[index] = bad
+            with self.subTest(index=index), self.assertRaises(mtt.Refused):
+                mtt.Pane.parse("\t".join(fields))
+
+    def test_wrap_pending_cursor(self):
+        self.assertEqual(mtt.Pane.parse(LINE.replace("\t84\t", "\t85\t")).x, 84)
+
+    def test_dead_mode_sync(self):
+        for field in ("dead", "mode", "sync"):
+            with self.subTest(field=field), self.assertRaises(mtt.Refused):
+                replace(PANE, **{field: 1}).safe()
+
+    def test_socket_replacement(self):
+        with patch.object(mtt, "socket_identity", return_value=(1000, 1, 3)):
+            with self.assertRaisesRegex(mtt.Refused, "socket replaced"):
+                self.mirror.preflight()
+
+    def test_disappearance(self):
+        with patch.object(mtt, "process_identity", side_effect=mtt.Refused("gone")):
+            with self.assertRaises(mtt.Refused):
+                self.mirror.preflight()
+
+    def test_pid_reuse(self):
+        for births in ([("new", 1)], [("birth", 1), ("new", 1)]):
+            with patch.object(mtt, "process_identity", side_effect=births):
+                with self.assertRaisesRegex(mtt.Refused, "identity changed"):
+                    self.mirror.preflight()
+
+    def test_socket_type_and_owner(self):
+        with patch.object(mtt.os, "stat") as probe:
+            for mode, uid in ((stat.S_IFREG, os.getuid()), (stat.S_IFSOCK, os.getuid() + 1)):
+                probe.return_value = Mock(st_mode=mode, st_uid=uid)
+                with self.subTest(mode=mode), self.assertRaises(mtt.Refused):
+                    # Test the real function, not setUp's patch.
+                    REAL_SOCKET_IDENTITY("/tmp/fixture/socket")
+
+    def test_self_same_server(self):
+        with patch.dict(os.environ, {"TMUX": "/tmp/fixture/socket,100,0", "TMUX_PANE": "%4"}):
+            with self.assertRaisesRegex(mtt.Refused, "viewer's pane"):
+                mtt.refuse_self(PANE, "/tmp/fixture/socket")
+
+    def test_other_server_same_pane_id(self):
+        with patch.dict(os.environ, {"TMUX": "/tmp/other/socket,101,0", "TMUX_PANE": "%4"}):
+            with patch.object(mtt.os, "isatty", return_value=False):
+                mtt.refuse_self(PANE, "/tmp/fixture/socket")
+
+    def test_self_tty(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(mtt.os, "isatty", return_value=True):
+                with patch.object(mtt.os, "ttyname", return_value=PANE.tty):
+                    with self.assertRaisesRegex(mtt.Refused, "TTY"):
+                        mtt.refuse_self(PANE, "/tmp/fixture/socket")
+
+    def test_self_ancestor(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(mtt.os, "isatty", return_value=False):
+                with patch.object(mtt, "process_identity", return_value=("birth", PANE.root)):
+                    with self.assertRaisesRegex(mtt.Refused, "ancestor"):
+                        mtt.refuse_self(PANE, "/tmp/fixture/socket")
+
+    def test_guard_fields_and_hooks(self):
+        guard = mtt.condition(PANE)
+        for name in ("pid", "session_id", "window_id", "pane_id", "pane_pid",
+                     "pane_tty", "pane_dead", "pane_in_mode", "synchronize-panes",
+                     "after-capture-pane", "after-send-keys"):
+            self.assertIn("#{" + name + "}", guard)
+        self.assertIn("#{==:#{after-send-keys},}", guard)
+
+    def test_input_quoting(self):
+        payload = b"'; run-shell \"bad\"; #{}\x00\x03\r\n\x1d"
+        command = mtt.input_command(PANE, [payload, "Up"])
+        self.assertEqual(command[:4], ["if-shell", "-F", "-t", "$0:@2.%4"])
+        self.assertNotIn("run-shell", command[5])
+        self.assertIn(" ".join("{:02x}".format(b) for b in payload), command[5])
+        self.assertTrue(command[5].endswith("display-message -p MTT_SENT"))
+        self.assertNotIn("Enter", command[5])
+        self.assertNotIn("-b", command)
+
+    def test_named_key_allowlist_and_bounds(self):
+        for events in ([], ["PasteStart"], ["Enter;kill-pane"], [b"x" * 4097], ["Up"] * 65):
+            with self.subTest(events=str(events)[:50]), self.assertRaises(mtt.Refused):
+                mtt.input_command(PANE, events)
+
+    def test_read_only(self):
+        self.mirror.read_only = True
+        with patch.object(self.mirror, "call") as call:
+            with self.assertRaisesRegex(mtt.Refused, "read-only"):
+                self.mirror.send([b"x"])
+            call.assert_not_called()
+
+    def test_timeout_no_replay(self):
+        with patch.object(mtt, "bounded_run", side_effect=mtt.Refused("timed out")) as run:
+            with self.assertRaisesRegex(mtt.Refused, "never retried"):
+                self.mirror.send([b"x"])
+            with self.assertRaisesRegex(mtt.Refused, "not retried"):
+                self.mirror.send([b"x"])
+            self.assertEqual(run.call_count, 1)
+
+    def test_ack_required(self):
+        with patch.object(mtt, "bounded_run", return_value=b"") as run:
+            with self.assertRaisesRegex(mtt.Refused, "acknowledgement"):
+                self.mirror.send([b"x"])
+            with self.assertRaises(mtt.Refused):
+                self.mirror.send([b"y"])
+            self.assertEqual(run.call_count, 1)
+
+    def test_explicit_socket_and_no_server_creation(self):
+        with patch.object(mtt, "bounded_run", return_value=b"MTT_SENT\n") as run:
+            self.mirror.send([b"x"])
+            self.assertEqual(run.call_args.args[0][:5],
+                             ["tmux", "-N", "-u", "-S", "/tmp/fixture/socket"])
+            self.assertNotIn("TMUX", run.call_args.kwargs["env"])
+
+    def test_one_inflight(self):
+        self.mirror.inflight = True
+        with self.assertRaises(mtt.Refused):
+            self.mirror.call(["list-panes"])
+
+    def test_metadata_has_no_capture_or_send(self):
+        with patch.object(self.mirror, "call", return_value=LINE + "\n") as call:
+            self.assertEqual(self.mirror.metadata(), PANE)
+            body = call.call_args.args[0][5]
+            self.assertNotIn("capture-pane", body)
+            self.assertNotIn("send-keys", body)
+
+    def test_guarded_snapshot_rows(self):
+        rows = ["abc  "] + [""] * 29
+        response = LINE + "\n" + "\n".join(rows) + "\nMTT_FRAME\n"
+        with patch.object(self.mirror, "call", return_value=response) as call:
+            self.assertEqual(self.mirror.snapshot(), (PANE, rows))
+            body = call.call_args.args[0][5]
+            self.assertIn("capture-pane -p -N -t $0:@2.%4", body)
+            self.assertNotIn(" -e", body)
+            self.assertNotIn(" -J", body)
+
+    def test_snapshot_missing_or_changed(self):
+        for response in ("MTT_REFUSED\n", LINE + "\nMTT_FRAME\n",
+                         LINE.replace("%4", "%5") + "\n" * 31 + "MTT_FRAME\n"):
+            with patch.object(self.mirror, "call", return_value=response):
+                with self.assertRaises(mtt.Refused):
+                    self.mirror.snapshot()
+
+    def test_output_and_time_bounds(self):
+        with self.assertRaisesRegex(mtt.Refused, "output exceeded"):
+            mtt.bounded_run([sys.executable, "-c", "print('x' * 4096)"], limit=32)
+        with self.assertRaisesRegex(mtt.Refused, "timed out"):
+            mtt.bounded_run([sys.executable, "-c", "import time; time.sleep(2)"], timeout=0.05)
+
+    def test_local_process_birth(self):
+        born, parent = REAL_PROCESS_IDENTITY(os.getpid())
+        self.assertTrue(born)
+        self.assertEqual(parent, os.getppid())
+
+    def test_macos_birth_fallback(self):
+        with patch.object(mtt.sys, "platform", "darwin"):
+            with patch.object(mtt, "bounded_run", return_value=b" 1 Thu Sep 10 01:02:03 2026\n"):
+                self.assertEqual(REAL_PROCESS_IDENTITY(123),
+                                 ("Thu Sep 10 01:02:03 2026", 1))
+
+
+class ControlsAndCells(unittest.TestCase):
+    def feed(self, controls, text):
+        result = []
+        for key in text:
+            result.extend(controls.key(key, 9, 1.0))
+        return result
+
+    def test_local_controls(self):
+        controls = mtt.Controls()
+        self.assertEqual(self.feed(controls, "\x1dp"), [])
+        self.assertFalse(controls.interactive)
+        self.assertEqual(self.feed(controls, "not sent"), [])
+        self.feed(controls, "\x1df")
+        self.assertTrue(controls.interactive)
+        self.assertEqual(self.feed(controls, "\x1d\x1d"), [b"\x1d"])
+        self.feed(controls, "\x1dq")
+        self.assertTrue(controls.quit)
+
+    def test_readonly_cannot_resume_input(self):
+        controls = mtt.Controls(True)
+        self.feed(controls, "\x1dp\x1df")
+        self.assertFalse(controls.interactive)
+        self.assertEqual(self.feed(controls, "a\x03"), [])
+
+    def test_normal_keys(self):
+        controls = mtt.Controls()
+        self.assertEqual(self.feed(controls, "\x03\x7f\r"), [b"\x03", b"\x7f", b"\r"])
+        self.assertEqual(controls.key(curses.KEY_UP, 9, 1), ["Up"])
+
+    def test_paste_preserves_prefix_and_newlines(self):
+        controls = mtt.Controls()
+        frame = mtt.PASTE_START + "a\x1dq\nb\x1b[A" + mtt.PASTE_END
+        self.assertEqual(self.feed(controls, frame), [frame.encode()])
+        self.assertFalse(controls.quit)
+        self.assertFalse(controls.prefix)
+
+    def test_paste_bound_and_timeout(self):
+        for suffix in ("x" * 4091,):
+            controls = mtt.Controls()
+            with self.assertRaisesRegex(mtt.Refused, "exceeds"):
+                self.feed(controls, mtt.PASTE_START + suffix)
+        controls = mtt.Controls()
+        self.feed(controls, mtt.PASTE_START + "unfinished")
+        with self.assertRaisesRegex(mtt.Refused, "incomplete"):
+            controls.tick(4)
+
+    def test_paste_readonly_discard(self):
+        controls = mtt.Controls(True)
+        self.assertEqual(self.feed(controls, mtt.PASTE_START + "\x1dq" + mtt.PASTE_END), [])
+        self.assertFalse(controls.quit)
+
+    def test_escape_timeout(self):
+        controls = mtt.Controls()
+        self.feed(controls, "\x1b")
+        self.assertEqual(controls.tick(1.1), [b"\x1b"])
+
+    def test_partial_paste_delimiter_not_forwarded(self):
+        controls = mtt.Controls()
+        self.assertEqual(self.feed(controls, "\x1b[20"), [])
+        with self.assertRaisesRegex(mtt.Refused, "incomplete paste delimiter"):
+            controls.tick(1.1)
+
+    def test_viewport_follow_and_bounds(self):
+        view = mtt.Viewport()
+        view.fit(PANE, 9, 20)
+        self.assertEqual((view.top, view.left), (21, 65))
+        view.fit(PANE, 50, 120)
+        self.assertEqual((view.top, view.left), (0, 0))
+        view.follow = False
+        view.top, view.left = 999, -3
+        view.fit(PANE, 9, 20)
+        self.assertEqual((view.top, view.left), (21, 0))
+        view.pan(curses.KEY_HOME, 9)
+        self.assertEqual((view.top, view.left), (0, 0))
+        view.pan(curses.KEY_NPAGE, 9)
+        view.pan(curses.KEY_RIGHT, 9)
+        self.assertEqual((view.top, view.left), (9, 1))
+
+    def test_whole_rows_no_string_cell_slicing(self):
+        rows = ["A\u754ce\u0301  "] + [""] * 29
+        pad = Mock()
+        with patch.object(mtt.curses, "newpad", return_value=pad) as new:
+            self.assertIs(mtt.make_pad(PANE, rows), pad)
+            new.assert_called_once_with(30, 85)
+            pad.erase.assert_called_once()
+            self.assertEqual(pad.addstr.call_args_list[0].args, (0, 0, rows[0]))
+            self.assertEqual(pad.addstr.call_count, 30)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/mtt-tmux-test.py
+++ b/tests/mtt-tmux-test.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+"""Real-PTY fixtures. Run ONLY inside the documented owned resource sandbox.
+
+tmux provides the rendering oracle; this test does not implement a VT parser.
+All source processes cooperate with task-owned stop files. No kill-server.
+"""
+
+import fcntl
+import importlib.machinery
+import importlib.util
+import json
+import os
+from pathlib import Path
+import pty
+import select
+import signal
+import struct
+import subprocess
+import sys
+import tempfile
+import termios
+import time
+import tty
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SELF = Path(__file__).resolve()
+loader = importlib.machinery.SourceFileLoader("mtt_live", str(ROOT / "bin/mtt"))
+spec = importlib.util.spec_from_loader(loader.name, loader)
+mtt = importlib.util.module_from_spec(spec)
+sys.modules[loader.name] = mtt
+loader.exec_module(mtt)
+
+
+def wait_for(predicate, description, timeout=5):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = predicate()
+        if result:
+            return result
+        time.sleep(0.03)
+    raise AssertionError("timed out: " + description)
+
+
+def source(directory, name):
+    directory = Path(directory)
+    tty.setraw(0)
+    screen = ""
+    with (directory / (name + ".input")).open("ab", buffering=0) as received:
+        while not (directory / (name + ".stop")).exists():
+            request = directory / (name + ".screen")
+            desired = request.read_text() if request.exists() else "full"
+            if desired != screen:
+                screen = desired
+                if name == "sibling":
+                    image = "\x1b[2J\x1b[HPROTECTED-SIBLING"
+                elif desired == "blank":
+                    image = "\x1b[2J\x1b[H"
+                elif desired == "cursor":
+                    image = "\x1b[30;85H"
+                else:
+                    rows = ["SOURCE-{:02d}".format(y) + "." * 75 for y in range(30)]
+                    rows[1] = "a" * 18 + "\u754c" + "e\u0301" + "b" * 64
+                    rows[2] = "c" * 83 + "\u754c"
+                    rows[3] = "d" * 84 + "e\u0301"
+                    rows[4] = " "*85
+                    image = "\x1b[2J" + "".join(
+                        "\x1b[{};1H{}".format(y + 1, row) for y, row in enumerate(rows))
+                    image += "\x1b[H"
+                os.write(1, image.encode())
+            if select.select([0], [], [], 0.02)[0]:
+                chunk = os.read(0, 4096)
+                if not chunk:
+                    break
+                received.write(chunk)
+
+
+def viewer_child(directory, socket_path, target, *options):
+    before = termios.tcgetattr(0)
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "bin/mtt"), "--socket", socket_path, *options]
+        + ([target] if target != "PICKER" else []),
+        timeout=30,
+    )
+    after = termios.tcgetattr(0)
+    Path(directory, "viewer.result").write_text(json.dumps(
+        {"code": result.returncode, "restored": before == after}))
+    while not Path(directory, "viewer.stop").exists():
+        time.sleep(0.02)
+
+
+class IsolatedMirror(unittest.TestCase):
+    def setUp(self):
+        if os.environ.get("MTT_TEST_ISOLATED") != "1":
+            self.fail("refusing real tmux fixtures outside the owned resource sandbox")
+        self.temp = tempfile.TemporaryDirectory(prefix="mtt-fixture-")
+        self.directory = Path(self.temp.name)
+        self.socket = str(self.directory / "socket")
+        self.client = None
+        self.master = self.slave = None
+        self.phone = None
+        self.addCleanup(self.cleanup)
+        self.source = self.tmux(
+            "new-session", "-d", "-s", "source", "-x", "171", "-y", "30",
+            "-P", "-F", "#{pane_id}",
+            sys.executable, str(SELF), "--source", str(self.directory), "source",
+            create=True,
+        ).strip()
+        self.tmux("set-option", "-t", "source", "status", "off")
+        self.tmux("set-option", "-w", "-t", "source:0", "window-size", "manual")
+        self.sibling = self.tmux(
+            "split-window", "-h", "-d", "-t", self.source, "-l", "85",
+            "-P", "-F", "#{pane_id}", sys.executable, str(SELF), "--source",
+            str(self.directory), "sibling",
+        ).strip()
+        wait_for(lambda: "PROTECTED-SIBLING" in self.capture(self.sibling), "source startup")
+        self.assertEqual(self.tmux("display-message", "-p", "-t", self.source,
+                                   "#{pane_width}x#{pane_height}").strip(), "85x30")
+        self.before = self.protected_state()
+
+    def tmux(self, *args, create=False):
+        command = ["tmux", "-u", "-S", self.socket, "-f", "/dev/null"]
+        if not create:
+            command.append("-N")
+        return mtt.bounded_run(command + list(args)).decode()
+
+    def capture(self, pane):
+        return self.tmux("capture-pane", "-p", "-N", "-t", pane)
+
+    def protected_state(self):
+        return self.tmux("list-panes", "-t", "source:0", "-F",
+                         "#{session_id}|#{window_id}|#{pane_id}|#{pane_pid}|#{pane_tty}|"
+                         "#{pane_active}|#{window_active}|#{window_zoomed_flag}|"
+                         "#{window_layout}|#{pane_width}|#{pane_height}|"
+                         "#{window_width}|#{window_height}")
+
+    def cleanup(self):
+        # The fixture owns every path, pane, and client referenced here.
+        try:
+            roots = [int(pid) for pid in self.tmux(
+                "list-panes", "-a", "-F", "#{pane_pid}").splitlines()]
+        except mtt.Refused:
+            roots = []
+        if self.client is not None and not self.result_path.exists():
+            self.keys(b"\x1dq")
+        for name in ("source", "sibling", "viewer"):
+            (self.directory / (name + ".stop")).touch()
+        if self.client is not None:
+            try:
+                self.client.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                self.client.terminate()
+                self.client.wait(timeout=2)
+        def stopped():
+            for pid in roots:
+                try:
+                    mtt.process_identity(pid)
+                except mtt.Refused:
+                    continue
+                return False
+            return True
+        wait_for(stopped, "owned fixture roots stop", timeout=4)
+        for fd in (self.master, self.slave):
+            if fd is not None:
+                os.close(fd)
+        self.temp.cleanup()
+
+    def start_viewer(self, cols=20, rows=10, options=(), picker=False):
+        target = "PICKER" if picker else self.source
+        self.phone = self.tmux(
+            "new-session", "-d", "-s", "phone", "-x", str(cols), "-y", str(rows),
+            "-P", "-F", "#{pane_id}", sys.executable, str(SELF), "--viewer",
+            str(self.directory), self.socket, target, *options,
+        ).strip()
+        self.tmux("set-option", "-t", "phone", "status", "off")
+        self.master, self.slave = pty.openpty()
+        self.resize(cols, rows)
+        self.client = subprocess.Popen(
+            ["tmux", "-N", "-u", "-S", self.socket, "attach-session", "-t", "phone"],
+            stdin=self.slave, stdout=self.slave, stderr=self.slave,
+            start_new_session=True,
+        )
+        os.set_blocking(self.master, False)
+        if picker:
+            wait_for(lambda: "source:0.0" in self.capture(self.phone), "picker")
+        else:
+            wait_for(lambda: "mtt " in self.capture(self.phone)
+                     or self.result_path.exists(), "first frame")
+            self.assertFalse(self.result_path.exists(), self.capture(self.phone))
+        self.drain()
+
+    @property
+    def result_path(self):
+        return self.directory / "viewer.result"
+
+    def drain(self):
+        data = bytearray()
+        while select.select([self.master], [], [], 0)[0]:
+            try:
+                chunk = os.read(self.master, 65536)
+            except OSError:
+                break
+            if not chunk:
+                break
+            data.extend(chunk)
+        return bytes(data)
+
+    def resize(self, cols, rows):
+        fcntl.ioctl(self.slave, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+        if self.client is not None:
+            self.client.send_signal(signal.SIGWINCH)
+
+    def keys(self, value):
+        self.drain()
+        os.write(self.master, value)
+
+    def input(self, name="source"):
+        path = self.directory / (name + ".input")
+        return path.read_bytes() if path.exists() else b""
+
+    def finish(self, expected=0):
+        if not self.result_path.exists():
+            self.keys(b"\x1dq")
+        result = json.loads(wait_for(
+            lambda: self.result_path.read_text() if self.result_path.exists() else "",
+            "viewer exit"))
+        self.assertEqual(result["code"], expected)
+        self.assertTrue(result["restored"], result)
+        self.assertEqual(self.input("sibling"), b"")
+        self.assertEqual(self.protected_state(), self.before)
+
+    def pinned(self):
+        mirror = mtt.Mirror(self.socket)
+        mirror.pin(mtt.resolve(mirror.inventory(), self.source))
+        return mirror
+
+    def test_metadata_exact_and_self(self):
+        command = [sys.executable, str(ROOT / "bin/mtt"), "--socket", self.socket, "--check"]
+        self.assertEqual(mtt.bounded_run(command + [self.source]).decode(),
+                         self.source + " 85x30\n")
+        self.assertEqual(mtt.bounded_run(command + ["source:0.0"]).decode(),
+                         self.source + " 85x30\n")
+        with self.assertRaises(mtt.Refused):
+            mtt.bounded_run(command + ["source"])
+        server = self.tmux("display-message", "-p", "#{pid}").strip()
+        env = dict(os.environ, TMUX=self.socket + "," + server + ",0", TMUX_PANE=self.source)
+        with self.assertRaises(mtt.Refused):
+            mtt.bounded_run(command + [self.source], env=env)
+        self.assertEqual(self.protected_state(), self.before)
+
+    def test_small_large_resize_unicode_blanks(self):
+        self.start_viewer()
+        initial = self.capture(self.phone)
+        self.assertIn("SOURCE-00", initial)
+        self.assertNotIn("PROTECTED-SIBLING", initial)
+        self.assertIn("\u754c", initial)
+        self.keys(b"\x1dp")
+        wait_for(lambda: " pan " in self.capture(self.phone), "crop pan")
+        self.keys(b"\x1bOC" * 19)
+        wait_for(lambda: self.capture(self.phone).splitlines()[1].startswith(" e\u0301"),
+                 "wide glyph clipped at left edge")
+        self.resize(100, 35)
+        wait_for(lambda: "\u0301" in self.capture(self.phone), "larger viewport")
+        wait_for(lambda: self.tmux("display-message", "-p", "-t", self.phone,
+                                  "#{pane_width}x#{pane_height}").strip() == "100x35", "phone resize")
+        source_rows = self.capture(self.source).splitlines()
+        phone_rows = self.capture(self.phone).splitlines()
+        self.assertEqual([row.rstrip() for row in phone_rows[:30]],
+                         [row.rstrip() for row in source_rows])
+        (self.directory / "source.screen").write_text("blank")
+        wait_for(lambda: not self.capture(self.phone).splitlines()[0].strip(), "clear stale cells")
+        self.assertTrue(all(not row.strip() for row in self.capture(self.phone).splitlines()[:30]))
+        self.resize(20, 10)
+        wait_for(lambda: self.tmux("display-message", "-p", "-t", self.phone,
+                                  "#{pane_width}").strip() == "20", "smaller viewport")
+        self.finish()
+
+    def test_cursor_follow_pan_and_input(self):
+        self.start_viewer(cols=40, rows=10)
+        (self.directory / "source.screen").write_text("cursor")
+        wait_for(lambda: "45,21" in self.capture(self.phone), "physical cursor follow")
+        self.keys(b"\x1dp")
+        wait_for(lambda: " pan " in self.capture(self.phone), "pan mode")
+        self.keys(b"\x1bOH")
+        wait_for(lambda: "0,0" in self.capture(self.phone), "pan home")
+        self.keys(b"\x1b[6~")
+        wait_for(lambda: "0,9" in self.capture(self.phone), "pan page")
+        self.keys(b"\x1bOC")
+        wait_for(lambda: "1,9" in self.capture(self.phone), "pan right")
+        self.assertEqual(self.input(), b"")
+        self.keys(b"\x1df")
+        wait_for(lambda: " input " in self.capture(self.phone), "resume input")
+        self.keys(b"a\x7f\x1bOA\x03\x1d\x1d")
+        wait_for(lambda: self.input().endswith(b"\x03\x1d"), "ordinary input")
+        self.assertEqual(self.input(), b"a\x7f\x1b[A\x03\x1d")
+        self.finish()
+
+    def test_readonly(self):
+        self.start_viewer(cols=40, options=("--read-only",))
+        self.keys(b"abc\x03\x1dp")
+        wait_for(lambda: " pan " in self.capture(self.phone), "read-only pan")
+        self.keys(b"\x1df")
+        wait_for(lambda: "read-only" in self.capture(self.phone), "read-only follow")
+        self.assertEqual(self.input(), b"")
+        self.finish()
+
+    def test_complete_paste_and_local_prefix(self):
+        self.start_viewer(cols=40)
+        payload = b"\x1b[200~first\n\x1dq second\x1b[A\x1b[201~"
+        self.keys(payload)
+        wait_for(lambda: self.input() == payload, "literal complete paste")
+        self.assertFalse(self.result_path.exists())
+        self.finish()
+
+    def test_incomplete_paste_restores_terminal(self):
+        self.start_viewer(cols=40)
+        self.keys(b"\x1b[200~unfinished\x1dq")
+        wait_for(lambda: self.result_path.exists(), "incomplete paste refusal")
+        self.assertEqual(self.input(), b"")
+        self.finish(expected=1)
+
+    def test_copy_mode_and_sync_guard(self):
+        for option in ("copy", "sync"):
+            with self.subTest(option=option):
+                mirror = self.pinned()
+                if option == "copy":
+                    self.tmux("copy-mode", "-t", self.source)
+                else:
+                    self.tmux("set-option", "-w", "-t", "source:0", "synchronize-panes", "on")
+                with self.assertRaises(mtt.Refused):
+                    mirror.send([b"NEVER"])
+                self.assertEqual(self.input(), b"")
+                self.assertEqual(self.input("sibling"), b"")
+                if option == "copy":
+                    self.tmux("send-keys", "-X", "-t", self.source, "cancel")
+                else:
+                    self.tmux("set-option", "-w", "-t", "source:0", "synchronize-panes", "off")
+        self.assertEqual(self.protected_state(), self.before)
+
+    def test_hooks_refuse_capture_and_send(self):
+        for hook in ("after-capture-pane", "after-send-keys"):
+            for scope in ("global", "session", "window", "pane"):
+                with self.subTest(hook=hook, scope=scope):
+                    mirror = self.pinned()
+                    sender = self.pinned()
+                    args = {"global": ["-g"], "session": ["-t", "source"],
+                            "window": ["-w", "-t", "source:0"],
+                            "pane": ["-p", "-t", self.source]}[scope]
+                    self.tmux("set-hook", *args, hook + "[7]",
+                              "set-option -g @mtt_hook_ran yes")
+                    try:
+                        with self.assertRaises(mtt.Refused):
+                            mirror.snapshot()
+                        with self.assertRaises(mtt.Refused):
+                            sender.send([b"NEVER"])
+                        self.assertEqual(self.tmux("show-option", "-gqv", "@mtt_hook_ran"), "")
+                    finally:
+                        self.tmux("set-hook", "-u", *args, hook)
+        self.assertEqual(self.input(), b"")
+        self.assertEqual(self.protected_state(), self.before)
+
+    def test_unrelated_autosave_hooks_allowed(self):
+        hooks = ("after-new-session", "after-new-window", "after-split-window", "after-kill-pane")
+        for hook in hooks:
+            self.tmux("set-hook", "-g", hook + "[90]", "set-option -g @unrelated_hook yes")
+        before = self.tmux("show-hooks", "-g")
+        mirror = self.pinned()
+        mirror.snapshot()
+        mirror.send([b"ok"])
+        wait_for(lambda: self.input() == b"ok", "input with unrelated hooks")
+        self.assertEqual(self.tmux("show-hooks", "-g"), before)
+        self.assertEqual(self.tmux("show-option", "-gqv", "@unrelated_hook"), "")
+        self.assertEqual(self.protected_state(), self.before)
+
+    def test_respawn_refuses_old_pin(self):
+        mirror = self.pinned()
+        sibling_before = self.before.splitlines()[1]
+        self.tmux("respawn-pane", "-k", "-t", self.source,
+                  sys.executable, str(SELF), "--source", str(self.directory), "source")
+        with self.assertRaises(mtt.Refused):
+            mirror.send([b"NEVER"])
+        with self.assertRaises(mtt.Refused):
+            mirror.snapshot()
+        self.assertEqual(self.protected_state().splitlines()[1], sibling_before)
+        self.assertEqual(self.input(), b"")
+
+    def test_socket_replacement_refuses_old_pin(self):
+        mirror = self.pinned()
+        os.rename(self.socket, self.socket + ".original")
+        import socket
+        replacement = socket.socket(socket.AF_UNIX)
+        try:
+            replacement.bind(self.socket)
+            with self.assertRaises(mtt.Refused):
+                mirror.send([b"NEVER"])
+        finally:
+            replacement.close()
+            os.unlink(self.socket)
+            os.rename(self.socket + ".original", self.socket)
+        self.assertEqual(self.input(), b"")
+        self.assertEqual(self.protected_state(), self.before)
+
+    def test_picker_metadata_and_startup_flush(self):
+        self.start_viewer(cols=60, picker=True)
+        rows = self.capture(self.phone).splitlines()
+        self.assertNotIn("SOURCE-00", "\n".join(rows))
+        index = next(i for i, row in enumerate(rows) if "source:0.0" in row)
+        if index:
+            self.keys(b"\x1bOB" * index)
+            time.sleep(0.1)
+        self.keys(b"\rDISCARD-STARTUP")
+        wait_for(lambda: "mtt " in self.capture(self.phone), "picker selection")
+        time.sleep(0.3)
+        self.assertEqual(self.input(), b"")
+        self.finish()
+
+    def test_desktop_resize_updates_pad_only(self):
+        self.start_viewer(cols=40)
+        self.tmux("resize-pane", "-t", self.source, "-x", "81")
+        wait_for(lambda: "81x30" in self.capture(self.phone), "source-side dimension update")
+        self.assertEqual(self.tmux("display-message", "-p", "-t", self.phone,
+                                   "#{pane_width}").strip(), "40")
+        self.tmux("resize-pane", "-t", self.source, "-x", "85")
+        wait_for(lambda: "85x30" in self.capture(self.phone), "source dimension restore")
+        self.finish()
+
+    def viewer_mode_refusal(self, mode):
+        self.start_viewer(cols=40)
+        if mode == "copy":
+            self.tmux("copy-mode", "-t", self.source)
+        else:
+            self.tmux("set-option", "-w", "-t", "source:0", "synchronize-panes", "on")
+        self.keys(b"NEVER")
+        wait_for(lambda: self.result_path.exists(), "viewer mode refusal")
+        self.assertEqual(self.input(), b"")
+        if mode == "copy":
+            self.tmux("send-keys", "-X", "-t", self.source, "cancel")
+        else:
+            self.tmux("set-option", "-w", "-t", "source:0", "synchronize-panes", "off")
+        self.finish(expected=1)
+
+    def test_viewer_copy_mode_refusal_restores_terminal(self):
+        self.viewer_mode_refusal("copy")
+
+    def test_viewer_sync_refusal_restores_terminal(self):
+        self.viewer_mode_refusal("sync")
+
+    def test_server_restart_never_reresolves(self):
+        mirror = self.pinned()
+        self.assertEqual(self.protected_state(), self.before)
+        (self.directory / "source.stop").touch()
+        (self.directory / "sibling.stop").touch()
+        def old_server_stopped():
+            try:
+                mtt.process_identity(mirror.server)
+            except mtt.Refused:
+                return True
+            return False
+        wait_for(old_server_stopped, "old fixture server exits")
+        (self.directory / "source.stop").unlink()
+        replacement = self.tmux(
+            "new-session", "-d", "-s", "source", "-x", "85", "-y", "30",
+            "-P", "-F", "#{pane_id}", sys.executable, str(SELF), "--source",
+            str(self.directory), "source", create=True,
+        ).strip()
+        self.assertEqual(replacement, self.source)
+        with self.assertRaises(mtt.Refused):
+            mirror.send([b"NEVER"])
+        with self.assertRaises(mtt.Refused):
+            mirror.inventory()
+        self.assertEqual(self.input(), b"")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "--source":
+        source(*sys.argv[2:])
+    elif len(sys.argv) > 1 and sys.argv[1] == "--viewer":
+        viewer_child(*sys.argv[2:])
+    else:
+        unittest.main(verbosity=2)

--- a/tests/mtt-tmux-test.py
+++ b/tests/mtt-tmux-test.py
@@ -190,6 +190,27 @@ class IsolatedMirror(unittest.TestCase):
             self.assertFalse(self.result_path.exists(), self.capture(self.phone))
         self.drain()
 
+    def start_direct_viewer(self, options=()):
+        self.master, self.slave = pty.openpty()
+        self.resize(40, 10)
+        self.client = subprocess.Popen(
+            [sys.executable, str(SELF), "--viewer", str(self.directory),
+             self.socket, self.source, *options],
+            stdin=self.slave, stdout=self.slave, stderr=self.slave,
+            start_new_session=True,
+        )
+        os.set_blocking(self.master, False)
+        self.wait_output(b"\x1b[?2004h")
+        self.assertFalse(self.result_path.exists())
+
+    def wait_output(self, expected):
+        output = bytearray()
+        def received():
+            output.extend(self.drain())
+            self.assertLessEqual(len(output), mtt.OUTPUT_LIMIT)
+            return expected in output
+        wait_for(received, "direct viewer output " + repr(expected))
+
     @property
     def result_path(self):
         return self.directory / "viewer.result"
@@ -311,6 +332,53 @@ class IsolatedMirror(unittest.TestCase):
         self.keys(payload)
         wait_for(lambda: self.input() == payload, "literal complete paste")
         self.assertFalse(self.result_path.exists())
+        self.finish()
+
+    def test_direct_mobile_prefix_controls(self):
+        self.start_direct_viewer()
+        self.keys(b"\x02\x1d\x1d\x02\x02x\x1dxdqpf\x03\x02\x02\x1d\x1d")
+        expected = b"dqpf\x03\x02\x1d"
+        wait_for(lambda: self.input() == expected, "literal input and consumed unknown actions")
+        for prefix in (b"\x02", b"\x1d"):
+            with self.subTest(prefix=repr(prefix)):
+                self.keys(prefix + b"pDISCARD-TRANSITION")
+                self.wait_output(b"pan")
+                self.keys(b"\x1bOCnot-sent" + prefix * 2)
+                self.assertEqual(self.input(), expected)
+                self.keys(prefix + b"fDISCARD-TRANSITION")
+                self.wait_output(b"input")
+                self.keys(b"ok")
+                expected += b"ok"
+                wait_for(lambda: self.input() == expected, "follow resumes without queued keys")
+        frame = b"\x1b[200~first\n\x02d\x02p\x1dq\x1dp\x1b[A\x1b[201~"
+        self.keys(b"\x02" + frame + b"z")
+        expected += frame + b"z"
+        wait_for(lambda: self.input() == expected, "paste clears prefix and preserves literal controls")
+        self.assertFalse(self.result_path.exists())
+        self.keys(b"\x02dDISCARD-EXIT")
+        wait_for(lambda: self.result_path.exists(), "mobile detach exits only viewer")
+        self.assertEqual(self.input(), expected)
+        self.finish()
+
+    def test_direct_readonly_prefix_controls(self):
+        self.start_direct_viewer(options=("--read-only",))
+        for prefix in (b"\x02", b"\x1d"):
+            with self.subTest(prefix=repr(prefix)):
+                self.keys(prefix + b"p")
+                self.wait_output(b"pan")
+                self.keys(prefix + b"f")
+                self.wait_output(b"read-only")
+        self.keys(b"\x02\x02\x1d\x1dabc\x03\x02\x1b[200~\x02d\x1dq\n\x1b[201~")
+        self.keys(b"\x02q")
+        wait_for(lambda: self.result_path.exists(), "read-only mobile quit")
+        self.assertEqual(self.input(), b"")
+        self.finish()
+
+    def test_direct_legacy_detach_alias(self):
+        self.start_direct_viewer()
+        self.keys(b"\x1ddDISCARD-EXIT")
+        wait_for(lambda: self.result_path.exists(), "legacy detach exits only viewer")
+        self.assertEqual(self.input(), b"")
         self.finish()
 
     def test_incomplete_paste_restores_terminal(self):


### PR DESCRIPTION
## Summary

- Replace the mobile attachment wrapper with a fixed-size, current-screen mirror of exactly one existing tmux pane.
- Add metadata-only checks, read-only viewing, local pan/follow controls, and mobile-friendly `Ctrl-b` aliases alongside `Ctrl-]`.
- Pin source identity and guard bounded capture/input without attaching, resizing, zooming, or changing protected panes.
- Wire the existing bootstrap preflight/link manifest and add focused unit, real-PTY, and refresh-fixture coverage.

## Validation

- Fresh publication checkout: two isolated real-PTY integration cases passed, covering exact metadata/self-target refusal and direct-viewer mobile controls.
- Reused unchanged-file validation: 37 original unit tests, 16 original PTY cases, and one private-HOME refresh fixture passed; the shortcut follow-up passed 13 focused unit tests and eight PTY cases.
- Prior Python compile/3.9 syntax, help assertions, and ShellCheck results remain applicable. Fresh whitespace and private-data scans passed.
- All six file hashes match the reviewed changes. Only the two mirror commits are included; unrelated CI work is excluded.
- Runtime SHA-256: `2ee62c6b43d0a78077727bf9875f99c64394dcd6a260a77c7f7b94a44d3782cd`.

## Scope And Limits

- Monochrome current screen only: no history, mouse forwarding, or color-fidelity claim. Use plain SSH outside an attached tmux grid.
- Existing viewers keep running; new shortcuts apply on subsequent launches.
- No tmux configuration changes, session restoration, or remote deployment are part of this PR.
