### PR TITLE
fix(agents): disable Tokenjuice statistics without replacing local settings

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,3 +1,5 @@
+export TOKENJUICE_STATS=off
+
 # Source fzf if available
 [ -f ~/.fzf.bash ] && source ~/.fzf.bash
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "env": {
+    "TOKENJUICE_STATS": "off"
+  },
   "attribution": {
     "commit": "",
     "pr": ""

--- a/.exports
+++ b/.exports
@@ -325,6 +325,8 @@ fi
 # Development Tools
 #
 
+export TOKENJUICE_STATS=off
+
 # Less
 export LESS='-F -i -J -M -R -W -x4 -X -z-4'
 export LESS_TERMCAP_mb=$'\E[01;31m'

--- a/.zshenv
+++ b/.zshenv
@@ -38,6 +38,7 @@ fi
 
 export DISABLE_TELEMETRY=1
 export DO_NOT_TRACK=1
+export TOKENJUICE_STATS=off
 
 # Load Rust environment if it has been bootstrapped
 if [ -f "$HOME/.cargo/env" ]; then

--- a/bin/claude-managed-settings
+++ b/bin/claude-managed-settings
@@ -15,6 +15,7 @@ import sys
 MANAGED_LINK = "settings.managed.json"
 LINK_SIBLING = ".settings.json.managed-link"
 SEED_SIBLING = ".settings.managed.json.seed"
+STATS_SIBLING = ".settings.json.tokenjuice-stats"
 RENAME_EXCL = 0x00000004
 RENAME_SWAP = 0x00000002
 
@@ -307,28 +308,143 @@ def finish_managed_recovery(parent: dict, legacy_target: str) -> None:
     unlink_exact(parent, LINK_SIBLING, sibling)
 
 
-def apply(dotfiles: pathlib.Path, claude_dir: pathlib.Path) -> str:
+def stats_off_payload(payload: bytes) -> bytes:
+    def unique_object(pairs: list) -> dict:
+        result = {}
+        for key, value in pairs:
+            if key in result:
+                raise ManagedSettingsError("duplicate_json_key")
+            result[key] = value
+        return result
+
+    def invalid_constant(value: str) -> None:
+        raise ManagedSettingsError("invalid_json")
+
+    try:
+        parsed = json.loads(
+            payload,
+            object_pairs_hook=unique_object,
+            parse_constant=invalid_constant,
+        )
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise ManagedSettingsError("invalid_json") from error
+    if not isinstance(parsed, dict):
+        raise ManagedSettingsError("invalid_json")
+    environment = parsed.get("env", {})
+    if not isinstance(environment, dict):
+        raise ManagedSettingsError("invalid_env")
+    if environment.get("TOKENJUICE_STATS") == "off":
+        return payload
+    environment["TOKENJUICE_STATS"] = "off"
+    parsed["env"] = environment
+    return (json.dumps(parsed, indent=2, ensure_ascii=True) + "\n").encode()
+
+
+def check_stats_parent(parent: dict) -> None:
+    check_directory(parent)
+    metadata = os.fstat(parent["fd"])
+    if metadata.st_uid != os.getuid() or stat.S_IMODE(metadata.st_mode) & 0o022:
+        raise ManagedSettingsError("parent_incompatible")
+
+
+def update_stats_off(parent: dict, name: str, original: dict, link: dict) -> None:
+    payload = stats_off_payload(original["payload"])
+
+    def check_target(expected: dict) -> None:
+        check_stats_parent(parent)
+        if name != "settings.json" and not same(
+            classify(parent["fd"], "settings.json"),
+            link,
+        ):
+            raise ManagedSettingsError("target_changed")
+        if not same(classify(parent["fd"], name, include_payload=True), expected):
+            raise ManagedSettingsError("target_changed")
+
+    check_target(original)
+    if payload == original["payload"]:
+        return
+    try:
+        descriptor = os.open(
+            STATS_SIBLING,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=parent["fd"],
+        )
+    except FileExistsError as error:
+        raise ManagedSettingsError("recovery_required") from error
+    try:
+        write_all(descriptor, payload)
+        os.fchmod(descriptor, original["mode"])
+        os.fsync(descriptor)
+        os.fsync(parent["fd"])
+        staged = classify(parent["fd"], STATS_SIBLING, include_payload=True)
+        opened = os.fstat(descriptor)
+        if (
+            staged.get("payload") != payload
+            or staged.get("uid") != os.getuid()
+            or staged.get("mode") != original["mode"]
+            or (staged.get("device"), staged.get("inode")) != (opened.st_dev, opened.st_ino)
+        ):
+            raise ManagedSettingsError("target_changed")
+        failpoint("before_stats_publish")
+        check_target(original)
+        if not same(classify(parent["fd"], STATS_SIBLING, include_payload=True), staged):
+            raise ManagedSettingsError("target_changed")
+        # Keep the exchanged original until both identities and bytes are verified.
+        # A mismatch or interruption retains recovery evidence, never a blind rollback.
+        rename_atomic(parent["fd"], STATS_SIBLING, name, RENAME_SWAP)
+        failpoint("after_stats_publish")
+        check_target(staged)
+        if not same(classify(parent["fd"], STATS_SIBLING, include_payload=True), original):
+            raise ManagedSettingsError("target_changed")
+        failpoint("before_stats_cleanup")
+        check_target(staged)
+        unlink_exact(
+            parent,
+            STATS_SIBLING,
+            {key: value for key, value in original.items() if key != "payload"},
+        )
+    finally:
+        os.close(descriptor)
+
+
+def apply(
+    dotfiles: pathlib.Path,
+    claude_dir: pathlib.Path,
+    tokenjuice_stats_off: bool = False,
+) -> str:
     baseline_spec, baseline_payload = validate_baseline(dotfiles)
+    seed_payload = stats_off_payload(baseline_payload) if tokenjuice_stats_off else baseline_payload
     baseline_path = str(dotfiles / ".claude/settings.json")
     parent = open_directory(claude_dir, create=True)
     try:
         check_directory(parent)
+        if tokenjuice_stats_off:
+            check_stats_parent(parent)
+            # Stats updates never adopt an earlier run's stage or recovery files.
+            for residue in (STATS_SIBLING, SEED_SIBLING, LINK_SIBLING):
+                if classify(parent["fd"], residue)["kind"] != "absent":
+                    raise ManagedSettingsError("recovery_required")
         settings = classify(parent["fd"], "settings.json", include_payload=True)
         sibling = classify(parent["fd"], LINK_SIBLING)
         if settings["kind"] == "file":
             if sibling["kind"] != "absent":
                 raise ManagedSettingsError("recovery_required")
             validate_json_file(settings, "target_incompatible")
+            if tokenjuice_stats_off:
+                update_stats_off(parent, "settings.json", settings, settings)
             state = "regular"
         elif settings["kind"] == "symlink" and settings.get("target") == MANAGED_LINK:
             validate_symlink(settings, MANAGED_LINK)
             managed = classify(parent["fd"], MANAGED_LINK, include_payload=True)
             validate_json_file(managed, "managed_target_incompatible")
             finish_managed_recovery(parent, baseline_path)
+            if tokenjuice_stats_off:
+                update_stats_off(parent, MANAGED_LINK, managed, settings)
             state = "managed"
         elif settings["kind"] == "symlink" and settings.get("target") == baseline_path:
             validate_symlink(settings, baseline_path)
-            ensure_managed_target(parent, baseline_payload)
+            ensure_managed_target(parent, seed_payload)
             ensure_link_sibling(parent)
             if not same(classify(parent["fd"], "settings.json"), settings):
                 raise ManagedSettingsError("target_changed")
@@ -341,7 +457,7 @@ def apply(dotfiles: pathlib.Path, claude_dir: pathlib.Path) -> str:
             unlink_exact(parent, LINK_SIBLING, settings)
             state = "migrated"
         elif settings["kind"] == "absent":
-            ensure_managed_target(parent, baseline_payload)
+            ensure_managed_target(parent, seed_payload)
             ensure_link_sibling(parent)
             if classify(parent["fd"], "settings.json")["kind"] != "absent":
                 raise ManagedSettingsError("target_changed")
@@ -365,12 +481,17 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--dotfiles-dir", type=pathlib.Path, required=True)
     parser.add_argument("--claude-dir", type=pathlib.Path, required=True)
+    parser.add_argument(
+        "--tokenjuice-stats-off",
+        action="store_true",
+        help="Set env.TOKENJUICE_STATS to off while preserving other settings.",
+    )
     args = parser.parse_args()
     if not args.dotfiles_dir.is_absolute() or not args.claude_dir.is_absolute():
         print("claude_managed_settings=blocked reason=path_not_absolute")
         return 2
     try:
-        state = apply(args.dotfiles_dir, args.claude_dir)
+        state = apply(args.dotfiles_dir, args.claude_dir, args.tokenjuice_stats_off)
     except ManagedSettingsError as error:
         print(f"claude_managed_settings=blocked reason={error.reason}")
         return 2

--- a/bin/codex
+++ b/bin/codex
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Non-login hook shells inherit policy from the Codex parent.
+export TOKENJUICE_STATS=off
+
 wrapper_dir="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 codex_home="${CODEX_HOME:-$HOME/.codex}"
 platform="$(uname -s)"

--- a/install.sh
+++ b/install.sh
@@ -692,7 +692,8 @@ setup_claude_dotfiles() {
     if ! claude_settings_output="$(
         python3 "$claude_settings_helper" \
             --dotfiles-dir "$df_dir" \
-            --claude-dir "$claude_dir"
+            --claude-dir "$claude_dir" \
+            --tokenjuice-stats-off
     )"; then
         error "$claude_settings_output"
         return 1

--- a/profiles/linux-server/profile
+++ b/profiles/linux-server/profile
@@ -18,6 +18,7 @@ export LESS='-F -i -J -M -R -W -x4 -X -z-4'
 export COLORTERM="${COLORTERM:-truecolor}"
 export DISABLE_TELEMETRY=1
 export DO_NOT_TRACK=1
+export TOKENJUICE_STATS=off
 
 # Keep cockpit scratch on disk without changing other login environments.
 _cockpit_private_tmp() {

--- a/tests/claude-managed-settings-test.sh
+++ b/tests/claude-managed-settings-test.sh
@@ -109,6 +109,93 @@ mkdir -p "$(dirname "$absent_claude")"
 cmp -s "$absent_repo/.claude/settings.json" "$absent_claude/settings.managed.json"
 assert_repo_clean "$absent_repo"
 
+for initial in regular managed legacy absent; do
+  repo="$(new_repo "stats-$initial")"
+  claude="$fixture/stats-$initial/home/.claude"
+  mkdir -p "$claude"
+  case "$initial" in
+    regular|managed)
+      target="$claude/settings.json"
+      if [[ "$initial" == managed ]]; then
+        target="$claude/settings.managed.json"
+        ln -s settings.managed.json "$claude/settings.json"
+      fi
+      printf '{"hooks":{"machine":true},"env":{"OTHER_SETTING":"keep","TOKENJUICE_STATS":"on"}}\n' >"$target"
+      chmod 0640 "$target"
+      ;;
+    legacy)
+      ln -s "$repo/.claude/settings.json" "$claude/settings.json"
+      ;;
+  esac
+  "$helper" --dotfiles-dir "$repo" --claude-dir "$claude" --tokenjuice-stats-off >/dev/null
+  python3 - "$claude/settings.json" "$initial" <<'PY'
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+settings = json.loads(pathlib.Path(sys.argv[1]).read_bytes())
+expected = {"hooks": {"baseline": True}, "env": {"TOKENJUICE_STATS": "off"}}
+if sys.argv[2] in ("regular", "managed"):
+    expected = {
+        "hooks": {"machine": True},
+        "env": {"OTHER_SETTING": "keep", "TOKENJUICE_STATS": "off"},
+    }
+assert settings == expected
+environment = dict(os.environ, TOKENJUICE_STATS="on")
+environment.update(settings["env"])
+subprocess.run(
+    ["/bin/bash", "--noprofile", "--norc", "-c", '[[ "$TOKENJUICE_STATS" == off ]]'],
+    env=environment, check=True,
+)
+PY
+  before="$(python3 -c 'import os,sys; print(os.stat(sys.argv[1]).st_ino)' "$claude/settings.json")"
+  "$helper" --dotfiles-dir "$repo" --claude-dir "$claude" --tokenjuice-stats-off >/dev/null
+  [[ "$(python3 -c 'import os,sys; print(os.stat(sys.argv[1]).st_ino)' "$claude/settings.json")" == "$before" ]]
+  [[ ! -e "$claude/.settings.json.tokenjuice-stats" ]]
+  [[ ! -e "$claude/.settings.json.managed-link" ]]
+  [[ ! -e "$claude/.settings.managed.json.seed" ]]
+  assert_repo_clean "$repo"
+done
+
+for initial in regular managed; do
+  for point in before_stats_publish after_stats_publish before_stats_cleanup; do
+    name="stats-interrupt-$initial-$point"
+    repo="$(new_repo "$name")"
+    claude="$fixture/$name/home/.claude"
+    mkdir -p "$claude"
+    target="$claude/settings.json"
+    if [[ "$initial" == managed ]]; then
+      target="$claude/settings.managed.json"
+      ln -s settings.managed.json "$claude/settings.json"
+    fi
+    printf '{"hooks":{"machine":true}}\n' >"$target"
+    set +e
+    CLAUDE_MANAGED_SETTINGS_FAILPOINT="$point" "$helper" \
+      --dotfiles-dir "$repo" --claude-dir "$claude" --tokenjuice-stats-off >/dev/null
+    status=$?
+    set -e
+    [[ "$status" == 86 ]]
+    [[ -f "$claude/.settings.json.tokenjuice-stats" ]]
+    if [[ "$point" == before_stats_publish ]]; then
+      [[ "$(cat "$target")" == '{"hooks":{"machine":true}}' ]]
+    else
+      [[ "$(cat "$claude/.settings.json.tokenjuice-stats")" == '{"hooks":{"machine":true}}' ]]
+    fi
+    stage_hash="$(shasum -a 256 "$claude/.settings.json.tokenjuice-stats" | awk '{print $1}')"
+    target_hash="$(shasum -a 256 "$target" | awk '{print $1}')"
+    if output="$("$helper" --dotfiles-dir "$repo" --claude-dir "$claude" --tokenjuice-stats-off)"; then
+      printf 'expected interrupted update to require recovery\n' >&2
+      exit 1
+    fi
+    [[ "$output" == "claude_managed_settings=blocked reason=recovery_required" ]]
+    [[ "$(shasum -a 256 "$claude/.settings.json.tokenjuice-stats" | awk '{print $1}')" == "$stage_hash" ]]
+    [[ "$(shasum -a 256 "$target" | awk '{print $1}')" == "$target_hash" ]]
+    assert_repo_clean "$repo"
+  done
+done
+
 for link_target in /tmp/absolute.json ../escape.json missing.json intermediate.json; do
   name="$(printf '%s' "$link_target" | tr '/.' '__')"
   repo="$(new_repo "hostile-$name")"
