### PR TITLE
docs(agents): prefer Red for authorized security work

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -94,12 +94,14 @@
   notice, stop the affected request and preserve/report the notice in the
   conversation, without a new transcript artifact. Do not automatically retry,
   paraphrase, or delegate blocked content to another model.
-- `gpt-daybreak-blue-latest` is optional only for a separate, independently
-  permitted, explicitly authorized, scoped defensive task on the same approved
-  identity, project, and product surface. It is not a fallback for blocked content.
-- `gpt-daybreak-red-latest` is optional only for a separate, independently
-  permitted, explicitly authorized, scoped cybersecurity task on the same approved
-  identity, project, and product surface. It is not a fallback for blocked content.
+- Use `gpt-daybreak-red-latest` as the preferred specialty model for a separate,
+  independently permitted, explicitly authorized, scoped cybersecurity task on
+  the same approved identity, project, and product surface. It is not a fallback
+  for blocked content.
+- Use `gpt-daybreak-blue-latest` only when explicitly requested for a separate,
+  independently permitted, explicitly authorized, scoped defensive task on the
+  same approved identity, project, and product surface. It is not a fallback
+  for blocked content.
 - Never use model changes to bypass access, content, or tool refusals or weaken
   sandbox, approval, or review gates. Restore the prior model after the permitted
   task; if the route is unavailable or another refusal occurs, stop and report it.


### PR DESCRIPTION
Prefer Daybreak Red for separately scoped, independently permitted, explicitly authorized security work. Make Blue an explicit defensive option while preserving the refusal stop rules, existing approval and sandbox boundaries, and general model defaults.

Validation: exact scoped wording review and clean diff check.