@@ -307,9 +394,17 @@ HOME="$setup_home" PATH="$fake_bin:$PATH" bash -c '
   setup_claude_dotfiles
 ' _ "$root" >/dev/null
 [[ "$(readlink "$setup_home/.claude/settings.json")" == settings.managed.json ]]
-cmp -s \
+python3 - \
   "$setup_home/GIT/_Perso/dotfiles/.claude/settings.json" \
-  "$setup_home/.claude/settings.managed.json"
+  "$setup_home/.claude/settings.managed.json" <<'PY'
+import json
+import pathlib
+import sys
+
+expected = json.loads(pathlib.Path(sys.argv[1]).read_bytes())
+expected["env"] = {"TOKENJUICE_STATS": "off"}
+assert json.loads(pathlib.Path(sys.argv[2]).read_bytes()) == expected
+PY
 assert_repo_clean "$setup_home/GIT/_Perso/dotfiles"
 
 printf 'claude_managed_settings_test=passed\n'

--- a/tests/codex-wrapper-test.sh
+++ b/tests/codex-wrapper-test.sh
@@ -156,7 +156,10 @@ printf 'native\n' >>"$CODEX_TEST_ORDER_LOG"
 [[ "$GITHUB_PERSONAL_ACCESS_TOKEN" == native-token ]]
 [[ "$GITHUB_PAT_TOKEN" == native-token ]]
 [[ "$CODEX_TEST_SENTINEL" == preserved ]]
+[[ "$TOKENJUICE_STATS" == off ]]
+/bin/bash --noprofile --norc -c '[[ "$TOKENJUICE_STATS" == off ]]' || exit 67
 printf 'native\n'
+exit "${CODEX_TEST_NATIVE_EXIT:-0}"
 EOF
 chmod +x "$catalog_binary"
 
@@ -206,6 +209,8 @@ printf 'helper\n' >>"$CODEX_TEST_ORDER_LOG"
 [[ "$GITHUB_PERSONAL_ACCESS_TOKEN" == native-token ]]
 [[ "$GITHUB_PAT_TOKEN" == native-token ]]
 [[ "$CODEX_TEST_SENTINEL" == preserved ]]
+[[ "$TOKENJUICE_STATS" == off ]]
+/bin/bash --noprofile --norc -c '[[ "$TOKENJUICE_STATS" == off ]]' || exit 67
 printf 'helper\n'
 exit "${CODEX_TEST_HELPER_EXIT:-0}"
 EOF
@@ -296,6 +301,43 @@ else
 fi
 [[ "$failure_output" == helper && "$(cat "$order_log")" == helper ]]
 [[ ! -s "$native_args" && -s "$helper_args" ]]
+
+for inherited in unset on; do
+  (
+    if [[ "$inherited" == unset ]]; then
+      unset TOKENJUICE_STATS
+    else
+      export TOKENJUICE_STATS=on
+    fi
+    export DOTFILES_EXPORTS_LOADED=1
+    assert_catalog_route native --version "" "two words"
+    assert_catalog_route helper exec "" "two words"
+    for route in native helper; do
+      if [[ "$route" == native ]]; then
+        export CODEX_TEST_NATIVE_EXIT=74
+        args=(--version "" "two words")
+      else
+        export CODEX_TEST_HELPER_EXIT=73
+        args=(exec "" "two words")
+      fi
+      if output="$(catalog_run "${args[@]}")"; then
+        printf 'expected %s exit code to survive wrapper\n' "$route" >&2
+        exit 1
+      else
+        status=$?
+      fi
+      [[ "$output" == "$route" ]]
+      if [[ "$route" == native ]]; then
+        [[ "$status" == 74 ]]
+        assert_argv "$native_args" "${args[@]}"
+      else
+        [[ "$status" == 73 ]]
+        assert_argv "$helper_args" --binary "$catalog_binary" \
+          --codex-home "$catalog_home" --exec -- "${args[@]}"
+      fi
+    done
+  )
+done
 
 if grep -Fq 'gh auth token' "$repo_root/.zshrc"; then
   printf '.zshrc must not fetch GitHub credentials during startup\n' >&2

--- a/tests/linux-server-startup-test.py
+++ b/tests/linux-server-startup-test.py
@@ -56,6 +56,8 @@ class StartupTests(unittest.TestCase):
             '(( $+functions[doctor] )) || exit 33\n'
             '(( $+functions[mcd] )) || exit 34\n'
             '[[ ${(j.:.)path} == "$PATH" ]] || exit 35\n'
+            '[[ "$TOKENJUICE_STATS" == off ]] || exit 36\n'
+            '/bin/bash --noprofile --norc -c \'[[ "$TOKENJUICE_STATS" == off ]]\' || exit 37\n'
         )
 
     def test_four_shell_modes(self):
@@ -80,6 +82,11 @@ class StartupTests(unittest.TestCase):
         self.env["TMPDIR"] = str(scratch)
         self.shell("-lc", self.check_command())
         self.assertFalse((self.home / "tmux.log").exists())
+
+    def test_stats_policy_overrides_stale_parent_in_every_mode(self):
+        self.env["TOKENJUICE_STATS"] = "on"
+        self.env["DOTFILES_EXPORTS_LOADED"] = "1"
+        self.test_four_shell_modes()
 
     def test_profile_in_sh_emulation(self):
         self.shell("-lc", 'emulate sh\nsource "$HOME/.profile"\n'

--- a/tests/test_claude_managed_settings.py
+++ b/tests/test_claude_managed_settings.py
@@ -3,8 +3,11 @@ from __future__ import annotations
 
 import importlib.machinery
 import importlib.util
+import json
 import pathlib
+import tempfile
 import unittest
+from unittest.mock import patch
 
 
 SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "bin" / "claude-managed-settings"
@@ -63,6 +66,251 @@ class ValidationTests(unittest.TestCase):
         with self.assertRaises(MODULE.ManagedSettingsError) as raised:
             MODULE.validate_symlink(value, MODULE.MANAGED_LINK)
         self.assertEqual(raised.exception.reason, "target_incompatible")
+
+
+class StatsUpdateTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = pathlib.Path(temporary.name)
+        self.claude = self.root / ".claude"
+        self.claude.mkdir(mode=0o700)
+        self.dotfiles = self.root / "dotfiles"
+        self.baseline = b'{"hooks":{"baseline":true}}\n'
+        baseline = patch.object(
+            MODULE, "validate_baseline", return_value=({"kind": "file"}, self.baseline),
+        )
+        baseline.start()
+        self.addCleanup(baseline.stop)
+        self.original = {
+            "hooks": {"PreToolUse": [{"hooks": [{"type": "command", "command": "example hook"}]}]},
+            "env": {"OTHER_SETTING": "keep", "TOKENJUICE_STATS": "on"},
+            "permissions": {"defaultMode": "default"},
+            "enabledPlugins": {"example": True},
+        }
+
+    def target(self, managed=False, payload=None):
+        name = MODULE.MANAGED_LINK if managed else "settings.json"
+        target = self.claude / name
+        target.write_bytes(
+            payload if payload is not None else (json.dumps(self.original) + "\n").encode(),
+        )
+        target.chmod(0o640)
+        if managed:
+            (self.claude / "settings.json").symlink_to(MODULE.MANAGED_LINK)
+        return target
+
+    def apply(self, enabled=True):
+        return MODULE.apply(self.dotfiles, self.claude, enabled)
+
+    def assert_blocked(self, reason):
+        with self.assertRaises(MODULE.ManagedSettingsError) as raised:
+            self.apply()
+        self.assertEqual(raised.exception.reason, reason)
+
+    def test_regular_and_managed_preserve_other_fields_and_mode(self):
+        for managed in (False, True):
+            with self.subTest(managed=managed):
+                target = self.target(managed)
+                inode = target.stat().st_ino
+                expected_files = set(self.claude.iterdir())
+                self.assertEqual(self.apply(), "managed" if managed else "regular")
+                expected = json.loads(json.dumps(self.original))
+                expected["env"]["TOKENJUICE_STATS"] = "off"
+                self.assertEqual(json.loads(target.read_bytes()), expected)
+                self.assertEqual(target.stat().st_mode & 0o777, 0o640)
+                self.assertNotEqual(target.stat().st_ino, inode)
+                self.assertEqual(set(self.claude.iterdir()), expected_files)
+                if managed:
+                    self.assertEqual(
+                        (self.claude / "settings.json").readlink(),
+                        pathlib.Path(MODULE.MANAGED_LINK),
+                    )
+                    (self.claude / "settings.json").unlink()
+                target.unlink()
+
+    def test_default_is_byte_and_inode_preserving(self):
+        for managed in (False, True):
+            with self.subTest(managed=managed):
+                target = self.target(managed)
+                before = target.read_bytes(), target.stat().st_ino, set(self.claude.iterdir())
+                self.apply(enabled=False)
+                self.assertEqual(
+                    (target.read_bytes(), target.stat().st_ino, set(self.claude.iterdir())), before,
+                )
+                if managed:
+                    (self.claude / "settings.json").unlink()
+                target.unlink()
+
+    def test_already_off_does_not_stage_or_change_inode(self):
+        for managed in (False, True):
+            with self.subTest(managed=managed):
+                target = self.target(
+                    managed, b'{ "env": { "TOKENJUICE_STATS": "off" }, "hooks": {} }\n',
+                )
+                before = target.read_bytes(), target.stat().st_ino, set(self.claude.iterdir())
+                with patch.object(MODULE, "write_all") as write:
+                    self.apply()
+                write.assert_not_called()
+                self.assertEqual(
+                    (target.read_bytes(), target.stat().st_ino, set(self.claude.iterdir())), before,
+                )
+                if managed:
+                    (self.claude / "settings.json").unlink()
+                target.unlink()
+
+    def test_absent_and_legacy_receive_policy_without_changing_baseline(self):
+        for legacy in (False, True):
+            with self.subTest(legacy=legacy):
+                settings = self.claude / "settings.json"
+                if legacy:
+                    settings.symlink_to(self.dotfiles / ".claude/settings.json")
+                self.assertEqual(self.apply(), "migrated" if legacy else "created")
+                self.assertEqual(settings.readlink(), pathlib.Path(MODULE.MANAGED_LINK))
+                expected = json.loads(self.baseline)
+                expected["env"] = {"TOKENJUICE_STATS": "off"}
+                self.assertEqual(json.loads(settings.read_bytes()), expected)
+                self.assertEqual(
+                    {item.name for item in self.claude.iterdir()},
+                    {"settings.json", MODULE.MANAGED_LINK},
+                )
+                settings.unlink()
+                (self.claude / MODULE.MANAGED_LINK).unlink()
+
+    def test_invalid_env_and_duplicate_keys_do_not_mutate(self):
+        for payload, reason in (
+            (b'{"env": null}', "invalid_env"),
+            (b'{"env": []}', "invalid_env"),
+            (b'{"env": "on"}', "invalid_env"),
+            (b'{"env": false}', "invalid_env"),
+            (b'{"env": {}, "env": {}}', "duplicate_json_key"),
+            (b'{"env": {"TOKENJUICE_STATS": "off", "TOKENJUICE_STATS": "on"}}', "duplicate_json_key"),
+            (b'{"hooks": {"command": "a", "command": "b"}}', "duplicate_json_key"),
+            (b'{"example": NaN}', "invalid_json"),
+        ):
+            with self.subTest(payload=payload):
+                target = self.target(payload=payload)
+                inode = target.stat().st_ino
+                self.assert_blocked(reason)
+                self.assertEqual(target.read_bytes(), payload)
+                self.assertEqual(target.stat().st_ino, inode)
+                self.assertEqual(list(self.claude.iterdir()), [target])
+                target.unlink()
+
+    def test_any_existing_recovery_residue_is_preserved(self):
+        target = self.target()
+        original = target.read_bytes()
+        for name in (MODULE.STATS_SIBLING, MODULE.SEED_SIBLING, MODULE.LINK_SIBLING):
+            with self.subTest(name=name):
+                residue = self.claude / name
+                residue.write_bytes(b"operator recovery\n")
+                self.assert_blocked("recovery_required")
+                self.assertEqual(residue.read_bytes(), b"operator recovery\n")
+                self.assertEqual(target.read_bytes(), original)
+                residue.unlink()
+
+    def test_unsafe_parent_mode_is_rejected_before_staging(self):
+        target = self.target()
+        self.claude.chmod(0o777)
+        self.assert_blocked("parent_incompatible")
+        self.assertEqual(list(self.claude.iterdir()), [target])
+
+    def test_prepublication_in_place_edit_is_preserved(self):
+        target = self.target()
+        concurrent = b'{"env":{"OTHER_SETTING":"concurrent"}}\n'
+
+        def edit(name):
+            if name == "before_stats_publish":
+                target.write_bytes(concurrent)
+
+        with patch.object(MODULE, "failpoint", side_effect=edit):
+            self.assert_blocked("target_changed")
+        self.assertEqual(target.read_bytes(), concurrent)
+        self.assertTrue((self.claude / MODULE.STATS_SIBLING).is_file())
+
+    def test_original_changed_during_exchange_is_retained(self):
+        target = self.target()
+        concurrent = b'{"hooks":{"concurrent":true}}\n'
+        rename = MODULE.rename_atomic
+
+        def exchange(*args):
+            target.write_bytes(concurrent)
+            rename(*args)
+
+        with patch.object(MODULE, "rename_atomic", side_effect=exchange):
+            self.assert_blocked("target_changed")
+        self.assertEqual((self.claude / MODULE.STATS_SIBLING).read_bytes(), concurrent)
+        self.assertEqual(json.loads(target.read_bytes())["env"]["TOKENJUICE_STATS"], "off")
+
+    def test_published_and_held_original_edits_never_trigger_rollback_or_cleanup(self):
+        for changed_name in ("settings.json", MODULE.STATS_SIBLING):
+            with self.subTest(changed_name=changed_name):
+                target = self.target()
+                original = target.read_bytes()
+                concurrent = b'{"hooks":{"concurrent":true}}\n'
+
+                def edit(name):
+                    if name == "before_stats_cleanup":
+                        (self.claude / changed_name).write_bytes(concurrent)
+
+                with patch.object(MODULE, "failpoint", side_effect=edit):
+                    self.assert_blocked("target_changed")
+                stage = self.claude / MODULE.STATS_SIBLING
+                self.assertEqual((self.claude / changed_name).read_bytes(), concurrent)
+                if changed_name == "settings.json":
+                    self.assertEqual(stage.read_bytes(), original)
+                stage.unlink()
+                target.unlink()
+
+    def test_managed_link_retarget_during_update_is_preserved(self):
+        target = self.target(managed=True)
+        original = target.read_bytes()
+        settings = self.claude / "settings.json"
+
+        def retarget(name):
+            if name == "before_stats_publish":
+                settings.unlink()
+                settings.symlink_to("operator.json")
+
+        with patch.object(MODULE, "failpoint", side_effect=retarget):
+            self.assert_blocked("target_changed")
+        self.assertEqual(settings.readlink(), pathlib.Path("operator.json"))
+        self.assertEqual(target.read_bytes(), original)
+        self.assertTrue((self.claude / MODULE.STATS_SIBLING).is_file())
+
+    def test_parent_retarget_during_update_keeps_both_directories(self):
+        target = self.target()
+        original = target.read_bytes()
+        retained = self.root / "retained-claude"
+
+        def retarget(name):
+            if name == "before_stats_publish":
+                self.claude.rename(retained)
+                self.claude.mkdir(mode=0o700)
+                (self.claude / "settings.json").write_bytes(b'{"operator":true}\n')
+
+        with patch.object(MODULE, "failpoint", side_effect=retarget):
+            self.assert_blocked("parent_retargeted")
+        self.assertEqual((retained / target.name).read_bytes(), original)
+        self.assertTrue((retained / MODULE.STATS_SIBLING).is_file())
+        self.assertEqual((self.claude / target.name).read_bytes(), b'{"operator":true}\n')
+
+    def test_stage_replaced_before_exchange_is_not_adopted(self):
+        target = self.target()
+        original = target.read_bytes()
+        stage = self.claude / MODULE.STATS_SIBLING
+        retained = self.claude / "retained-stage"
+
+        def replace(name):
+            if name == "before_stats_publish":
+                stage.rename(retained)
+                stage.write_bytes(b'{"operator":true}\n')
+
+        with patch.object(MODULE, "failpoint", side_effect=replace):
+            self.assert_blocked("target_changed")
+        self.assertEqual(target.read_bytes(), original)
+        self.assertEqual(stage.read_bytes(), b'{"operator":true}\n')
+        self.assertTrue(retained.is_file())
 
 
 if __name__ == "__main__":

--- a/tests/zsh-env-loader-test.py
+++ b/tests/zsh-env-loader-test.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Shell policy checks with isolated startup files and no agent processes."""
+
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class EnvironmentTests(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.home = Path(temporary.name)
+        for name in (".zshenv", ".exports", ".bashrc"):
+            (self.home / name).symlink_to(ROOT / name)
+        self.env = {
+            "HOME": str(self.home),
+            "ZDOTDIR": str(self.home),
+            "PATH": "/usr/bin:/bin",
+            "TERM": "xterm",
+            "LC_ALL": "C",
+            "DOTFILES_EXPORTS_LOADED": "1",
+        }
+        self.probe = (
+            '[[ "$TOKENJUICE_STATS" == off ]] || exit 31\n'
+            '/bin/bash --noprofile --norc -c \'[[ "$TOKENJUICE_STATS" == off ]]\''
+        )
+
+    def check_shell(self, argv):
+        for inherited in (None, "on"):
+            with self.subTest(inherited=inherited, argv=argv):
+                env = dict(self.env)
+                if inherited is not None:
+                    env["TOKENJUICE_STATS"] = inherited
+                result = subprocess.run(
+                    argv, env=env, capture_output=True, text=True, timeout=15,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, "")
+
+    def test_nonlogin_zsh_with_exports_already_loaded(self):
+        zsh = shutil.which("zsh")
+        self.assertIsNotNone(zsh)
+        self.check_shell([zsh, "-c", self.probe])
+
+    def test_nonlogin_interactive_bash(self):
+        self.check_shell(["/bin/bash", "--noprofile", "-ic", self.probe])
+
+    def test_shared_exports(self):
+        self.check_shell([
+            "/bin/bash", "--noprofile", "--norc", "-c",
+            'source "$HOME/.exports"\n' + self.probe,
+        ])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Export `TOKENJUICE_STATS=off` in shared exports, unconditional zsh startup, interactive Bash startup, the Linux server profile, and the Codex launcher before either backend route.
- Add only `env.TOKENJUICE_STATS` to the Claude baseline. Preserve every existing hook command and trust setting.
- Add an explicit `claude-managed-settings --tokenjuice-stats-off` mode and opt the existing installer call into it. Default regular/managed settings handling remains byte-preserving.

## Settings Transaction

The existing helper owns settings topology and migration. Its seed-recovery path is not reused to rewrite arbitrary local settings.

The new update stages one exclusive same-directory file, preserves permissions, fsyncs, validates parent/topology/owner/mode/link count and exact preimage, then atomically exchanges the target. The exchanged original remains until both identities and contents verify. Concurrent changes or interruption preserve recovery evidence; there is no blind rollback or automatic cleanup. Existing recovery residue blocks a new update.

Already-off settings do not stage, rewrite, or change inode. Non-object `env`, duplicate JSON keys, unsafe files, and unsupported topology fail closed. Only the `TOKENJUICE_STATS` environment member changes semantically.

## Contract Evidence

Personally inspected upstream `openai/codex` at `414782450952a196bbb64b1605a458c2531c47b6`:

- `codex-rs/core/src/session/mod.rs:3893`: configured hook shells request non-login execution.
- `codex-rs/core/src/shell.rs:22`: non-login Bash/zsh execution uses `-c`.
- `codex-rs/hooks/src/engine/command_runner.rs:24`: command execution inherits the parent environment and applies handler environment overrides.

This requires both fresh-shell startup policy and the Codex parent export. Existing running parents are not modified.

## Validation

Candidate: `49b2fe44014934e4b468fe6b53e38adb0012e43c`, based on `49835ec670bdbf206d06f8d0942755fb3a7eb9c2`.

- `python3 -B tests/test_claude_managed_settings.py`: 17 passed, including concurrent writes, directory/stage retargeting, permissions, duplicate keys, and no-op inode preservation.
- `python3 -B tests/zsh-env-loader-test.py`: 3 passed; unset/on inherited values and already-loaded exports.
- `python3 -B tests/linux-server-startup-test.py`: 6 passed, including login/non-login, interactive/non-interactive, and nested modes.
- `bash tests/codex-wrapper-test.sh`: passed; native/catalog routes preserve arguments, output, nonzero exit status, and stats-off inheritance into non-login Bash.
- `bash tests/claude-managed-settings-test.sh`: passed; regular/managed/legacy/absent layouts, actual atomic operations, interruption residue, and isolated installer integration.
- ShellCheck for the launcher and changed shell tests; targeted Bash/zsh syntax, Python AST, baseline-only JSON delta, and `git diff --check`: passed.
- Both commits have verified signatures. No dependencies installed, live settings changed, installer executed against a real home, old statistics files removed, or fleet processes restarted.

Native GitHub Actions workflows are absent. Local runtime proof is macOS; Linux/WSL atomic-update runtime proof remains a later canary gate.

## Scope And Hold

Production/config: +139/-5 (net +134). Tests: +456/-2 (net +454). Production growth implements the explicit policy and guarded settings-update owner boundary; no new service or generic settings framework.

Draft for independent review. No source merge or rollout is authorized by this PR. Package publication and fleet canary remain separate gates.
